### PR TITLE
Added attribute catalog, pulling out single tile from Accumulo

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/SpaceTimeKey.scala
+++ b/spark/src/main/scala/geotrellis/spark/SpaceTimeKey.scala
@@ -1,6 +1,7 @@
 package geotrellis.spark
 
 import monocle.SimpleLens
+import org.joda.time.DateTime
 
 case class SpaceTimeKey(spatialKey: SpatialKey, temporalKey: TemporalKey)
 
@@ -13,4 +14,7 @@ object SpaceTimeKey {
 
   implicit def ordering: Ordering[SpaceTimeKey] =
     Ordering.by(stk => (stk.spatialKey, stk.temporalKey))
+
+  def apply(col: Int, row: Int, time: DateTime): SpaceTimeKey =
+    SpaceTimeKey(SpatialKey(col, row), TemporalKey(time))
 }

--- a/spark/src/main/scala/geotrellis/spark/io/AttributeCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/AttributeCatalog.scala
@@ -1,0 +1,10 @@
+package geotrellis.spark.io
+
+import geotrellis.spark._
+
+trait AttributeCatalog {
+  type ReadableWritable[T]
+
+  def load[T: ReadableWritable](layerId: LayerId, attributeName: String): T
+  def save[T: ReadableWritable](layerId: LayerId, attributeName: String, value: T): Unit
+}

--- a/spark/src/main/scala/geotrellis/spark/io/Catalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/Catalog.scala
@@ -4,31 +4,44 @@ import geotrellis.spark._
 
 import scala.reflect.ClassTag
 
