### PR TITLE
Check bounds on LZW decompression.

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/decompression/LZWDecompression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/decompression/LZWDecompression.scala
@@ -111,8 +111,6 @@ trait LZWDecompression {
 
         def isInTable(code: Int) = code < stringTableIndex
 
-        var printed = 0
-
         def writeString(string: Array[Byte]) = {
           System.arraycopy(
             string,
@@ -129,7 +127,7 @@ trait LZWDecompression {
         var oldCode = 0
 
         var break = false
-        while (!break && { code = bis.get(threshold); code != EoICode } ) {
+        while (!break && { code = bis.get(threshold); code != EoICode } && outputArrayIndex < size) {
           if (code == ClearCode) {
             initializeStringTable
             code = bis.get(threshold)


### PR DESCRIPTION
There was a bug in LZW decompression of GeoTiffs that caused an ArrayOutOfBounds exception. The file that was tripping it was way too big to include a unit test (I tried and failed at creating a small test case), but this did fix the issue.