### PR TITLE
RasterRDD union

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/RasterRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/RasterRDD.scala
@@ -77,6 +77,18 @@ class RasterRDD[K: ClassTag](val tileRdd: RDD[(K, Tile)], val metaData: RasterMe
     }
   }
 
+  def union(other: RasterRDD[K]): RasterRDD[K] = {    
+    require(metaData.cellType == other.metaData.cellType, 
+      s"CellTypes of unioned rasters match: ${metaData.cellType} != ${other.metaData.cellType}")
+    require(metaData.crs == other.metaData.crs, 
+      s"CRS of unioned rasters match: ${metaData.crs} != ${other.metaData.crs}")
+    require(metaData.tileLayout == other.metaData.tileLayout, 
+      s"TileLayout of unioned rasters match: ${metaData.tileLayout} != ${other.metaData.tileLayout}")
+    
+    new RasterRDD(tileRdd union other.tileRdd, 
+      metaData.copy(extent = metaData.extent combine other.metaData.extent))
+  }
+
   def minMax: (Int, Int) =
     map(_.tile.findMinMax)
       .reduce { (t1, t2) =>

--- a/spark/src/test/scala/geotrellis/spark/RasterRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterRDDSpec.scala
@@ -22,6 +22,15 @@ class RasterRDDSpec extends FunSpec
         max should be (1)
       }
 
+      it ("should union two RasterRDD") {
+        val ones: RasterRDD[SpatialKey] = AllOnesTestFile
+        val twos: RasterRDD[SpatialKey] = AllTwosTestFile
+
+        val rdd: RasterRDD[SpatialKey] = ones union twos
+
+        rdd.count should equal (ones.count + twos.count)
+      }
+
       it ("should find integer min/max of example") {
         val arr: Array[Int] = 
           Array(1, 1, 2, 2, 


### PR DESCRIPTION
Provide a union for RasterRDD given that CellType, Layout and CRS match. An envelope of two raster extents is taken.