+object Catalog {
+  object AttributeKeys {
+    val rasterMetaData = "raster-metadata"
+  }
+}
+
+trait RasterCatalog {
+  type SupportedKey[K]
+
+  def load[K: SupportedKey: ClassTag](layerId: LayerId, metaData: RasterMetaData): RasterRDD[K]
+  def save[K: SupportedKey: ClassTag](layerId: LayerId, rdd: RasterRDD[K]): Unit
+}
+
 trait Catalog {
   type Params
   type SupportedKey[K]
 
-  def metaDataCatalog: MetaDataCatalog[Params]
+  def attributeCatalog: AttributeCatalog
 
   def paramsFor[K: SupportedKey: ClassTag](layerId: LayerId): Params
 
-  def load[K: SupportedKey: ClassTag](id: LayerId): RasterRDD[K] =
-    load(id, new FilterSet[K])
+  def load[K: SupportedKey: ClassTag](layerId: LayerId): RasterRDD[K] =
+    load(layerId, paramsFor[K](layerId), new FilterSet[K])
 
-  def load[K: SupportedKey: ClassTag](id: LayerId, params: Params): RasterRDD[K] =
-    load(id, params, new FilterSet[K])
+  def load[K: SupportedKey: ClassTag](layerId: LayerId, params: Params): RasterRDD[K] =
+    load(layerId, params, new FilterSet[K])
 
-  def load[K: SupportedKey: ClassTag](id: LayerId, filters: FilterSet[K]): RasterRDD[K] = {
-    val (metaData, params) = metaDataCatalog.load(id)
-    load(id, metaData.rasterMetaData, params, filters)
+  def load[K: SupportedKey: ClassTag](layerId: LayerId, filters: FilterSet[K]): RasterRDD[K] = {
+    val metaData = attributeCatalog.load[RasterMetaData](layerId, Catalog.AttributeKeys.rasterMetaData)
+    load(layerId, metaData.rasterMetaData, paramsFor(layerId), filters)
   }
 
-  def load[K: SupportedKey: ClassTag](id: LayerId, params: Params, filters: FilterSet[K]): RasterRDD[K] = {
-    val metaData = metaDataCatalog.load(id, params)
-    load(id, metaData.rasterMetaData, params, filters)
+  def load[K: SupportedKey: ClassTag](layerId: LayerId, params: Params, filters: FilterSet[K]): RasterRDD[K] = {
+    val metaData = attributeCatalog.load[RasterMetaData](layerId, Catalog.AttributeKeys.rasterMetaData)
+    load(layerId, metaData.rasterMetaData, params, filters)
   }
 
-  def load[K: SupportedKey: ClassTag](id: LayerId, metaData: RasterMetaData, params: Params, filters: FilterSet[K]): RasterRDD[K]
+  def load[K: SupportedKey: ClassTag](layerId: LayerId, metaData: RasterMetaData, params: Params, filters: FilterSet[K]): RasterRDD[K]
 
   def save[K: SupportedKey: ClassTag](id: LayerId, rdd: RasterRDD[K]): Unit =
     save(id, rdd, false)

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeCatalog.scala
@@ -1,0 +1,47 @@
+package geotrellis.spark.io.accumulo
+
+import geotrellis.spark._
+import geotrellis.spark.io._
+
+import spray.json._
+
+import scala.collection.JavaConversions._
+
+import org.apache.spark.Logging
+import org.apache.accumulo.core.client.Connector
+import org.apache.accumulo.core.security.Authorizations
+import org.apache.accumulo.core.data._
+import org.apache.hadoop.io.Text
+
+class AccumuloAttributeCatalog(connector: Connector, val catalogTable: String) extends AttributeCatalog with Logging {
+  type ReadableWritable[T] = RootJsonFormat[T]
+
+  private def fetch(layerId: LayerId, attributeName: String): List[Value] = {
+    val scanner  = connector.createScanner(catalogTable, new Authorizations())
+    scanner.setRange(new Range(new Text(layerId.toString)))
+    scanner.fetchColumnFamily(new Text(attributeName))
+    scanner.iterator.toList.map(_.getValue)
+  }
+
+  def load[T: RootJsonFormat](layerId: LayerId, attributeName: String): T = {
+    val values = fetch(layerId, attributeName)
+
+    if(values.size == 0) {
+      sys.error(s"Attribute $attributeName not found for layer $layerId")
+    } else if(values.size > 1) {
+      sys.error(s"Multiple attributes found for $attributeName for layer $layerId")
+    } else {
+      values.head.toString.parseJson.convertTo[T]
+    }
+  }
+
+  def save[T: RootJsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
+    val mutation = new Mutation()
+      mutation.put( //RasterMetaData
+        new Text(attributeName), new Text(), System.currentTimeMillis(),
+        new Value(value.toJson.compactPrint.getBytes)
+      )
+
+    connector.write(catalogTable, mutation)
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeCatalog.scala
@@ -37,7 +37,7 @@ class AccumuloAttributeCatalog(connector: Connector, val catalogTable: String) e
 
   def save[T: RootJsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
     val mutation = new Mutation()
-      mutation.put( //RasterMetaData
+      mutation.put( 
         new Text(attributeName), new Text(), System.currentTimeMillis(),
         new Value(value.toJson.compactPrint.getBytes)
       )

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloCatalog.scala
@@ -2,6 +2,7 @@ package geotrellis.spark.io.accumulo
 
 import geotrellis.spark._
 import geotrellis.spark.io._
+import geotrellis.raster._
 import org.apache.spark.SparkContext
 import scala.reflect._
 import scala.util.{Failure, Success, Try}
@@ -23,6 +24,16 @@ class AccumuloCatalog(sc: SparkContext, instance: AccumuloInstance,
   def load[K: AccumuloDriver: ClassTag](id: LayerId, metaData: RasterMetaData, table: String, filters: FilterSet[K]): RasterRDD[K] = {
     val driver = implicitly[AccumuloDriver[K]]
     driver.load(sc, instance)(id, metaData, table, filters)
+  }
+
+  def loadTile[K: AccumuloDriver: ClassTag](id: LayerId, key: K): Tile = {
+    val (metaData, table) = metaDataCatalog.load(id)
+    loadTile(id, metaData, table, key)
+  }
+
+  def loadTile[K: AccumuloDriver: ClassTag](id: LayerId, metaData: LayerMetaData, table: String, key: K): Tile = {
+    val driver = implicitly[AccumuloDriver[K]]
+    driver.loadTile(instance)(id, metaData.rasterMetaData, table, key)
   }
 
   def save[K: SupportedKey : ClassTag](id: LayerId, table: String, rdd: RasterRDD[K], clobber: Boolean): Unit = {

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloDriver.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloDriver.scala
@@ -1,6 +1,7 @@
 package geotrellis.spark.io.accumulo
 
 import geotrellis.spark._
+import geotrellis.raster._
 import org.apache.accumulo.core.client.BatchWriterConfig
 import org.apache.accumulo.core.client.mapreduce.{ AccumuloOutputFormat, AccumuloInputFormat, InputFormatBase }
 import org.apache.accumulo.core.data.{ Value, Key, Mutation }
@@ -29,6 +30,8 @@ trait AccumuloDriver[K] extends Serializable {
     val rdd = sc.newAPIHadoopRDD(job.getConfiguration, classOf[AccumuloInputFormat], classOf[Key], classOf[Value])
     decode(rdd, metaData)
   }
+
+  def loadTile(accumulo: AccumuloInstance)(id: LayerId, metaData: RasterMetaData, table: String, key: K): Tile
 
   /** NOTE: Accumulo will always perform destructive update, clobber param is not followed */
   def save(sc: SparkContext, accumulo: AccumuloInstance)(layerId: LayerId, raster: RasterRDD[K], table: String, clobber: Boolean): Unit = {

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloMetaDataCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloMetaDataCatalog.scala
@@ -106,4 +106,3 @@ class AccumuloMetaDataCatalog(connector: Connector, val catalogTable: String) ex
     data map { case (key, fieldMap) => key -> readLayerMetaData(fieldMap)}
   }
 }
-

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/TimeRasterAccumuloDriver.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/TimeRasterAccumuloDriver.scala
@@ -7,12 +7,14 @@ import org.apache.accumulo.core.client.IteratorSetting
 import org.apache.accumulo.core.client.mapreduce.InputFormatBase
 import org.apache.accumulo.core.data.{Range => ARange, Key, Value, Mutation}
 import org.apache.accumulo.core.util.{Pair => APair}
+import org.apache.accumulo.core.security.Authorizations
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.rdd.RDD
 import org.joda.time.{DateTimeZone, DateTime}
 import scala.collection.JavaConversions._
 import scala.util.matching.Regex
+import scala.reflect._
 
 object TimeRasterAccumuloDriver extends AccumuloDriver[SpaceTimeKey] {
   val rowIdRx = new Regex("""(\d+)_(\d+)_(\d+)_(\d+)""", "zoom", "col", "row", "year")
@@ -24,13 +26,15 @@ object TimeRasterAccumuloDriver extends AccumuloDriver[SpaceTimeKey] {
     f"${id.zoom}%02d_${col}%06d_${row}%06d_${timeChunk(time)}"
   }
 
+  def timeText(key: SpaceTimeKey): Text = 
+    new Text(key.temporalKey.time.withZone(DateTimeZone.UTC).toString)
+
   /** Map rdd of indexed tiles to tuples of (table name, row mutation) */
   def encode(layerId: LayerId, raster: RasterRDD[SpaceTimeKey]): RDD[(Text, Mutation)] =
     raster.map {
       case (key, tile) =>    
-        val time = key.temporalKey.time.withZone(DateTimeZone.UTC).toString
         val mutation = new Mutation(rowId(layerId, key))
-        mutation.put(new Text(layerId.name), new Text(time),
+        mutation.put(new Text(layerId.name), timeText(key),
           System.currentTimeMillis(), new Value(tile.toBytes()))
         (null, mutation)
     }
@@ -46,6 +50,28 @@ object TimeRasterAccumuloDriver extends AccumuloDriver[SpaceTimeKey] {
         SpaceTimeKey(spatialKey, time) -> tile.asInstanceOf[Tile]
     }
     new RasterRDD(tileRdd, metaData)
+  }
+
+  def loadTile(accumulo: AccumuloInstance)(layerId: LayerId, metaData: RasterMetaData, table: String, key: SpaceTimeKey): Tile = {
+    val scanner  = accumulo.connector.createScanner(table, new Authorizations())
+    scanner.setRange(new ARange(rowId(layerId, key)))
+    scanner.fetchColumn(new Text(layerId.name), timeText(key))
+    val values = scanner.iterator.toList.map(_.getValue)
+    val value = 
+      if(values.size == 0) {
+        sys.error(s"Tile with key $key not found for layer $layerId")
+      } else if(values.size > 1) {
+        sys.error(s"Multiple tiles found for $key for layer $layerId")
+      } else {
+        values.head
+      }
+
+    ArrayTile.fromBytes(
+      value.get,
+      metaData.cellType,
+      metaData.tileLayout.tileCols,
+      metaData.tileLayout.tileRows
+    )
   }
 
   def tileSlugs(filters: List[GridBounds]): List[(String, String)] = filters match {

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeCatalog.scala
@@ -1,0 +1,54 @@
+package geotrellis.spark.io.hadoop
+
+import geotrellis.spark._
+import geotrellis.spark.io._
+
+import spray.json._
+import org.apache.hadoop.fs.Path
+import org.apache.spark._
+import java.io.PrintWriter
+
+class HadoopAttributeCatalog(sc: SparkContext, catalogRoot: Path, layerDataDir: LayerId => String, metaDataFileName: String) extends AttributeCatalog {
+  type ReadableWritable[T] = RootJsonFormat[T]
+
+  val fs = catalogRoot.getFileSystem(sc.hadoopConfiguration)
+
+  def attributePath(layerId: LayerId, attributeName: String): Path = 
+    new Path(new Path(catalogRoot, layerDataDir(layerId)), s"${attributeName}.json")
+
+  def load[T: RootJsonFormat](layerId: LayerId, attributeName: String): T = {
+    val path = attributePath(layerId, attributeName)
+
+    val txt = HdfsUtils.getLineScanner(path, sc.hadoopConfiguration) match {
+      case Some(in) =>
+        try {
+          in.mkString
+        }
+        finally {
+          in.close
+        }
+      case None =>
+        throw new LayerNotFoundError(layerId)
+    }
+
+    txt.parseJson.convertTo[T]
+
+  }
+
+  def save[T: RootJsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
+    val path = attributePath(layerId, attributeName)
+
+    if(fs.exists(path)) {
+      fs.delete(path, false)
+    }
+
+    val fdos = fs.create(path)
+    val out = new PrintWriter(fdos)
+    try {
+      out.println(value.toJson)
+    } finally {
+      out.close()
+      fdos.close()
+    }
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopMetaDataCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopMetaDataCatalog.scala
@@ -11,8 +11,7 @@ import spray.json._
 import java.io.PrintWriter
 
 class HadoopMetaDataCatalog(sc: SparkContext, catalogRoot: Path, layerDataDir: LayerId => String, metaDataFileName: String)
-  extends MetaDataCatalog[String] with Logging
-{
+  extends MetaDataCatalog[String] with Logging {
   val fs = catalogRoot.getFileSystem(sc.hadoopConfiguration)
 
   def metaDataPath(layerId: LayerId, subDir: String) =
@@ -20,7 +19,6 @@ class HadoopMetaDataCatalog(sc: SparkContext, catalogRoot: Path, layerDataDir: L
       new Path(new Path(catalogRoot, layerDataDir(layerId)) , metaDataFileName)
     else
       new Path(new Path(new Path(catalogRoot, subDir), layerDataDir(layerId)) , metaDataFileName)
-
 
   def load(layerId: LayerId): (LayerMetaData, String) =
     (load(layerId, ""), "")
@@ -41,7 +39,6 @@ class HadoopMetaDataCatalog(sc: SparkContext, catalogRoot: Path, layerDataDir: L
 
     txt.parseJson.convertTo[LayerMetaData]
   }
-
 
   def save(id: LayerId, subDir: String, metaData: LayerMetaData, clobber: Boolean): Unit = {
     val metaPath = metaDataPath(id, subDir)

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloAttributeCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloAttributeCatalogSpec.scala
@@ -1,0 +1,74 @@
+package geotrellis.spark.io.accumulo
+
+import java.io.IOException
+
+import geotrellis.raster._
+import geotrellis.raster.json._
+import geotrellis.raster.stats._
+
+import geotrellis.spark._
+
+import geotrellis.spark.testfiles._
+import geotrellis.spark.op.stats._
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import org.joda.time.DateTime
+import org.scalatest._
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+
+class AccumuloAttributeCatalogSpec extends FunSpec
+  with Matchers
+  with TestFiles
+  with TestEnvironment
+  with OnlyIfCanRunSpark {
+
+  describe("Accumulo Attribute Catalog") {
+    ifCanRunSpark { 
+
+      val accumulo = new AccumuloInstance(
+        instanceName = "fake",
+        zookeeper = "localhost",
+        user = "root",
+        token = new PasswordToken("")
+      )
+
+      val attribCatalog = new AccumuloAttributeCatalog(accumulo.connector, "attributes")
+      val layerId = LayerId("test", 3)
+
+      it("should save and pull out a histogram") {
+        val histo = DecreasingTestFile.histogram
+
+        attribCatalog.save(layerId, "histogram", histo)
+
+        val loaded = attribCatalog.load[Histogram](layerId, "histogram")
+        loaded.getMean should be (histo.getMean)
+      }
+
+      it("should save and load a random RootJsonReadable object") {
+        case class Foo(x: Int, y: String)
+
+        implicit object FooFormat extends RootJsonFormat[Foo] {
+          def write(obj: Foo): JsObject =
+            JsObject(
+              "the_first_field" -> JsNumber(obj.x),
+              "the_second_field" -> JsString(obj.y)
+            )
+
+          def read(json: JsValue): Foo =
+            json.asJsObject.getFields("the_first_field", "the_second_field") match {
+              case Seq(JsNumber(x), JsString(y)) =>
+                Foo(x.toInt, y)
+              case _ =>
+                throw new DeserializationException(s"JSON reading failed.")
+            }
+        }
+
+        val foo = Foo(1, "thing")
+
+        attribCatalog.save(layerId, "foo", foo)
+        attribCatalog.load[Foo](layerId, "foo") should be (foo)
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloCatalogSpec.scala
@@ -54,6 +54,12 @@ class AccumuloCatalogSpec extends FunSpec
 
       it("should load out saved tiles"){
         catalog.load[SpatialKey](LayerId("ones", 10)).count should be > 0l
+        catalog.load[SpatialKey](LayerId("ones", 10)).collect.foreach { case (key, tile) => println(s"KEY $key") }
+      }
+
+      it("should load out a single tile"){
+        val tile = catalog.loadTile(LayerId("ones", 10), SpatialKey(917, 616))
+        (tile.cols, tile.rows) should be ((512, 512))
       }
 
       it("should load out saved tiles, but only for the right zoom"){

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloCatalogSpec.scala
@@ -54,7 +54,6 @@ class AccumuloCatalogSpec extends FunSpec
 
       it("should load out saved tiles"){
         catalog.load[SpatialKey](LayerId("ones", 10)).count should be > 0l
-        catalog.load[SpatialKey](LayerId("ones", 10)).collect.foreach { case (key, tile) => println(s"KEY $key") }
       }
 
       it("should load out a single tile"){


### PR DESCRIPTION
Created AttributeCatalog, so that any RootJsonReadable type can be read to and from the catalog by layer ID and attribute name. Still trying to figure out how to work that into the catalog infrastructure, tried out a couple API's but didn't really find something that worked yet.

Also added the ability to read a single tile out of AccumuloCatalog (this needs to be lifted up to the Catalog trait and implemented for HDFS).