### PR TITLE
S3 InputFormat

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -390,6 +390,7 @@ object GeotrellisBuild extends Build {
           "com.quantifind" %% "sumac" % "0.2.3",
           "org.apache.accumulo" % "accumulo-core" % "1.5.2",
           "de.javakaffee" % "kryo-serializers" % "0.27",
+          logging, awsSdkS3,
           spire,
           monocleCore, monocleMacro,
           nscalaTime,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
     "spray repo"              at "http://repo.spray.io/",
     "sonatypeSnapshots"       at "http://oss.sonatype.org/content/repositories/snapshots"
   )
-
+  val logging       = "com.typesafe"        %% "scalalogging-slf4j" % "1.1.0"
   val scalatest     = "org.scalatest"       %  "scalatest_2.10"  % "2.2.0"
   val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.11.1"
   val scalaReflect  = "org.scala-lang"      %  "scala-reflect"   % "2.10.2"
@@ -72,4 +72,5 @@ object Dependencies {
    from "http://plastic-idolatry.com/jars/caliper-1.0-SNAPSHOT.jar")
 
   val nscalaTime    = "com.github.nscala-time" %% "nscala-time" % "1.6.0"
+  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.9.16"
 }

--- a/spark/src/main/scala/geotrellis/spark/ingest/SpaceTimeInputKey.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/SpaceTimeInputKey.scala
@@ -1,0 +1,28 @@
+package geotrellis.spark.ingest
+
+import com.github.nscala_time.time.Imports._
+import geotrellis.proj4._
+import geotrellis.spark._
+import geotrellis.vector.Extent
+
+/** A key for a Tile with temporal as well as spatial dimension */
+case class SpaceTimeInputKey(extent: Extent, crs: CRS, time: DateTime)
+
+object SpaceTimeInputKey {
+  // Allows us to view and modify only the spatial component of this key
+  implicit def ingestKey = new KeyComponent[SpaceTimeInputKey, ProjectedExtent] {
+    def lens = createLens(
+      key => ProjectedExtent(key.extent, key.crs),
+      pe => key => SpaceTimeInputKey(pe.extent, pe.crs, key.time)
+    )
+  }
+
+  // This tiler will be found to produce RDD[(SpaceTimeKey, Tile)]
+  implicit def tiler: Tiler[SpaceTimeInputKey, SpaceTimeKey] = {
+    val getExtent = (inKey: SpaceTimeInputKey) => inKey.extent
+    val createKey = (inKey: SpaceTimeInputKey, spatialComponent: SpatialKey) =>
+      SpaceTimeKey(spatialComponent, inKey.time)
+
+    Tiler(getExtent, createKey)
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopSparkContextMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopSparkContextMethods.scala
@@ -7,6 +7,7 @@ import geotrellis.raster._
 import org.apache.spark._
 import org.apache.spark.rdd._
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.Job
 
 trait HadoopSparkContextMethods {
   val sc: SparkContext
@@ -74,4 +75,10 @@ trait HadoopSparkContextMethods {
         band -> tile
     }
   }
+
+  def newJob: Job = 
+    Job.getInstance(sc.hadoopConfiguration)  
+
+  def newJob(name: String) = 
+    Job.getInstance(sc.hadoopConfiguration, name)  
 }

--- a/spark/src/main/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormat.scala
@@ -1,0 +1,22 @@
+package geotrellis.spark.io.s3
+
+import com.github.nscala_time.time.Imports._
+import geotrellis.proj4._
+import geotrellis.raster.io.geotiff.reader._
+import geotrellis.raster.Tile
+import geotrellis.spark._
+import geotrellis.spark.ingest._
+import geotrellis.vector.Extent
+import org.apache.hadoop.mapreduce.{InputSplit, TaskAttemptContext}
+
+/** Read single band GeoTiff from S3 */
+class GeoTiffS3InputFormat extends S3InputFormat[ProjectedExtent,Tile] {
+  def createRecordReader(split: InputSplit, context: TaskAttemptContext) = 
+    new S3RecordReader[ProjectedExtent, Tile] {
+      def read(bytes: Array[Byte]) = {
+        val geoTiff = GeoTiffReader.read(bytes)        
+        val GeoTiffBand(tile, extent, crs, _) = geoTiff.bands.head
+        (ProjectedExtent(extent, crs), tile)        
+      }
+    }     
+}

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3InputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3InputFormat.scala
@@ -1,0 +1,110 @@
+package geotrellis.spark.io.s3
+
+import org.apache.hadoop.mapreduce.{InputFormat, JobContext}
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.{ListObjectsRequest, ObjectListing}
+import com.amazonaws.auth._
+import org.apache.hadoop.mapreduce.Job
+import com.typesafe.scalalogging.slf4j.Logging
+
+import scala.util.matching.Regex
+
+/** Reads keys from s3n URL using AWS Java SDK.
+  * The number of keys per InputSplits are controlled by S3 pagination.
+  * If AWS credentials are not part of the URL they will be discovered using [DefaultAWSCredentialsProviderChain]:
+  *   - EnvironmentVariableCredentialsProvider
+  *   - SystemPropertiesCredentialsProvider
+  *   - ProfileCredentialsProvider
+  *   - InstanceProfileCredentialsProvider
+  */
+abstract class S3InputFormat[K, V] extends InputFormat[K,V] with Logging {
+  import S3InputFormat._
+
+  override def getSplits(context: JobContext) = {
+    import scala.collection.JavaConversions._
+
+    val conf = context.getConfiguration
+    val anon = conf.get(ANONYMOUS)
+    val id = conf.get(AWS_ID)
+    val key = conf.get(AWS_KEY)
+    val bucket = conf.get(BUCKET)
+    val prefix = conf.get(PREFIX)
+    val maxKeys: Integer = {
+      val max = conf.get(MAX_KEYS)
+      if (max != null)  max.toInt  else  null
+    }
+
+    val credentials = 
+      if (anon != null)
+        new AnonymousAWSCredentials()
+      else if (id != null && key != null)
+        new BasicAWSCredentials(id, key)
+      else      
+        new DefaultAWSCredentialsProviderChain().getCredentials
+    
+    val s3client = new AmazonS3Client(credentials)
+    
+    logger.info(s"Listing Splits: bucket=$bucket prefix=$prefix")
+    logger.debug(s"Authenticationg with ID=${credentials.getAWSAccessKeyId}")
+    val request = new ListObjectsRequest()
+      .withBucketName(bucket)
+      .withPrefix(prefix)
+      .withMaxKeys(maxKeys)
+    
+    var listing: ObjectListing = null
+    var splits: List[S3InputSplit] = Nil    
+    do {
+      listing = s3client.listObjects(request)     
+      val split = new S3InputSplit()
+      split.accessKeyId = credentials.getAWSAccessKeyId
+      split.secretKey = credentials.getAWSSecretKey
+      split.bucket = bucket
+      // avoid including "directories" in the input split, can cause 403 errors on GET
+      split.keys = listing.getObjectSummaries.map(_.getKey).filterNot(_ endsWith "/")
+    
+      splits = split :: splits
+      request.setMarker(listing.getNextMarker)
+    } while (listing.isTruncated)
+  
+    splits
+  }
+}
+
+object S3InputFormat {
+  final val ANONYMOUS = "s3.anonymous"
+  final val AWS_ID = "s3.awsId"
+  final val AWS_KEY = "s3.awsKey"
+  final val BUCKET = "s3.bucket"
+  final val PREFIX = "s3.prefix"
+  final val MAX_KEYS = "s3.maxKeys"
+
+  private val idRx = "[A-Z0-9]{20}"
+  private val keyRx = "[a-zA-Z0-9+/]+={0,2}"
+  private val slug = "[a-z0-9-]+"
+  val S3UrlRx = new Regex(s"""s3n://(?:($idRx):($keyRx)@)?($slug)/{0,1}(.*)""", "aws_id", "aws_key", "bucket", "prefix")
+
+  /** Set S3N url to use, may include AWS Id and Key */
+  def setUrl(job: Job, url: String) = {
+    val conf = job.getConfiguration
+    val S3UrlRx(id, key, bucket, prefix) = url
+
+    if (id != null && key != null) {
+      conf.set(AWS_ID, id)  
+      conf.set(AWS_KEY, key)  
+    }
+    conf.set(BUCKET, bucket)
+    conf.set(PREFIX, prefix)        
+  }
+
+  /** Set maximum number of keys per split, less may be returned */
+  def setMaxKeys(job: Job, limit: Int) = {
+    val conf = job.getConfiguration
+    conf.set(MAX_KEYS, limit.toString)
+  }
+
+  /** Force anonymous access, bypass all key discovery */
+  def setAnonymous(job: Job) = {
+    val conf = job.getConfiguration
+    conf.set(ANONYMOUS, "true")
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3InputSplit.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3InputSplit.scala
@@ -1,0 +1,51 @@
+package geotrellis.spark.io.s3
+
+import java.io.{DataOutput, DataInput}
+import org.apache.hadoop.io.Writable
+import org.apache.hadoop.mapreduce.InputSplit
+import com.amazonaws.auth.{AWSCredentials, BasicAWSCredentials, AnonymousAWSCredentials}
+
+/**
+ * Represents are batch of keys to be read from an S3 bucket.
+ * AWS credentials have already been discovered and provided by the S3InputFormat.
+ */
+class S3InputSplit extends InputSplit with Writable 
+{
+  var haveAuth = false
+  var accessKeyId: String = _
+  var secretKey: String = _
+  var bucket: String = _
+  var keys: Seq[String] = Seq.empty
+
+  def credentials: AWSCredentials =
+    if (haveAuth)
+      new BasicAWSCredentials(accessKeyId, secretKey)    
+    else
+      new AnonymousAWSCredentials()
+
+  override def getLength: Long = keys.length
+
+  override def getLocations: Array[String] = Array.empty
+
+  override def write(out: DataOutput): Unit = {
+    out.writeBoolean(haveAuth)
+    if (haveAuth){
+      out.writeUTF(accessKeyId)
+      out.writeUTF(secretKey)
+    }
+    out.writeUTF(bucket)
+    out.writeInt(keys.length)
+    keys.foreach(out.writeUTF)
+  }
+  
+  override def readFields(in: DataInput): Unit = {
+    haveAuth = in.readBoolean
+    if (accessKeyId != null && secretKey != null){
+      accessKeyId = in.readUTF
+      secretKey = in.readUTF
+    }
+    bucket = in.readUTF
+    val keyCount = in.readInt
+    keys = for (i <- 1 to keyCount) yield in.readUTF
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3RecordReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3RecordReader.scala
@@ -1,0 +1,71 @@
+package geotrellis.spark.io.s3
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.GetObjectRequest
+import com.typesafe.scalalogging.slf4j.Logging
+import java.io.{InputStream, ByteArrayOutputStream}
+import org.apache.hadoop.mapreduce.{InputSplit, TaskAttemptContext, RecordReader}
+
+/** This reader will fetch bytes of each key one at a time using [AmazonS3Client.getObject].
+  * Subclass must extend [read] method to map from S3 object bytes to (K,V) */
+abstract class S3RecordReader[K, V] extends RecordReader[K, V] with Logging {
+  var bucket: String = _
+  var s3client: AmazonS3Client = _
+  var keys: Iterator[String] = null
+  var curKey: K = _
+  var curValue: V = _
+  var keyCount: Int = _
+  var curCount: Int = 0
+
+  def initialize(split: InputSplit, context: TaskAttemptContext): Unit = {
+    val sp = split.asInstanceOf[S3InputSplit]
+    s3client = new AmazonS3Client(sp.credentials)
+    keys = sp.keys.iterator
+    keyCount =  sp.keys.length
+    bucket = sp.bucket
+    logger.debug(s"Initialize split on bucket '$bucket' with $keyCount keys")  
+  }
+
+  def getProgress: Float = curCount / keyCount
+
+  def read(obj: Array[Byte]): (K, V)
+
+  def nextKeyValue(): Boolean = {
+    if (keys.hasNext){
+      val key = keys.next()
+      logger.debug(s"Reading: $key")
+      val obj = s3client.getObject(new GetObjectRequest(bucket, key))
+      val inStream = obj.getObjectContent
+      val objectData = S3RecordReader.readInputStream(inStream)
+      inStream.close()
+      
+      val (k, v) = read(objectData)          
+      curKey = k
+      curValue = v
+      curCount += 1      
+      true
+    } else {
+      false
+    }
+  }
+
+  def getCurrentKey: K = curKey
+
+  def getCurrentValue: V = curValue
+
+  def close(): Unit = {}
+}
+
+object S3RecordReader {
+    def readInputStream(inStream: InputStream): Array[Byte] = {
+    val bufferSize = 0x20000
+    val buffer = new Array[Byte](bufferSize)
+    val outStream = new ByteArrayOutputStream(bufferSize)    
+    var bytes: Int = 0
+    while (bytes != -1) {      
+      bytes = inStream.read(buffer)
+      if (bytes != -1) outStream.write(buffer, 0, bytes);
+    }
+    outStream.toByteArray
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormat.scala
@@ -1,0 +1,29 @@
+package geotrellis.spark.io.s3
+
+import com.github.nscala_time.time.Imports._
+import geotrellis.proj4._
+import geotrellis.raster.io.geotiff.reader._
+import geotrellis.raster.Tile
+import geotrellis.spark._
+import geotrellis.spark.ingest._
+import geotrellis.vector.Extent
+import org.apache.hadoop.mapreduce.{InputSplit, TaskAttemptContext}
+
+/** Read single band GeoTiff from S3 
+ * Input GeoTiffs should have 'ISO_TIME' tag with ISO 8601 DateTime formated timestamp.
+ */
+class TemporalGeoTiffS3InputFormat extends S3InputFormat[SpaceTimeInputKey,Tile] {
+  def createRecordReader(split: InputSplit, context: TaskAttemptContext) = 
+    new S3RecordReader[SpaceTimeInputKey,Tile] {
+      def read(bytes: Array[Byte]) = {        
+        val geoTiff = GeoTiffReader.read(bytes)
+        val meta = geoTiff.metaData
+        val isoString = geoTiff.tags("ISO_TIME")
+        val dateTime = DateTime.parse(isoString)
+
+        //WARNING: Assuming this is a single band GeoTiff
+        val GeoTiffBand(tile, extent, crs, _) = geoTiff.bands.head
+        (SpaceTimeInputKey(extent, crs, dateTime), tile)        
+      }
+    }     
+}

--- a/spark/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
@@ -1,0 +1,39 @@
+package geotrellis.spark.io.s3
+
+import geotrellis.proj4.LatLng
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.spark.io.hadoop._
+import geotrellis.spark.ingest._
+import org.scalatest._
+
+class GeoTiffS3InputFormatSpec extends FunSpec with OnlyIfCanRunSpark with Matchers {
+  
+  describe("GeoTiff S3 InputFormat") {      
+    val url = "s3n://geotrellis-test/nlcd-geotiff"      
+    ifCanRunSpark {  
+      it("should read GeoTiffs from S3") {
+        val job = sc.newJob("geotiff-ingest")        
+        S3InputFormat.setUrl(job, url)
+        S3InputFormat.setAnonymous(job)
+        
+        val source = sc.newAPIHadoopRDD(job.getConfiguration,
+          classOf[GeoTiffS3InputFormat],
+          classOf[ProjectedExtent],
+          classOf[Tile])
+        source.cache      
+        val sourceCount = source.count
+        sourceCount should not be (0)
+        info(s"Source RDD count: ${sourceCount}")
+        
+        val (level, rdd) =  Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme())
+        val rddCount = rdd.count
+        rddCount should not be (0)
+        info(s"Tiled RDD count: ${rddCount}")
+        
+        source.unpersist()
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/io/s3/S3InputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/S3InputFormatSpec.scala
@@ -1,0 +1,31 @@
+package geotrellis.spark.io.s3
+
+import org.scalatest._
+
+class S3InputFormatSpec extends FunSpec
+  with Matchers
+{
+  describe("S3 InputFormat") {
+
+    it("should parse the s3 url containing keys") {
+      // don't get too excited, not real keys
+      val url = "s3n://AAIKJLIB4YGGVMAATT4A:ZcjWmdXN+75555bptjE4444TqxDY3ESZgeJxGsj8@nex-bcsd-tiled-geotiff/prefix/subfolder"
+      val S3InputFormat.S3UrlRx(id,key,bucket,prefix) = url
+      
+      id should be ("AAIKJLIB4YGGVMAATT4A")
+      key should be ("ZcjWmdXN+75555bptjE4444TqxDY3ESZgeJxGsj8")
+      bucket should be ("nex-bcsd-tiled-geotiff")
+      prefix should be ("prefix/subfolder")      
+    }
+
+    it("should parse s3 url without keys"){
+      val url = "s3n://nex-bcsd-tiled-geotiff/prefix/subfolder"      
+      val  S3InputFormat.S3UrlRx(id,key,bucket,prefix) = url
+      
+      id should be (null)
+      key should be (null)
+      bucket should be ("nex-bcsd-tiled-geotiff")
+      prefix should be ("prefix/subfolder")  
+    }
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
@@ -1,0 +1,39 @@
+package geotrellis.spark.io.s3
+
+import geotrellis.proj4.LatLng
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.spark.io.hadoop._
+import geotrellis.spark.ingest._
+import org.scalatest._
+
+class TemporalGeoTiffS3InputFormatSpec extends FunSpec with Matchers with OnlyIfCanRunSpark {
+  val layoutScheme = ZoomedLayoutScheme()
+
+  describe("Temporal GeoTiff S3 InputFormat"){
+    ifCanRunSpark {
+      it("should read GeoTiffs with ISO_TIME tag from S3") {
+        val url = "s3n://geotrellis-test/nex-geotiff/"
+        val job = sc.newJob("temporal-geotiff-ingest")        
+        S3InputFormat.setUrl(job, url)
+        S3InputFormat.setAnonymous(job)
+
+        val source = sc.newAPIHadoopRDD(job.getConfiguration,
+          classOf[TemporalGeoTiffS3InputFormat],
+          classOf[SpaceTimeInputKey],
+          classOf[Tile])
+
+        source.cache      
+        val sourceCount = source.count
+        sourceCount should not be (0)
+        info(s"Source RDD count: ${sourceCount}")
+
+        val (level, rdd) =  Ingest[SpaceTimeInputKey, SpaceTimeKey](source, LatLng, layoutScheme)
+        val rddCount = rdd.count
+        rddCount should not be (0)
+        info(s"Tiled RDD count: ${rddCount}")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Using AWS S3 SDK allows us to list files significantly faster than using Hadoop FileInputFormat.

This input format defines InputSplits using S3 pagination, giving a reasonable spark task size for RDDs created from this InputFormat.

Concrete implementations are added to read GeoTiffs from S3.