### PR TITLE
Adds a cost distance with shortest paths

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/op/global/CostDistanceWithPathsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/op/global/CostDistanceWithPathsSpec.scala
@@ -1,0 +1,144 @@
+package geotrellis.raster.op.global
+
+import geotrellis.raster._
+import geotrellis.raster.op.global._
+
+import geotrellis.vector.Line
+
+import geotrellis.testkit._
+
+import org.scalatest._
+
+class CostDistanceWithPathsSpec extends FunSpec
+    with TestEngine {
+
+  val Eps = 1e-7
+
+  describe("Cost Distance with remembering optimal paths") {
+
+    it("should find single best path #1") {
+      val tile = ArrayTile(Array(
+        1,  10, 10, 10, 10,
+        10, 1,  10, 10, 10,
+        10, 10, 1,  10, 10,
+        10, 10, 10, 1,  10,
+        10, 10, 10, 10,  1
+      ), 5, 5)
+
+      val correctCost = math.sqrt(2) * 4
+      val correctPath = Line(List(
+        (0.0, 0.0),
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        (4.0, 4.0)
+      ))
+
+      val res = tile.costDistanceWithPaths((0, 0))
+      val (cost, paths) = res.getPath((4, 4))
+
+      cost should be (correctCost +- Eps)
+      paths.size should be (1)
+
+      val path = paths.head
+      path should be(correctPath)
+    }
+
+    it("should find single best path #2") {
+      val tile = ArrayTile(Array(
+        1,   1,  1,  1, 10,
+        10, 10, 10, 10, 1,
+        10, 10, 10, 10, 1,
+        10, 10, 10, 10, 1,
+        10, 10, 10, 10, 1
+      ), 5, 5)
+
+      val correctCost = math.sqrt(2) + 6
+      val correctPath = Line(List(
+        (0.0, 0.0),
+        (1.0, 0.0),
+        (2.0, 0.0),
+        (3.0, 0.0),
+        (4.0, 1.0),
+        (4.0, 2.0),
+        (4.0, 3.0),
+        (4.0, 4.0)
+      ))
+
+      val res = tile.costDistanceWithPaths((0, 0))
+      val (cost, paths) = res.getPath((4, 4))
+
+      cost should be (correctCost +- Eps)
+      paths.size should be (1)
+
+      val path = paths.head
+      path should be(correctPath)
+    }
+
+    it("should find both best paths #1") {
+      val tile = ArrayTile(Array(
+        1,  10, 10, 10, 10,
+        10,  1, 10,  1, 10,
+        10, 10,  1, 10,  1,
+        10,  1, 10, 10,  1,
+        10, 10,  1,  1,  1
+      ), 5, 5)
+
+      val correctCost = math.sqrt(2) * 4 + 2
+      val correctPaths = Set(
+        Line(List(
+          (0.0, 0.0), (1.0, 1.0), (2.0, 2.0),
+          (3.0, 1.0), (4.0, 2.0), (4.0, 3.0),
+          (4.0, 4.0)
+        )),
+          Line(List(
+            (0.0, 0.0), (1.0, 1.0), (2.0, 2.0),
+            (1.0, 3.0), (2.0, 4.0), (3.0, 4.0),
+            (4.0, 4.0)
+          ))
+      )
+
+      val res = tile.costDistanceWithPaths((0, 0))
+      val (cost, paths) = res.getPath((4, 4))
+
+      cost should be (correctCost +- Eps)
+      paths.size should be (2)
+
+      paths.toSet should be(correctPaths)
+    }
+
+  }
+
+  it("should find both best paths #2") {
+    val tile = ArrayTile(Array(
+       1,  1,  1, 10, 10,
+       1, 10, 10,  1, 10,
+       1, 10,  1, 10, 10,
+      10,  1, 10,  1, 10,
+      10, 10, 10, 10,  1
+    ), 5, 5)
+
+    val correctCost = math.sqrt(2) * 4 + 2
+    val correctPaths = Set(
+      Line(List(
+        (0.0, 0.0), (1.0, 0.0), (2.0, 0.0),
+        (3.0, 1.0), (2.0, 2.0), (3.0, 3.0),
+        (4.0, 4.0)
+      )),
+      Line(List(
+        (0.0, 0.0), (0.0, 1.0), (0.0, 2.0),
+        (1.0, 3.0), (2.0, 2.0), (3.0, 3.0),
+        (4.0, 4.0)
+      ))
+    )
+
+    val res = tile.costDistanceWithPaths((0, 0))
+    val (cost, paths) = res.getPath((4, 4))
+
+    cost should be (correctCost +- Eps)
+    paths.size should be (2)
+
+    paths.toSet should be(correctPaths)
+  }
+
+}

--- a/raster/src/main/scala/geotrellis/raster/op/global/CostDistance.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/global/CostDistance.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@ import java.util.PriorityQueue
   * @note    Operation will only work with integer typed Cost Tiles (TypeBit, TypeByte, TypeShort, TypeInt).
   *          If a double typed Cost Tile (TypeFloat, TypeDouble) is passed in, those costs will be rounded
   *          to their floor integer values.
