### PR TITLE
Cassandra Attribute and Metadata Catalogs

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -372,11 +372,13 @@ object GeotrellisBuild extends Build {
       libraryDependencies ++=
         Seq(
           "org.apache.spark" %% "spark-core" % Version.spark % "provided",
+          "org.apache.spark" %% "spark-streaming" % Version.spark % "provided",
           "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
           "com.quantifind" %% "sumac" % "0.3.0",
           "org.apache.accumulo" % "accumulo-core" % "1.5.2",
           "de.javakaffee" % "kryo-serializers" % "0.27",
-          "com.datastax.spark" % "spark-cassandra-connector_2.10" % Version.cassandra_connector,
+          "com.datastax.spark" % "spark-cassandra-connector_2.10" % Version.spark_cassandra_connector,
+          "com.datastax.cassandra" % "cassandra-driver-core" % Version.cassandra_connector,
           logging, awsSdkS3,
           spire,
           monocleCore, monocleMacro,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -376,6 +376,7 @@ object GeotrellisBuild extends Build {
           "com.quantifind" %% "sumac" % "0.3.0",
           "org.apache.accumulo" % "accumulo-core" % "1.5.2",
           "de.javakaffee" % "kryo-serializers" % "0.27",
+          "com.datastax.spark" % "spark-cassandra-connector_2.10" % Version.cassandra_connector,
           logging, awsSdkS3,
           spire,
           monocleCore, monocleMacro,
@@ -384,7 +385,7 @@ object GeotrellisBuild extends Build {
           scalatest % "test"
         ),
       resolvers ++= Seq(
-        "Cloudera Repo" at "https://repository.cloudera.com/artifactory/cloudera-repos"
+        "Cloudera Repo" at "https://repository.cloudera.com/artifactory/cloudera-repos"        
       ),
       initialCommands in console :=
         """

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -27,8 +27,8 @@ object Version {
   val spray       = "1.3.2"
   val jackson     = "1.6.1"
   val monocle     = "1.0.1"
-  lazy val hadoop              = either("SPARK_HADOOP_VERSION", "2.5.0")
-  lazy val spark               = either("SPARK_VERSION", "1.2.0")
-  lazy val cassandra_connector = "1.2.0-alpha2"
-
+  lazy val hadoop          = either("SPARK_HADOOP_VERSION", "2.5.0")
+  lazy val spark           = either("SPARK_VERSION", "1.2.0")
+  lazy val cassandra_connector       = "2.1.4"
+  lazy val spark_cassandra_connector = "1.2.0-alpha2"
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -27,6 +27,8 @@ object Version {
   val spray       = "1.3.2"
   val jackson     = "1.6.1"
   val monocle     = "1.0.1"
-  lazy val hadoop      = either("SPARK_HADOOP_VERSION", "2.5.0")
-  lazy val spark       = either("SPARK_VERSION", "1.2.0")
+  lazy val hadoop              = either("SPARK_HADOOP_VERSION", "2.5.0")
+  lazy val spark               = either("SPARK_VERSION", "1.2.0")
+  lazy val cassandra_connector = "1.2.0-alpha2"
+
 }

--- a/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraAttributeCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraAttributeCatalog.scala
@@ -1,0 +1,25 @@
+package geotrellis.spark.io.cassandra
+
+import geotrellis.spark._
+import geotrellis.spark.io._
+
+import spray.json._
+
+import org.apache.spark._
+
+class CassandraAttributeCatalog(sc: SparkContext, val attributeTable: String) extends AttributeCatalog {
+  type ReadableWriteable[T] = RootJsonFormat[T]
+
+  // Create the attribute table if it doesn't exist
+  {
+    
+  }
+
+  def load[T: RootJsonFormat](layerId: LayerId, attributeName: String): T = {
+    // Load json-formatted attribute
+  }
+
+  def save[T: RootJsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
+    // Save json-formatted attribute
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraAttributeCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraAttributeCatalog.scala
@@ -5,21 +5,53 @@ import geotrellis.spark.io._
 
 import spray.json._
 
-import org.apache.spark._
+import com.datastax.driver.core.DataType.text
+import com.datastax.driver.core.querybuilder.QueryBuilder
+import com.datastax.driver.core.querybuilder.QueryBuilder.set
+import com.datastax.driver.core.schemabuilder.SchemaBuilder
 
-class CassandraAttributeCatalog(sc: SparkContext, val attributeTable: String) extends AttributeCatalog {
-  type ReadableWriteable[T] = RootJsonFormat[T]
+import com.datastax.spark.connector.cql.CassandraConnector
+
+import org.apache.spark.Logging
+
+class CassandraAttributeCatalog(connector: CassandraConnector, val attributeTable: String) extends AttributeCatalog with Logging {
+  type ReadableWritable[T] = RootJsonFormat[T]
+
+  val eq = QueryBuilder.eq _
 
   // Create the attribute table if it doesn't exist
   {
+    val schema = SchemaBuilder.createTable(attributeTable).ifNotExists()
+      .addPartitionKey("layerId", text)
+      .addClusteringColumn("name", text)
+      .addStaticColumn("value", text)
     
+    connector.withSessionDo(_.execute(schema))
   }
-
+  
   def load[T: RootJsonFormat](layerId: LayerId, attributeName: String): T = {
-    // Load json-formatted attribute
+    val query = QueryBuilder.select.column("value").from(attributeTable)
+      .where (eq("layerId", layerId.toString))
+      .and   (eq("name", attributeName))
+    
+    val results = connector.withSessionDo(_.execute(query))
+    
+    val size = results.getAvailableWithoutFetching
+    if(size == 0) {
+      sys.error(s"Attribute $attributeName not found for layer $layerId")
+    } else if (size > 1) {
+      sys.error(s"Multiple attributes found for $attributeName for layer $layerId")
+    } else {
+      results.one.getString("value").parseJson.convertTo[T]
+    }
   }
-
+  
   def save[T: RootJsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
-    // Save json-formatted attribute
+    val update = QueryBuilder.update(attributeTable)
+      .`with`(set("value", value.toJson.compactPrint))
+      .where (eq("layerId", layerId.toString))
+      .and   (eq("name", attributeName))
+
+    connector.withSessionDo(_.execute(update))
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalog.scala
@@ -1,0 +1,119 @@
+package geotrellis.spark.io.cassandra
+
+import geotrellis.raster.histogram.Histogram
+import geotrellis.raster.io.json._
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.json._
+
+import spray.json._
+
+import com.datastax.driver.core.DataType.text
+import com.datastax.driver.core.DataType.cint
+import com.datastax.driver.core.querybuilder.QueryBuilder
+import com.datastax.driver.core.querybuilder.QueryBuilder.set
+import com.datastax.driver.core.schemabuilder.SchemaBuilder
+
+import com.datastax.spark.connector.cql.CassandraConnector
+
+import org.apache.spark.Logging
+
+import DefaultJsonProtocol._
+
+class CassandraMetaDataCatalog(connector: CassandraConnector, val catalogTable: String) extends MetaDataCatalog[String] with Logging {
+
+  var catalog: Map[(LayerId, TableName), LayerMetaData] = fetchAll
+  val eq = QueryBuilder.eq _
+
+  // Create the catalog table if it doesn't exist
+  {
+    val schema = SchemaBuilder.createTable(catalogTable).ifNotExists()
+      .addPartitionKey("name", text)
+      .addClusteringColumn("table", text)
+      .addClusteringColumn("zoom", cint)
+      .addStaticColumn("keyClass", text)
+      .addStaticColumn("metadata", text)
+      .addStaticColumn("histogram", text)
+    
+    connector.withSessionDo(_.execute(schema))
+  }
+  
+  type TableName = String
+
+  def load(layerId: LayerId): (LayerMetaData, TableName) = {
+    val candidates = catalog
+      .filterKeys( key => key._1 == layerId)
+
+    candidates.size match {
+      case 0 =>
+        throw new LayerNotFoundError(layerId)
+      case 1 =>
+        val (key, value) = candidates.toList.head
+        (value, key._2)
+      case _ =>
+        throw new MultipleMatchError(layerId)
+    }
+  }
+
+  def load(layerId: LayerId, table: TableName): LayerMetaData = {
+    catalog.get(layerId -> table) match {
+      case Some(md) => md
+      case None =>
+        throw new LayerNotFoundError(layerId)
+    }
+  }
+
+  def save(layerId: LayerId, table: TableName,  metaData: LayerMetaData, clobber: Boolean): Unit = {
+    if (catalog.contains(layerId -> table)) {
+      if (!clobber) {
+        throw new LayerExistsError(layerId)
+      }
+    }
+
+    catalog = catalog updated ((layerId -> table), metaData)
+
+    val update = QueryBuilder.update(catalogTable)
+      .`with`(set("metadata", metaData.rasterMetaData.toJson.compactPrint))
+      .and   (set("histogram", metaData.histogram.toJson.compactPrint))
+      .and   (set("keyClass", metaData.keyClass))
+      .where (eq("name", layerId.name))
+      .and   (eq("table", table.toString))
+
+    connector.withSessionDo(_.execute(update))
+  }
+
+  def fetchAll: Map[(LayerId, TableName), LayerMetaData] = {
+    var data: Map[(LayerId, TableName), Map[String, String]] =
+      Map.empty.withDefaultValue(Map.empty)
+
+    val queryAll = QueryBuilder.select.all.from(catalogTable)
+    val results = connector.withSessionDo(_.execute(queryAll))
+    val iter = results.iterator
+
+    while (iter.hasNext) {
+      val row = iter.next
+      val name = row.getString("name")
+      val table = row.getString("table")
+      val zoom: Int = row.getInt("zoom")
+      val keyClass = row.getString("keyClass")
+      val metaData = row.getString("metadata")
+      val histogram = row.getString("histogram")
+
+      val layerId = LayerId(name, zoom)      
+
+      val k = layerId -> table
+      data = data updated (k, data(k) updated ("keyClass", keyClass))
+      data = data updated (k, data(k) updated ("metadata", metaData))
+      data = data updated (k, data(k) updated ("histogram", histogram))
+    }
+
+    def readLayerMetaData(map: Map[String, String]): LayerMetaData =
+      LayerMetaData(
+        keyClass =  map("keyClass"),
+        rasterMetaData = map("metadata").parseJson.convertTo[RasterMetaData],
+        histogram = map.get("histogram").map(_.parseJson.convertTo[Histogram])
+      )
+
+    data map { case (key, fieldMap) => key -> readLayerMetaData(fieldMap)}
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalog.scala
@@ -95,7 +95,10 @@ class CassandraMetaDataCatalog(connector: CassandraConnector, val keyspace: Stri
       val zoom: Int  = row.getInt("zoom")
       val keyClass   = row.getString("keyClass")
       val rasterData = row.getString("metadata")
-      val histogram  = Option(row.getString("histogram")) 
+      val histogram  = row.getString("histogram") match {
+        case "null" => None
+        case hist: String => Some(hist)
+      }
 
       val layerId = LayerId(name, zoom)
       val metaData = LayerMetaData(

--- a/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraAttributeCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraAttributeCatalogSpec.scala
@@ -1,0 +1,74 @@
+package geotrellis.spark.io.cassandra
+
+import java.io.IOException
+
+import geotrellis.raster._
+import geotrellis.raster.io.json._
+import geotrellis.raster.histogram._
+
+import geotrellis.spark._
+
+import geotrellis.spark.testfiles._
+import geotrellis.spark.op.stats._
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import org.joda.time.DateTime
+import org.scalatest._
+
+import org.apache.spark.SparkConf
+import com.datastax.spark.connector.cql.CassandraConnector
+
+class CassandraAttributeCatalogSpec extends FunSpec
+  with Matchers
+  with TestFiles
+  with TestEnvironment
+  with OnlyIfCanRunSpark {
+
+  describe("Cassandra Attribute Catalog") {
+    ifCanRunSpark {
+
+      val conf = new SparkConf(true)
+        .set("spark.cassandra.connection.host", "127.0.0.1")
+
+      val connector = CassandraConnector(conf)
+
+      val attribCatalog = new CassandraAttributeCatalog(connector, "test", "attributes")
+      val layerId = LayerId("test", 3)
+
+      it("should save and pull out a histogram") {
+        val histo = DecreasingTestFile.histogram
+
+        attribCatalog.save(layerId, "histogram", histo)
+
+        val loaded = attribCatalog.load[Histogram](layerId, "histogram")
+        loaded.getMean should be (histo.getMean)
+      }
+
+      it("should save and load a random RootJsonReadable object") {
+        case class Foo(x: Int, y: String)
+
+        implicit object FooFormat extends RootJsonFormat[Foo] {
+          def write(obj: Foo): JsObject =
+            JsObject(
+              "the_first_field" -> JsNumber(obj.x),
+              "the_second_field" -> JsString(obj.y)
+            )
+
+          def read(json: JsValue): Foo =
+            json.asJsObject.getFields("the_first_field", "the_second_field") match {
+              case Seq(JsNumber(x), JsString(y)) =>
+                Foo(x.toInt, y)
+              case _ =>
+                throw new DeserializationException(s"JSON reading failed.")
+            }
+        }
+
+        val foo = Foo(1, "thing")
+
+        attribCatalog.save(layerId, "foo", foo)
+        attribCatalog.load[Foo](layerId, "foo") should be (foo)
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraAttributeCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraAttributeCatalogSpec.scala
@@ -27,47 +27,57 @@ class CassandraAttributeCatalogSpec extends FunSpec
 
   describe("Cassandra Attribute Catalog") {
     ifCanRunSpark {
-
+      
       val conf = new SparkConf(true)
         .set("spark.cassandra.connection.host", "127.0.0.1")
 
       val connector = CassandraConnector(conf)
-
-      val attribCatalog = new CassandraAttributeCatalog(connector, "test", "attributes")
-      val layerId = LayerId("test", 3)
-
-      it("should save and pull out a histogram") {
-        val histo = DecreasingTestFile.histogram
-
-        attribCatalog.save(layerId, "histogram", histo)
-
-        val loaded = attribCatalog.load[Histogram](layerId, "histogram")
-        loaded.getMean should be (histo.getMean)
+      
+      val catalog: Option[CassandraAttributeCatalog] = try {
+        Some(new CassandraAttributeCatalog(connector, "test", "attributes"))
+      } catch {
+        case _: Throwable => None
       }
-
-      it("should save and load a random RootJsonReadable object") {
-        case class Foo(x: Int, y: String)
-
-        implicit object FooFormat extends RootJsonFormat[Foo] {
-          def write(obj: Foo): JsObject =
-            JsObject(
-              "the_first_field" -> JsNumber(obj.x),
-              "the_second_field" -> JsString(obj.y)
-            )
-
-          def read(json: JsValue): Foo =
-            json.asJsObject.getFields("the_first_field", "the_second_field") match {
-              case Seq(JsNumber(x), JsString(y)) =>
-                Foo(x.toInt, y)
-              case _ =>
-                throw new DeserializationException(s"JSON reading failed.")
-            }
+      
+      if (catalog.isEmpty) {
+        info("No Cassandra db at 127.0.0.1; skipping tests.")
+      } else {
+        val attribCatalog = catalog.get
+        val layerId = LayerId("test", 3)
+        
+        it("should save and pull out a histogram") {
+          val histo = DecreasingTestFile.histogram
+          
+          attribCatalog.save(layerId, "histogram", histo)
+          
+          val loaded = attribCatalog.load[Histogram](layerId, "histogram")
+          loaded.getMean should be (histo.getMean)
         }
 
-        val foo = Foo(1, "thing")
-
-        attribCatalog.save(layerId, "foo", foo)
-        attribCatalog.load[Foo](layerId, "foo") should be (foo)
+        it("should save and load a random RootJsonReadable object") {
+          case class Foo(x: Int, y: String)
+          
+          implicit object FooFormat extends RootJsonFormat[Foo] {
+            def write(obj: Foo): JsObject =
+              JsObject(
+                "the_first_field" -> JsNumber(obj.x),
+                "the_second_field" -> JsString(obj.y)
+              )
+            
+            def read(json: JsValue): Foo =
+              json.asJsObject.getFields("the_first_field", "the_second_field") match {
+                case Seq(JsNumber(x), JsString(y)) =>
+                  Foo(x.toInt, y)
+                case _ =>
+                  throw new DeserializationException(s"JSON reading failed.")
+              }
+          }
+          
+          val foo = Foo(1, "thing")
+          
+          attribCatalog.save(layerId, "foo", foo)
+          attribCatalog.load[Foo](layerId, "foo") should be (foo)
+        }
       }
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalogSpec.scala
@@ -1,0 +1,56 @@
+package geotrellis.spark.io.cassandra
+
+import java.io.IOException
+
+import geotrellis.raster._
+import geotrellis.raster.io.json._
+import geotrellis.raster.histogram._
+
+import geotrellis.spark._
+
+import geotrellis.spark.testfiles._
+import geotrellis.spark.op.stats._
+import geotrellis.spark.io.LayerMetaData
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import org.joda.time.DateTime
+import org.scalatest._
+
+import org.apache.spark.SparkConf
+import com.datastax.spark.connector.cql.CassandraConnector
+
+class CassandraMetaDataCatalogSpec extends FunSpec
+                                   with Matchers
+                                   with TestFiles
+                                   with TestEnvironment
+                                   with OnlyIfCanRunSpark {
+
+  describe("Cassandra MetaData Catalog") {
+    ifCanRunSpark {
+
+      val conf = new SparkConf(true)
+        .set("spark.cassandra.connection.host", "127.0.0.1")
+
+      val connector = CassandraConnector(conf)
+
+      val metaDataCatalog = new CassandraMetaDataCatalog(connector, "test", "catalogs")
+      val layerId = LayerId("test", 3)
+
+      it("should save and pull out a catalog") {
+        val rdd = DecreasingTestFile
+        val metaData = LayerMetaData(
+          keyClass = "testClass",
+          rasterMetaData = rdd.metaData,
+          histogram = Some(rdd.histogram)
+        )
+        metaDataCatalog.save(layerId, "tabletest", metaData, true)
+
+        val loaded = metaDataCatalog.load(layerId, "tabletest")
+        loaded.keyClass should be (metaData.keyClass)
+        loaded.rasterMetaData should be (metaData.rasterMetaData)
+        loaded.histogram should be (metaData.histogram)
+      }     
+    }
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalogSpec.scala
@@ -50,7 +50,23 @@ class CassandraMetaDataCatalogSpec extends FunSpec
         loaded.keyClass should be (metaData.keyClass)
         loaded.rasterMetaData should be (metaData.rasterMetaData)
         loaded.histogram should be (metaData.histogram)
+      }
+
+      it("should save and pull out a catalog with no histogram") {
+        val rdd = DecreasingTestFile
+        val metaData = LayerMetaData(
+          keyClass = "testClass",
+          rasterMetaData = rdd.metaData,
+          histogram = None
+        )
+        metaDataCatalog.save(layerId, "tabletest", metaData, true)
+
+        val loaded = metaDataCatalog.load(layerId, "tabletest")
+        loaded.keyClass should be (metaData.keyClass)
+        loaded.rasterMetaData should be (metaData.rasterMetaData)
+        loaded.histogram should be (None)
       }     
+
     }
   }
 }


### PR DESCRIPTION
Implements CassandraAttributeCatalog and CassandraMetaDataCatalog. Also brings in required dependencies for interfacing with Cassandra.

The current test specs require a local cluster to be set up on 127.0.0.1; they will be skipped if no Cassandra cluster is up. Preferably, these tests should use mocks to eliminate dependencies on persisted tables and the developer's environment.