### PR TITLE
CassandraIngestCommand + tweaks for CassandraInstance

### DIFF
--- a/spark/src/main/resources/reference.conf
+++ b/spark/src/main/resources/reference.conf
@@ -1,1 +1,2 @@
 geotrellis.accumulo.catalog = "metadata"
+geotrellis.cassandra.catalog = "metadata"

--- a/spark/src/main/scala/geotrellis/spark/cmd/args/CassandraArgs.scala
+++ b/spark/src/main/scala/geotrellis/spark/cmd/args/CassandraArgs.scala
@@ -1,0 +1,9 @@
+package geotrellis.spark.cmd.args
+
+import com.quantifind.sumac.FieldArgs
+import com.quantifind.sumac.validation.Required
+
+trait CassandraArgs extends FieldArgs {
+  @Required var host: String = _
+  @Required var keyspace: String = _
+}

--- a/spark/src/main/scala/geotrellis/spark/ingest/CassandraIngestCommand.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/CassandraIngestCommand.scala
@@ -25,7 +25,7 @@ class CassandraIngestArgs extends IngestArgs with CassandraArgs {
   @Required var table: String = _
 }
 
-object CassandraIngestCommmand extends ArgMain[CassandraIngestArgs] with Logging {
+object CassandraIngestCommand extends ArgMain[CassandraIngestArgs] with Logging {
   def main(args: CassandraIngestArgs): Unit = {
     System.setProperty("com.sun.media.jai.disableMediaLib", "true")
 

--- a/spark/src/main/scala/geotrellis/spark/ingest/CassandraIngestCommand.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/CassandraIngestCommand.scala
@@ -1,0 +1,56 @@
+package geotrellis.spark.ingest
+
+import geotrellis.spark._
+import geotrellis.spark.cmd.args.CassandraArgs
+import geotrellis.spark.io.cassandra._
+
+import geotrellis.spark.io.hadoop._
+import geotrellis.spark.tiling._
+import geotrellis.spark.utils.SparkUtils
+import geotrellis.vector._
+import geotrellis.proj4._
+
+import org.apache.hadoop.fs._
+
+import org.apache.spark._
+
+import com.quantifind.sumac.ArgMain
+import com.quantifind.sumac.validation.Required
+
+import com.datastax.spark.connector.cql.CassandraConnector
+
+import scala.reflect.ClassTag
+
+class CassandraIngestArgs extends IngestArgs with CassandraArgs {
+  @Required var table: String = _
+}
+
+object CassandraIngestCommmand extends ArgMain[CassandraIngestArgs] with Logging {
+  def main(args: CassandraIngestArgs): Unit = {
+    System.setProperty("com.sun.media.jai.disableMediaLib", "true")
+
+    implicit val sparkContext = SparkUtils.createSparkContext("Ingest")
+
+    val sparkConf = sparkContext.getConf
+    val hadoopConf = sparkContext.hadoopConfiguration
+    sparkConf.set("spark.cassandra.connection.host", args.host)
+    hadoopConf.set("io.map.index.interval", "1")
+
+    val connector = CassandraConnector(sparkConf)
+    val cassandra = CassandraInstance(connector, args.keyspace)
+
+    val source = sparkContext.hadoopGeoTiffRDD(args.inPath).repartition(args.partitions)
+
+    val layoutScheme = ZoomedLayoutScheme(256)
+    val (level, rdd) =  Ingest[ProjectedExtent, SpatialKey](source, args.destCrs, layoutScheme)
+
+    val save = { (rdd: RasterRDD[SpatialKey], level: LayoutLevel) =>
+      cassandra.catalog.save(LayerId(args.layerName, level.zoom), args.table, rdd, args.clobber)
+    }
+    if (args.pyramid) {
+      Pyramid.saveLevels(rdd, level, layoutScheme)(save)
+    } else{
+      save(rdd, level)
+    }
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/ingest/CassandraIngestCommand.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/CassandraIngestCommand.scala
@@ -34,7 +34,6 @@ object CassandraIngestCommand extends ArgMain[CassandraIngestArgs] with Logging 
     val sparkConf = sparkContext.getConf
     val hadoopConf = sparkContext.hadoopConfiguration
     sparkConf.set("spark.cassandra.connection.host", args.host)
-    hadoopConf.set("io.map.index.interval", "1")
 
     val connector = CassandraConnector(sparkConf)
     val cassandra = CassandraInstance(connector, args.keyspace)

--- a/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraInstance.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraInstance.scala
@@ -5,13 +5,18 @@ import geotrellis.spark.io._
 import com.datastax.spark.connector.cql._
 import org.apache.spark.SparkContext
 
+import com.typesafe.config.{ConfigFactory,Config}
+
 case class CassandraInstance(
   connector: CassandraConnector, 
   keyspace: String
 ) {
   
   val session = connector.openSession()
-  val catalogTable = "metadata"  // TODO: Move into config file
+
+  val catalogTable =
+    ConfigFactory.load().getString("geotrellis.cassandra.catalog")
+
   val metaDataCatalog = new CassandraMetaDataCatalog(session, keyspace, catalogTable)
   
   def catalog(config: DefaultParams[String] = CassandraCatalog.BaseParamsConfig)(implicit sc: SparkContext) =

--- a/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraInstance.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraInstance.scala
@@ -7,11 +7,11 @@ import org.apache.spark.SparkContext
 
 case class CassandraInstance(
   connector: CassandraConnector, 
-  keyspace: String, 
-  catalogTable: String
+  keyspace: String
 ) {
   
   val session = connector.openSession()
+  val catalogTable = "metadata"  // TODO: Move into config file
   val metaDataCatalog = new CassandraMetaDataCatalog(session, keyspace, catalogTable)
   
   def catalog(config: DefaultParams[String] = CassandraCatalog.BaseParamsConfig)(implicit sc: SparkContext) =

--- a/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cassandra/CassandraMetaDataCatalog.scala
@@ -35,6 +35,10 @@ class CassandraMetaDataCatalog(session: Session, val keyspace: String, val catal
 
   var catalog: Map[(LayerId, TableName), LayerMetaData] = fetchAll
 
+  def zoomLevelsFor(layerName: String): Seq[Int] = {
+    catalog.keys.filter(_._1.name == layerName).map(_._1.zoom).toSeq
+  }
+
   type TableName = String
 
   def load(layerId: LayerId): (LayerMetaData, TableName) = {

--- a/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cassandra/CassandraCatalogSpec.scala
@@ -37,7 +37,7 @@ class CassandraCatalogSpec extends FunSpec
       useCassandraConfig("cassandra-default.yaml.template")
       val connector = EmbeddedCassandraConnector(Set(cassandraHost))
 
-      val instance = new CassandraInstance(connector, "test", "catalogs")
+      val instance = new CassandraInstance(connector, "test")
       val metaDataCatalog = instance.metaDataCatalog
       val catalog = instance.catalog(sc)
 


### PR DESCRIPTION
Provides CassandraIngestCommand and moves the metadata tablename into a configuration file, similar to AccumuloInstance. Also implements zoomLevelsFor, which was needed for the gt-admin server.

Tested with climate data using the `ingest-cassandra` and `run-cassandra-server` scripts found [here](https://github.com/kyeah/gt-admin). 