-  * 
+  *
   */
 object CostDistance {
   def apply(cost: Tile, points: Seq[(Int, Int)]): Tile = {
@@ -46,21 +46,14 @@ object CostDistance {
           def compare(a: Cost, b: Cost) = a._3.compareTo(b._3)
         })
 
+
     for((c, r) <- points) {
       calcNeighbors(c, r, cost, output, pqueue)
     }
 
-    var head: Cost = pqueue.poll
-    while(head != null) {
-      val c = head._1
-      val r = head._2
-      val v = head._3
-
-      if (v == output.getDouble(c, r)) {
-        calcNeighbors(c, r, cost, output, pqueue)
-      }
-
-      head = pqueue.poll
+    while (!pqueue.isEmpty) {
+      val (c, r, v) = pqueue.poll
+      if (v == output.getDouble(c, r)) calcNeighbors(c, r, cost, output, pqueue)
     }
 
     output
@@ -92,15 +85,15 @@ object CostDistance {
 
 
   /**
-    * Input: 
+    * Input:
     * (c, r) => Source cell
     * (dc, dr) => Delta (direction)
     * cost => Cost raster
     * d => C - D output raster
-    * 
+    *
     * Output:
     * List((c, r)) <- list of cells set
-    */    
+    */
   def calcCostCell(c: Int, r: Int, dir: Dir, cost: Tile, d: DoubleArrayTile) = {
     val cr = dir(c, r)
 
@@ -121,7 +114,7 @@ object CostDistance {
         if (baseCostOpt.isDefined) {
           curMinCost = source + baseCostOpt.get
         }
-                
+
         // Alternative solutions (going around the corner)
         // Generally you can check diags directly:
         // +---+---+---+
@@ -203,7 +196,7 @@ object CostDistance {
   def calcCost(c: Int, r: Int, cr2: (Int, Int), cost: Tile): DOption =
     calcCost(c, r, cr2._1, cr2._2, cost)
 
-  def calcCost(c: Int, r: Int, dir: Dir, cost: Tile): DOption = 
+  def calcCost(c: Int, r: Int, dir: Dir, cost: Tile): DOption =
     calcCost(c, r, dir(c, r), cost)
 }
 
@@ -211,7 +204,7 @@ object CostDistance {
   * Represents an optional integer
   * using 'Tile NODATA' as a flag
   */
-private [global] 
+private [global]
 class IOption(val v: Int) extends AnyVal {
   def map(f: Int => Int) = if (isDefined) new IOption(f(v)) else this
   def flatMap(f: Int => IOption) = if (isDefined) f(v) else this

--- a/raster/src/main/scala/geotrellis/raster/op/global/CostDistanceWithPaths.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/global/CostDistanceWithPaths.scala
@@ -1,0 +1,189 @@
+package geotrellis.raster.op.global
+
+import geotrellis.raster._
+
+import geotrellis.vector._
+
+import spire.syntax.cfor._
+
+import collection.mutable.ArrayBuffer
+
+import java.util.{PriorityQueue, BitSet}
+
+case class CostDistanceWithPathsResult(
+  res: Array[Seq[Int]],
+  costs: Array[Double],
+  tileDimension: (Int, Int)) {
+
+  val (cols, rows) = tileDimension
+
+  def getPath(dest: (Int, Int)): (Double, Seq[Line]) = {
+    val (col, row) = dest
+    val idx = row * cols + col
+    val start = Seq(idx)
+    val paths = getPath(start)
+
+    val res = Array.ofDim[Line](paths.size)
+    cfor(0)(_ < paths.size, _ + 1) { i =>
+      val path = paths(i)
+      res(i) = Line(path.map(idx => ((idx % cols).toDouble, (idx / cols).toDouble)))
+    }
+
+    (costs(idx), res)
+  }
+
+  def getPath(prevPath: Seq[Int]): Seq[Seq[Int]] = {
+    var paths = Seq[Seq[Int]]()
+    val parents = res(prevPath.head)
+
+    if (parents.isEmpty) paths :+ prevPath
+    else {
+      cfor(0)(_ < parents.size, _ + 1) { i =>
+        val parent = parents(i)
+        paths = paths ++ getPath(parent +: prevPath)
+      }
+
+      paths
+    }
+  }
+
+}
+
+object CostDistanceWithPaths {
+
+  def apply(cost: Tile, source: (Int, Int)): CostDistanceWithPathsResult =
+    new CostDistanceWithPaths(cost.toArrayTile, source).compute
+
+}
+
+private class CostDistanceWithPaths(cost: ArrayTile, source: (Int, Int)) {
+
+  val tileArray = cost
+
+  val Sqrt2 = math.sqrt(2)
+
+  val (cols, rows) = cost.dimensions
+
+  @inline final def indexToCoordinates(idx: Int) = (idx % cols, idx / cols)
+
+  @inline final def coordinatesToIndex(c: Int, r: Int) = r * cols + c
+
+  @inline final def getTileCost(sIdx: Int, eIdx: Int) = {
+    val v1 = cost(sIdx)
+    val v2 = cost(eIdx)
+
+    val r = v1 + v2
+
+    val absDifference = math.abs(sIdx - eIdx)
+
+    if (absDifference > 1 && absDifference != cols) r / Sqrt2
+    else r / 2.0
+  }
+
+  @inline final def getNeighbors(idx: Int) = {
+    val (col, row) = indexToCoordinates(idx)
+    val buff = ArrayBuffer[Int]()
+
+    val isRight = col == cols - 1
+    val isLeft = col == 0
+    val isTop = row == 0
+    val isBottom = row == rows - 1
+
+    if (!isLeft) buff += idx - 1
+    if (!isRight) buff += idx + 1
+    if (!isTop) buff += idx - cols
+    if (!isBottom) buff += idx + cols
+    if (!isLeft && !isTop) buff += idx - cols - 1
+    if (!isLeft && !isBottom) buff += idx + cols - 1
+    if (!isRight && !isTop) buff += idx - cols + 1
+    if (!isRight && !isBottom) buff += idx + cols + 1
+
+    buff.toArray
+  }
+
+  class Graph {
+
+    val neighbors = {
+      val vertices = cols * rows
+      val res = Array.ofDim[Array[(Int, Double)]](vertices)
+
+      cfor(0)(_ < vertices, _ + 1) { idx =>
+        val neighborIndices = getNeighbors(idx)
+        val neighbors = Array.ofDim[(Int, Double)](neighborIndices.size)
+
+        cfor(0)(_ < neighborIndices.size, _ + 1) { i =>
+          val other = neighborIndices(i)
+          val cost = getTileCost(idx, other)
+          neighbors(i) = ((other, cost))
+        }
+
+        res(idx) = neighbors
+      }
+
+      res
+    }
+
+    def getCost(s: Int, e: Int): Double = {
+      val sNeighbors = neighbors(s)
+      var res = Double.MaxValue
+      cfor(0)(_ < sNeighbors.size, _ + 1) { i =>
+        val (other, c) = sNeighbors(i)
+        if (other == e) res = c
+      }
+
+      res
+    }
+
+  }
+
+  def compute: CostDistanceWithPathsResult = {
+    val (sourceCol, sourceRow) = source
+    val sourceIdx = coordinatesToIndex(sourceCol, sourceRow)
+
+    val marked = new BitSet(cols * rows)
+    val pathCosts = Array.ofDim[Double](cols * rows).fill(Double.MaxValue)
+    pathCosts(sourceIdx) = 0
+
+    val rememberParents = Array.ofDim[Seq[Int]](cols * rows)
+
+    val priorityQueue = new PriorityQueue(cols * rows, new java.util.Comparator[Int] {
+
+      override def equals(a: Any) = a.equals(this)
+
+      def compare(a: Int, b: Int) = pathCosts(a).compareTo(pathCosts(b))
+
+    })
+
+    val graph = new Graph
+
+    cfor(0)(_ < cols * rows, _ + 1) { idx =>
+      rememberParents(idx) = Seq()
+    }
+
+    priorityQueue.add(sourceIdx)
+
+    while (!priorityQueue.isEmpty) {
+      val current = priorityQueue.poll
+      marked.flip(current)
+
+      val neighbors = getNeighbors(current)
+
+      cfor(0)(_ < neighbors.size, _ + 1) { i =>
+        val neighbor = neighbors(i)
+        if (!marked.get(neighbor)) {
+          val alt = pathCosts(current) + graph.getCost(current, neighbor)
+          val oldCost = pathCosts(neighbor)
+          if (alt < oldCost) {
+            pathCosts(neighbor) = alt
+            rememberParents(neighbor) = Seq(current)
+            priorityQueue.add(neighbor)
+          } else if (alt == oldCost)
+            rememberParents(neighbor) = rememberParents(neighbor) :+ current
+        }
+      }
+    }
+
+    CostDistanceWithPathsResult(rememberParents, pathCosts, cost.dimensions)
+  }
+
+}

--- a/raster/src/main/scala/geotrellis/raster/op/global/GlobalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/global/GlobalMethods.scala
@@ -10,6 +10,9 @@ trait GlobalMethods extends TileMethods {
   def costDistance(points: Seq[(Int, Int)]): Tile =
     CostDistance(tile, points)
 
+  def costDistanceWithPaths(point: (Int, Int)): CostDistanceWithPathsResult =
+    CostDistanceWithPaths(tile, point)
+
   def toVector(extent: Extent): List[PolygonFeature[Int]] =
     toVector(extent, RegionGroupOptions.default.connectivity)
 


### PR DESCRIPTION
Adds a cost distance with shortest paths method for identifying the shortest paths from a start to a goal for the raster project.

This issue references this implementation: #954