### PR TITLE
RDD Caching during Ingest and Catalog save

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -21,7 +21,7 @@ object Version {
     Properties.envOrElse(environmentVariable, default)
 
   val geotrellis  = "0.10.0-SNAPSHOT"
-  val scala       = "2.11.5"
+  val scala       = "2.10.4"
   val geotools    = "11.0"
   val akka        = "2.3.9"
   val spray       = "1.3.2"

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -21,7 +21,12 @@ object Version {
     Properties.envOrElse(environmentVariable, default)
 
   val geotrellis  = "0.10.0-SNAPSHOT"
-  val scala       = "2.10.4"
+  /* Even though we support cross-build to 2.11 the default target is scala 2.10 primarily because Cloudera
+   * (and likely others) spark distributions target 2.10 in their default spark-assembly.jar. 
+   * One can envoke the cross-build to 2.11 by prefixing command with '+' (ex: + assembly)
+   * Until the deployment of spark on 2.11 is fully addressed we are going to target 2.10 to minimize confusion.
+   */
+  val scala       = "2.10.4" 
   val geotools    = "11.0"
   val akka        = "2.3.9"
   val spray       = "1.3.2"

--- a/spark/src/main/scala/geotrellis/spark/ingest/AccumuloIngestCommand.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/AccumuloIngestCommand.scala
@@ -33,17 +33,10 @@ object AccumuloIngestCommand extends ArgMain[AccumuloIngestArgs] with Logging {
 
     val accumulo = AccumuloInstance(args.instance, args.zookeeper, args.user, new PasswordToken(args.password))
     val source = sparkContext.hadoopGeoTiffRDD(args.inPath).repartition(args.partitions)
-
     val layoutScheme = ZoomedLayoutScheme(256)
-    val (level, rdd) =  Ingest[ProjectedExtent, SpatialKey](source, args.destCrs, layoutScheme)
 
-    val save = { (rdd: RasterRDD[SpatialKey], level: LayoutLevel) =>
+    Ingest[ProjectedExtent, SpatialKey](source, args.destCrs, layoutScheme, args.pyramid){ (rdd, level) => 
       accumulo.catalog.save(LayerId(args.layerName, level.zoom), args.table, rdd, args.clobber)
-    }
-    if (args.pyramid) {
-      Pyramid.saveLevels(rdd, level, layoutScheme)(save)
-    } else{
-      save(rdd, level)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/ingest/AccumuloPyramidCommand.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/AccumuloPyramidCommand.scala
@@ -33,7 +33,5 @@ object AccumuloPyramidCommand extends ArgMain[AccumuloPyramidArgs] with Logging 
     val save = { (rdd: RasterRDD[SpatialKey], level: LayoutLevel) =>
       accumulo.catalog.save(LayerId(args.layerName, level.zoom), args.table, rdd, true)
     }
-
-    Pyramid.saveLevels(rdd, level, layoutScheme)(save)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/ingest/HadoopIngestCommand.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/HadoopIngestCommand.scala
@@ -27,18 +27,9 @@ object HadoopIngestCommand extends ArgMain[HadoopIngestArgs] with Logging {
     val catalog: HadoopCatalog = HadoopCatalog(sparkContext, args.catalogPath)
     val source = sparkContext.hadoopGeoTiffRDD(args.inPath)
     val layoutScheme = ZoomedLayoutScheme()
-    val (level, rdd) =  Ingest[ProjectedExtent, SpatialKey](source, args.destCrs, layoutScheme)
 
-    val save = { (rdd: RasterRDD[SpatialKey], level: LayoutLevel) =>
+    Ingest[ProjectedExtent, SpatialKey](source, args.destCrs, layoutScheme, args.pyramid){ (rdd, level) => 
       catalog.save(LayerId(args.layerName, level.zoom), rdd, args.clobber)
-    }
-
-    if (args.pyramid) {
-      Pyramid.saveLevels(rdd, level, layoutScheme)(save)
-    } else{
-      save(rdd, level)
     }
   }
 }
-
-

--- a/spark/src/main/scala/geotrellis/spark/ingest/NetCDFIngest.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/NetCDFIngest.scala
@@ -38,16 +38,9 @@ object NetCDFIngestCommand extends ArgMain[AccumuloIngestArgs] with Logging {
     val accumulo = AccumuloInstance(args.instance, args.zookeeper, args.user, new PasswordToken(args.password))
     val source = sparkContext.netCdfRDD(args.inPath)
     val layoutScheme = ZoomedLayoutScheme()
-    val (level, rdd) =  Ingest[NetCdfBand, SpaceTimeKey](source, args.destCrs, layoutScheme)
-
-    val save = { (rdd: RasterRDD[SpaceTimeKey], level: LayoutLevel) =>
+        
+    Ingest[NetCdfBand, SpaceTimeKey](source, args.destCrs, layoutScheme, args.pyramid) { (rdd, level) =>  
       accumulo.catalog.save(LayerId(args.layerName, level.zoom), args.table, rdd, args.clobber)
-    }
-
-    if (args.pyramid) {
-      Pyramid.saveLevels(rdd, level, layoutScheme)(save)
-    } else{
-      save(rdd, level)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/ingest/NetCDFIngestHDFS.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/NetCDFIngestHDFS.scala
@@ -34,16 +34,9 @@ object NetCDFIngestHDFSCommand extends ArgMain[HadoopIngestArgs] with Logging {
     val catalog: HadoopCatalog = HadoopCatalog(sparkContext, args.catalogPath)
     val source = sparkContext.netCdfRDD(args.inPath)
     val layoutScheme = ZoomedLayoutScheme()
-    val (level, rdd) =  Ingest[NetCdfBand, SpaceTimeKey](source, args.destCrs, layoutScheme, true)
 
-    val save = { (rdd: RasterRDD[SpaceTimeKey], level: LayoutLevel) =>
+    Ingest[NetCdfBand, SpaceTimeKey](source, args.destCrs, layoutScheme, args.pyramid, true){ (rdd, level) => 
       catalog.save(LayerId(args.layerName, level.zoom), rdd, true)
-    }
-
-    if (args.pyramid) {
-      Pyramid.saveLevels(rdd, level, layoutScheme)(save)
-    } else{
-      save(rdd, level)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/ingest/Pyramid.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/Pyramid.scala
@@ -16,22 +16,6 @@ import scala.reflect.ClassTag
 
 object Pyramid extends Logging {
   /**
-   * Save layers up, until level 1 is reached
-   * @param rdd           RDD containing original level to be pyramided
-   * @param layoutScheme  LayoutScheme used to create the RDD
-   * @param save          Function(rdd, layoutLevel) that will be called for zoom each level, including original
-   */
-  def saveLevels[K: SpatialComponent: ClassTag](rdd: RasterRDD[K], level: LayoutLevel, layoutScheme: LayoutScheme)
-                                               (save: (RasterRDD[K], LayoutLevel) => Unit): Unit = {
-    logInfo(s"Saving raster at $level")
-    save(rdd, level)
-    if (level.zoom > 1) {
-      val (nextRdd, nextLevel) = Pyramid.up(rdd, level, layoutScheme)
-      saveLevels(nextRdd, nextLevel, layoutScheme)(save)
-    }
-  }
-
-  /**
    * Functions that require RasterRDD to have a TMS grid dimension to their key
    */
   def up[K: SpatialComponent: ClassTag](rdd: RasterRDD[K], level: LayoutLevel, layoutScheme: LayoutScheme): (RasterRDD[K], LayoutLevel) = {

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloCatalog.scala
@@ -38,6 +38,7 @@ class AccumuloCatalog(sc: SparkContext, instance: AccumuloInstance,
 
   def save[K: SupportedKey : ClassTag](id: LayerId, table: String, rdd: RasterRDD[K], clobber: Boolean): Unit = {
     val driver = implicitly[AccumuloDriver[K]]
+    rdd.persist()
     driver.save(sc, instance)(id, rdd, table, clobber)
 
     val metaData = LayerMetaData(
@@ -46,6 +47,7 @@ class AccumuloCatalog(sc: SparkContext, instance: AccumuloInstance,
       histogram = Some(rdd.histogram)
     )
     metaDataCatalog.save(id, table: Params, metaData, clobber)
+    rdd.unpersist(blocking = false)
   }
 }
 

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloCatalogSpec.scala
@@ -3,6 +3,7 @@ package geotrellis.spark.io.accumulo
 import java.io.IOException
 
 import geotrellis.raster._
+import geotrellis.vector._
 import geotrellis.spark
 
 import geotrellis.spark._
@@ -46,45 +47,45 @@ class AccumuloCatalogSpec extends FunSpec
       val layoutScheme = ZoomedLayoutScheme(512)
       tableOps.create("tiles")
 
-      val (level, onesRdd) = Ingest(source, LatLng, layoutScheme)
-
-      val layerId = LayerId("ones", level.zoom)
-
-      it("should succeed writing to a table") {
-        catalog.save(layerId, "tiles", onesRdd)
-      }
-
-      it("should load out saved tiles") {
-        val rdd = catalog.load[SpatialKey](layerId)
-        rdd.count should be > 0l
-      }
-
-      it("should load out a single tile") {
-        val key = catalog.load[SpatialKey](layerId).map(_._1).collect.head
-        val tile = catalog.loadTile(layerId, key)
-        (tile.cols, tile.rows) should be ((512, 512))
-      }
-
-      it("should load out saved tiles, but only for the right zoom") {
-        intercept[LayerNotFoundError] {
-          catalog.load[SpatialKey](LayerId("ones", level.zoom + 1)).count()
-        }
-      }
-
-      it("fetch a TileExtent from catalog") {
-        val tileBounds = GridBounds(915,305,916,306)
-        val filters = new FilterSet[SpatialKey] withFilter SpaceFilter(tileBounds)
-        val rdd1 = catalog.load[SpatialKey](LayerId("ones", level.zoom), filters)
-        val rdd2 = catalog.load[SpatialKey](LayerId("ones", 10), filters)
-
-        val out = rdd1.combinePairs(rdd2) { case (tms1, tms2) =>
-          require(tms1.id == tms2.id)
-          val res = tms1.tile.localAdd(tms2.tile)
-          (tms1.id, res)
+      Ingest[ProjectedExtent, SpatialKey](source, LatLng, layoutScheme){ (onesRdd, level) => 
+        val layerId = LayerId("ones", level.zoom)
+        
+        it("should succeed writing to a table") {
+          catalog.save(layerId, "tiles", onesRdd)
         }
 
-        val tile = out.first.tile
-        tile.get(497,511) should be (2)
+        it("should load out saved tiles") {
+          val rdd = catalog.load[SpatialKey](layerId)
+          rdd.count should be > 0l
+        }
+
+        it("should load out a single tile") {
+          val key = catalog.load[SpatialKey](layerId).map(_._1).collect.head
+          val tile = catalog.loadTile(layerId, key)
+          (tile.cols, tile.rows) should be ((512, 512))
+        }
+
+        it("should load out saved tiles, but only for the right zoom") {
+          intercept[LayerNotFoundError] {
+            catalog.load[SpatialKey](LayerId("ones", level.zoom + 1)).count()
+          }
+        }
+
+        it("fetch a TileExtent from catalog") {
+          val tileBounds = GridBounds(915,305,916,306)
+          val filters = new FilterSet[SpatialKey] withFilter SpaceFilter(tileBounds)
+          val rdd1 = catalog.load[SpatialKey](LayerId("ones", level.zoom), filters)
+          val rdd2 = catalog.load[SpatialKey](LayerId("ones", 10), filters)
+
+          val out = rdd1.combinePairs(rdd2) { case (tms1, tms2) =>
+            require(tms1.id == tms2.id)
+            val res = tms1.tile.localAdd(tms2.tile)
+            (tms1.id, res)
+          }
+
+          val tile = out.first.tile
+          tile.get(497,511) should be (2)
+        }      
       }
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
@@ -28,12 +28,11 @@ class GeoTiffS3InputFormatSpec extends FunSpec with OnlyIfCanRunSpark with Match
         sourceCount should not be (0)
         info(s"Source RDD count: ${sourceCount}")
         
-        val (level, rdd) =  Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme())
-        val rddCount = rdd.count
-        rddCount should not be (0)
-        info(s"Tiled RDD count: ${rddCount}")
-        
-        source.unpersist()
+        Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme()){ (rdd, level) => 
+          val rddCount = rdd.count
+          rddCount should not be (0)
+          info(s"Tiled RDD count: ${rddCount}")        
+        }        
       }
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
@@ -29,10 +29,11 @@ class TemporalGeoTiffS3InputFormatSpec extends FunSpec with Matchers with OnlyIf
         sourceCount should not be (0)
         info(s"Source RDD count: ${sourceCount}")
 
-        val (level, rdd) =  Ingest[SpaceTimeInputKey, SpaceTimeKey](source, LatLng, layoutScheme)
-        val rddCount = rdd.count
-        rddCount should not be (0)
-        info(s"Tiled RDD count: ${rddCount}")
+        Ingest[SpaceTimeInputKey, SpaceTimeKey](source, LatLng, layoutScheme){ (rdd, level) => 
+          val rddCount = rdd.count
+          rddCount should not be (0)
+          info(s"Tiled RDD count: ${rddCount}")
+        }
       }
     }
   }


### PR DESCRIPTION
This PR addresses the issue of forking collects on RDD. This happens during Ingest, when each RDD is required for saving/sink and for generating the next pyramid level. Also this is an issue during Catalog save, where the catalog needs to collect the raster histogram before saving.

In case of pyramid at most two RDDs are kept in memory at a time, the source and destination for each level, creating a rolling persistence effect.