### PR TITLE
BatchAccumuloInputFormat

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/BatchAccumuloInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/BatchAccumuloInputFormat.scala
@@ -1,0 +1,101 @@
+package geotrellis.spark.io.accumulo
+
+import java.nio.ByteBuffer
+
+import org.apache.accumulo.core.client.impl.Tables
+import org.apache.accumulo.core.client.mapreduce.lib.util.{InputConfigurator => IC, ConfiguratorBase => CB}
+import org.apache.accumulo.core.client.mapreduce.{InputFormatBase, AccumuloInputFormat}
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.client.ZooKeeperInstance
+import org.apache.accumulo.core.client.{TableOfflineException, TableDeletedException}
+import org.apache.accumulo.core.data.{Range => ARange, Value, Key, KeyExtent}
+import org.apache.accumulo.core.master.state.tables.TableState
+import org.apache.accumulo.core.security.thrift.TCredentials
+import org.apache.accumulo.core.security.CredentialHelper
+import org.apache.accumulo.core.util.UtilWaitThread
+import org.apache.hadoop.mapreduce.{RecordReader, TaskAttemptContext, InputSplit, JobContext}
+import scala.collection.JavaConverters._
+
+/** This input format will use Accumulo [TabletLocator] to create InputSplits for each tablet that contains
+ * records from specified ranges. This is unlike AccumuloInputFormat which creates a single split per Range.
+ * The MultiRangeInputSplits are intended to be read using a BatchScanner. This drastically reduces the number of 
+ * splits and consequnetly spark tasks that are produced by this InputFormat. Locality is preserved because tablets
+ * may only be hosted by a single tablet server at a given time.
+ *
+ * Because RecordReader uses BatchScanner a number of modes are not supported: Offline, Isolated and Local Iterators.
+ * These modes are backed by specalized scanners that only support scanning through a single range.
+ *
+ * We borrow some Accumulo machinery to set and read configurations so classOf AccumuloInputFormat should be used 
+ * for mudifiying Congiruation, as if AccumuloInputFormat will be used.
+ */
+class BatchAccumuloInputFormat extends InputFormatBase[Key, Value] {
+  /** We're going to lie about our class so we can re-use Accumulo InputConfigurator to pull our Job settings */
+  private val CLASS: Class[_] = classOf[AccumuloInputFormat]
+
+  override def getSplits(context: JobContext): java.util.List[InputSplit] = {
+    val conf = context.getConfiguration
+    require(IC.isOfflineScan(CLASS,conf) == false, "Offline scans not supported")
+    require(IC.isIsolated(CLASS,conf) == false, "Isolated scans not supported")
+    require(IC.usesLocalIterators(CLASS,conf) == false, "Local iterators not supported")
+
+    val ranges  = IC.getRanges(CLASS, conf)
+    val tableName = IC.getInputTableName(CLASS, conf)
+    val instance = CB.getInstance(CLASS, conf)
+    val tabletLocator = IC.getTabletLocator(CLASS, conf)
+    val tokenClass = CB.getTokenClass(CLASS, conf)
+    val principal = CB.getPrincipal(CLASS, conf)
+    val tokenBytes = CB.getToken(CLASS, conf)
+    val token = CredentialHelper.extractToken(tokenClass, tokenBytes)
+    val credentials = new TCredentials(principal, tokenClass, ByteBuffer.wrap(tokenBytes), instance.getInstanceID)
+
+    /** Ranges binned by tablets */
+    val binnedRanges = new java.util.HashMap[String, java.util.Map[KeyExtent, java.util.List[ARange]]]()
+
+    // loop until list of tablet lookup failures is empty
+    while (! tabletLocator.binRanges(ranges, binnedRanges, credentials).isEmpty) {
+      var tableId: String = null
+      if (! instance.isInstanceOf[MockInstance]) {
+        if (tableId == null)
+          tableId = Tables.getTableId(instance, tableName)
+        if (! Tables.exists(instance, tableId))
+          throw new TableDeletedException(tableId)
+        if (Tables.getTableState(instance, tableId) eq TableState.OFFLINE)
+          throw new TableOfflineException(instance, tableId)
+      }
+      binnedRanges.clear()
+      //logger.warn("Unable to locate bins for specified ranges. Retrying.")
+      UtilWaitThread.sleep(100 + (Math.random * 100).toInt)
+      tabletLocator.invalidateCache()
+    }
+    // location: String = server:ip for the tablet server
+    // list: Map[KeyExtent, List[ARange]]
+    binnedRanges.asScala map { case (location, list) =>
+      list.asScala.map { case (keyExtent, extentRanges) =>        
+        val tabletRange = keyExtent.toDataRange        
+        val split = new MultiRangeInputSplit()
+        split.ranges = extentRanges.asScala map { tabletRange.clip }
+        split.location = location
+        split.table = tableName
+        split.instanceName = instance.getInstanceName
+        split.zooKeepers = instance.getZooKeepers
+        split.principal = principal
+        split.token = token
+        split.fetchedColumns = IC.getFetchedColumns(CLASS, conf).asScala
+        instance match {
+          case _: MockInstance      => split.mockInstance = true
+          case _: ZooKeeperInstance => split.mockInstance = false
+          case _ => sys.error("Unknown instance type")
+        }
+
+        split: InputSplit
+      }
+    }
+  }.flatten.toList.asJava
+
+  override def createRecordReader(inputSplit: InputSplit, taskAttemptContext: TaskAttemptContext): RecordReader[Key, Value] = {
+    val reader = new MultiRangeRecordReader()
+    reader.initialize(inputSplit, taskAttemptContext)
+    reader
+  }
+}
+

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/BatchAccumuloInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/BatchAccumuloInputFormat.scala
@@ -73,7 +73,13 @@ class BatchAccumuloInputFormat extends InputFormatBase[Key, Value] {
       list.asScala.map { case (keyExtent, extentRanges) =>        
         val tabletRange = keyExtent.toDataRange        
         val split = new MultiRangeInputSplit()
-        split.ranges = extentRanges.asScala map { tabletRange.clip }
+        val exr = extentRanges.asScala
+        split.ranges = 
+          if (exr.isEmpty)
+            List(new ARange())
+          else 
+            exr map { tabletRange.clip }
+        split.iterators = IC.getIterators(CLASS, conf).asScala.toList
         split.location = location
         split.table = tableName
         split.instanceName = instance.getInstanceName

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/MultiRangeInputSplit.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/MultiRangeInputSplit.scala
@@ -1,0 +1,165 @@
+package geotrellis.spark.io.accumulo
+
+import java.io.{IOException, DataOutput, DataInput}
+import java.nio.charset.Charset
+import org.apache.accumulo.core.client._
+import org.apache.accumulo.core.client.mapreduce.lib.util.{InputConfigurator => IC}
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.client.security.tokens.AuthenticationToken
+import org.apache.accumulo.core.data.{Range => ARange}
+import org.apache.accumulo.core.security.{CredentialHelper, Authorizations}
+import org.apache.accumulo.core.util.{Pair => APair}
+import org.apache.commons.codec.binary.Base64
+import org.apache.hadoop.io.{Writable, Text}
+import org.apache.hadoop.mapreduce.InputSplit
+import org.apache.log4j.Level
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+
+class MultiRangeInputSplit extends InputSplit with Writable {
+  var ranges: Seq[ARange] = null
+  var location: String = null
+  var table: String = null
+  var instanceName: String = null
+  var zooKeepers: String = null
+  var principal: String = null
+  var token: AuthenticationToken = null
+  var fetchedColumns: mutable.Set[APair[Text, Text]] = mutable.Set.empty
+  var auths: Authorizations = null
+  var iterators: List[IteratorSetting] = Nil  
+  
+  var mockInstance: Boolean = false
+  var level: Level = Level.INFO
+
+  
+  def instance = 
+    if (mockInstance)
+      new MockInstance(instanceName)
+    else
+      new ZooKeeperInstance(instanceName, zooKeepers)
+
+  def connector = instance.getConnector(principal, token)
+
+  override def getLength: Long = ranges.length
+
+
+  /** By definition this split can have only one location */
+  override def getLocations: Array[String] = Array(location)
+
+
+  override def write(out: DataOutput): Unit = {
+    out.writeInt(ranges.length)
+    ranges foreach { range => range .write(out) }
+    out.writeBoolean(null != table)
+    if (null != table) {
+      out.writeUTF(table)
+    }
+    out.writeUTF(location)
+    out.writeBoolean(mockInstance)
+    out.writeBoolean(null != fetchedColumns)
+    if (null != fetchedColumns) {
+      val cols: Array[String] = IC.serializeColumns(fetchedColumns.asJava)
+      out.writeInt(cols.length)
+      for (col <- cols) {
+        out.writeUTF(col)
+      }
+    }
+    out.writeBoolean(null != auths)
+    if (null != auths) {
+      out.writeUTF(auths.serialize)
+    }
+    out.writeBoolean(null != principal)
+    if (null != principal) {
+      out.writeUTF(principal)
+    }
+    out.writeBoolean(null != token)
+    if (null != token) {
+      out.writeUTF(token.getClass.getCanonicalName)
+      try {
+        out.writeUTF(CredentialHelper.tokenAsBase64(token))
+      }
+      catch {
+        case e: AccumuloSecurityException => {
+          throw new IOException(e)
+        }
+      }
+    }
+    out.writeBoolean(null != instanceName)
+    if (null != instanceName) {
+      out.writeUTF(instanceName)
+    }
+    out.writeBoolean(null != zooKeepers)
+    if (null != zooKeepers) {
+      out.writeUTF(zooKeepers)
+    }
+    out.writeBoolean(null != iterators)
+    if (null != iterators) {
+      out.writeInt(iterators.size)
+      for (iterator <- iterators) {
+        iterator.write(out)
+      }
+    }
+    out.writeBoolean(null != level)
+    if (null != level) {
+      out.writeInt(level.toInt)
+    }
+  }
+
+  override def readFields(in: DataInput): Unit = {
+    val numRanges = in.readInt()
+    ranges = for(i <- 0  until numRanges) yield {
+      val range = new ARange()
+      range.readFields(in)
+      range
+    }
+    if (in.readBoolean()) {
+      table = in.readUTF()
+    }    
+    location = in.readUTF()
+    mockInstance = in.readBoolean()
+    
+    if (in.readBoolean()) {
+      val numColumns = in.readInt()
+      var columns: java.util.List[String] = new java.util.ArrayList()
+      for (i <- 0 until numColumns) {
+        columns.add(in.readUTF())
+      }
+      fetchedColumns = IC.deserializeFetchedColumns(columns).asScala
+    }
+
+    if (in.readBoolean()) {
+      val strAuths = in.readUTF()
+      auths = new Authorizations(strAuths.getBytes(Charset.forName("UTF-8")))
+    }
+
+    if (in.readBoolean()) {
+      principal = in.readUTF();
+    }
+
+    if (in.readBoolean()) {
+      val tokenClass = in.readUTF();
+      val base64TokenBytes = in.readUTF().getBytes(Charset.forName("UTF-8"));
+      val tokenBytes = Base64.decodeBase64(base64TokenBytes);
+      token = CredentialHelper.extractToken(tokenClass, tokenBytes);
+    }
+
+    if (in.readBoolean()) {
+      instanceName = in.readUTF();
+    }
+
+    if (in.readBoolean()) {
+      zooKeepers = in.readUTF();
+    }
+
+    if (in.readBoolean()) {
+      val numIterators = in.readInt()      
+      for (i <- 0 until numIterators) {
+        iterators = new IteratorSetting(in) :: iterators
+      }
+    }
+
+    if (in.readBoolean()) {
+      level = Level.toLevel(in.readInt());
+    }
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/MultiRangeRecordReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/MultiRangeRecordReader.scala
@@ -33,8 +33,8 @@ class MultiRangeRecordReader extends RecordReader[Key, Value] {
     iterator = scanner.iterator().asScala
   }
 
-  def getProgress: Float = ???
-
+  def getProgress: Float = 0 //not sure how this is used
+  
   def nextKeyValue(): Boolean = {
     val hasNext = iterator.hasNext
     if (hasNext) {

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/MultiRangeRecordReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/MultiRangeRecordReader.scala
@@ -1,0 +1,55 @@
+package geotrellis.spark.io.accumulo
+
+import org.apache.accumulo.core.client._
+import org.apache.accumulo.core.data._
+import org.apache.accumulo.core.security.Authorizations
+import org.apache.hadoop.mapreduce.{RecordReader, TaskAttemptContext, InputSplit}
+import scala.collection.JavaConverters._
+
+/**
+ * It is not clear what would be better, a series of scanners or a BatchScanner.
+ * BatchScanner is way easier to code for this, so that's what's happening.
+ */
+class MultiRangeRecordReader extends RecordReader[Key, Value] {
+  var scanner: BatchScanner = null
+  var iterator: Iterator[java.util.Map.Entry[Key, Value]] = null
+  var key: Key = null
+  var value: Value = null
+
+  def initialize(inputSplit: InputSplit, context: TaskAttemptContext): Unit = {    
+    val split = inputSplit.asInstanceOf[MultiRangeInputSplit]
+    
+    val queryThreads = 1
+    val connector = split.connector
+    scanner = connector.createBatchScanner(split.table, new Authorizations(), queryThreads);
+    scanner.setRanges(split.ranges.asJava)        
+    split.iterators foreach { scanner.addScanIterator }
+    split.fetchedColumns foreach { pair =>  
+      if (pair.getSecond != null)
+        scanner.fetchColumn(pair.getFirst, pair.getSecond) 
+      else 
+        scanner.fetchColumnFamily(pair.getFirst)
+    }
+    iterator = scanner.iterator().asScala
+  }
+
+  def getProgress: Float = ???
+
+  def nextKeyValue(): Boolean = {
+    val hasNext = iterator.hasNext
+    if (hasNext) {
+      val entry = iterator.next()
+      key = entry.getKey
+      value = entry.getValue
+    }
+    hasNext
+  }
+
+  def getCurrentValue: Value = value
+
+  def getCurrentKey: Key = key
+
+  def close(): Unit = {
+    scanner.close
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/BatchAccumuloInputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/BatchAccumuloInputFormatSpec.scala
@@ -1,0 +1,116 @@
+package geotrellis.spark.io.accumulo
+
+import java.io.IOException
+
+import geotrellis.raster._
+import geotrellis.spark
+
+import geotrellis.spark._
+import geotrellis.spark.ingest._
+import geotrellis.spark.io._
+import geotrellis.spark.io.hadoop._
+import geotrellis.spark.tiling._
+import geotrellis.raster.op.local._
+import geotrellis.spark.utils.SparkUtils
+import geotrellis.proj4.LatLng
+
+import org.apache.spark._
+import org.apache.spark.rdd._
+import org.joda.time.DateTime
+import org.scalatest._
+import org.scalatest.Matchers._
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.data.{Key, Mutation, Value, Range => ARange}
+import org.apache.accumulo.core.client.mapreduce.lib.util.{ConfiguratorBase => CB}
+import org.apache.accumulo.core.client.mapreduce.{AccumuloInputFormat, InputFormatBase }
+import org.apache.accumulo.core.client.{BatchWriterConfig, IteratorSetting}
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.Text
+import scala.collection.JavaConverters._
+
+// we don't care about data or row/column selection
+case class Row(id: String, colFam: String, colQual: String){
+  def mutation: Mutation = {
+    val mutation = new Mutation(new Text(id))
+    mutation.put(
+      new Text(colFam), new Text(colQual),
+      System.currentTimeMillis(), new Value(Array.empty[Byte])
+    )
+    mutation
+  }
+}
+
+/**
+ * We need to test if Batch IF behaves the same as Accumulo IF.
+ * The operations we care about is range selection and filter application.
+ */
+class BatchAccumuloInputFormatSpec extends FunSpec 
+  with Matchers
+  with TestEnvironment
+  with OnlyIfCanRunSpark 
+{
+  val data = List[Row] (
+    Row("1", "col", "a"), Row("1", "col", "b"), Row("1", "col", "c"),
+    Row("2", "col", "a"), Row("2", "col", "b"), Row("2", "col", "c"),
+    Row("3", "col", "a"), Row("3", "col", "b"), Row("3", "col", "c")
+  )
+  val table = "data"
+  val accumulo = new AccumuloInstance(
+    instanceName = "fake",
+    zookeeper = "localhost",
+    user = "root",
+    token = new PasswordToken("")
+  )
+  val job = sc.newJob
+  val jconf = job.getConfiguration
+  CB.setMockInstance(classOf[AccumuloInputFormat], jconf, "fake")
+  CB.setConnectorInfo(classOf[AccumuloInputFormat], jconf, "root", new PasswordToken(""))
+  InputFormatBase.setInputTableName(job, table)
+  accumulo.connector.tableOperations().create(table)
+  val writer = accumulo.connector.createBatchWriter(table, new BatchWriterConfig())
+  data map { _.mutation } foreach { writer.addMutation }
+  
+  describe("BatchAccumuloInputFormat") {
+    ifCanRunSpark {
+      it("full table scan") {
+        val ifSet = sc.newAPIHadoopRDD(job.getConfiguration, classOf[AccumuloInputFormat], classOf[Key], classOf[Value]).collect.toSet        
+        val bifSet = sc.newAPIHadoopRDD(job.getConfiguration, classOf[BatchAccumuloInputFormat], classOf[Key], classOf[Value]).collect.toSet
+        info(s"AccumloInputFormat records ${ifSet.size}")
+        info(s"BatchAccumloInputFormat records ${bifSet.size}")        
+        bifSet should be (ifSet)
+      }
+
+      it("range constraint") {       
+        InputFormatBase.setRanges(job, List(
+          new ARange(new Text("1"), new Text("1")), 
+          new ARange(new Text("3"), new Text("3"))
+        ).asJava)       
+        val ifSet = sc.newAPIHadoopRDD(job.getConfiguration, classOf[AccumuloInputFormat], classOf[Key], classOf[Value]).collect.toSet        
+        val bifSet = sc.newAPIHadoopRDD(job.getConfiguration, classOf[BatchAccumuloInputFormat], classOf[Key], classOf[Value]).collect.toSet
+        info(s"AccumloInputFormat records ${ifSet.size}")
+        info(s"BatchAccumloInputFormat records ${bifSet.size}")        
+        bifSet should be (ifSet)
+        ifSet.size should be (6)
+      }    
+
+      it("filter constraints") {
+        val props =  Map(
+          "startBound" -> "b",
+          "endBound" -> "c",
+          "startInclusive" -> "true",
+          "endInclusive" -> "true"
+        )
+
+        InputFormatBase.addIterator(job, 
+          new IteratorSetting(1, "TimeColumnFilter", "org.apache.accumulo.core.iterators.user.ColumnSliceFilter", props.asJava))
+
+        val ifSet = sc.newAPIHadoopRDD(job.getConfiguration, classOf[AccumuloInputFormat], classOf[Key], classOf[Value]).collect.toSet        
+        val bifSet = sc.newAPIHadoopRDD(job.getConfiguration, classOf[BatchAccumuloInputFormat], classOf[Key], classOf[Value]).collect.toSet
+        info(s"AccumloInputFormat records ${ifSet.size}")
+        info(s"BatchAccumloInputFormat records ${bifSet.size}")
+        bifSet should be (ifSet)
+        ifSet.size should be (4)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This InputFormat groups the Ranges by tablet servers where they are located. The corresponding RecordReader will use BatchScanner to read them. The overall effect is to reduce the number of splits to the minimum possible and provide some parallelism in reading them. This reduces the spark overhead of processing each task.