### PR TITLE
Fixes to S3 catalog.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,7 +67,7 @@ object Dependencies {
 
   val nscalaTime    = "com.github.nscala-time" %% "nscala-time" % "1.6.0"
 
-  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.9.33"
+  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.9.34"
 
   val scalazStream  = "org.scalaz.stream" %% "scalaz-stream" % "0.7a"
 }

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3Client.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3Client.scala
@@ -78,7 +78,7 @@ class AmazonS3Client(credentials: AWSCredentials, config: ClientConfiguration) e
   def this(provider: AWSCredentialsProvider, config: ClientConfiguration) =
     this(provider.getCredentials, config)
 
-  val s3client = new com.amazonaws.services.s3.AmazonS3Client(credentials)
+  val s3client = new com.amazonaws.services.s3.AmazonS3Client(credentials, config)
 
   def listObjects(listObjectsRequest: ListObjectsRequest): ObjectListing = {
     s3client.listObjects(listObjectsRequest)

--- a/spark/src/main/scala/geotrellis/spark/io/s3/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/package.scala
@@ -10,4 +10,11 @@ package object s3 {
   implicit lazy val s3SpaceTimeRasterRDDReader = spacetime.SpaceTimeRasterRDDReader
   implicit lazy val s3SpaceTimeRasterRDDWriter = spacetime.SpaceTimeRasterRDDWriter
   implicit lazy val s3SpaceTimeRasterTileReader = spacetime.SpaceTimeTileReader
+
+  private[s3]
+  def maxIndexWidth(maxIndex: Long): Int = {
+    def digits(x: Long): Int = if (x < 10) 1 else 1 + digits(x/10)
+    digits(maxIndex)
+  }
+
 }

--- a/spark/src/main/scala/geotrellis/spark/io/s3/spacetime/SpaceTimeRasterRDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/spacetime/SpaceTimeRasterRDDReader.scala
@@ -15,8 +15,7 @@ import scala.collection.mutable
 object SpaceTimeRasterRDDReader extends RasterRDDReader[SpaceTimeKey] with LazyLogging {
   val tileIdRx: Regex = """.+\/(\d+)-\d{4}.+$""".r    
 
-  val indexToPath = (i: Long) => 
-    f"${i}%019d" // This does not generate time, but it's good enough to place an S3 Marker
+  val indexToPath = encodeIndex
       
   val pathToIndex = (s: String) => {
     val tileIdRx(tileId) = s

--- a/spark/src/main/scala/geotrellis/spark/io/s3/spacetime/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/spacetime/package.scala
@@ -9,8 +9,13 @@ package object spacetime {
 
   private[spacetime]
   val encodeKey = (key: SpaceTimeKey, ki: KeyIndex[SpaceTimeKey], max: Int) => {
-    val index: String = ki.toIndex(key).toString.reverse.padTo(max, '0').reverse
+    val index = encodeIndex(ki.toIndex(key), max)
     val isoTime: String = fmt.print(key.time)
     f"${index}-${isoTime}"
+  }
+
+  private[spacetime]
+  val encodeIndex = (index: Long, max: Int) => {
+    index.toString.reverse.padTo(max, '0').reverse
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/s3/spatial/SpatialRasterRDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/spatial/SpatialRasterRDDReader.scala
@@ -12,7 +12,7 @@ import scala.util.matching.Regex
 object SpatialRasterRDDReader extends RasterRDDReader[SpatialKey] with LazyLogging {
   val tileIdRx: Regex = """.+\/(\d+)""".r
 
-  val indexToPath = (i: Long) => f"${i}%019d"
+  val indexToPath = encodeIndex
       
   val pathToIndex = (s: String) => {
     val tileIdRx(tileId) = s

--- a/spark/src/main/scala/geotrellis/spark/io/s3/spatial/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/spatial/package.scala
@@ -10,4 +10,9 @@ package object spatial {
   val encodeKey = (key: SpatialKey, ki: KeyIndex[SpatialKey], max: Int) => {
     ki.toIndex(key).toString.reverse.padTo(max, '0').reverse
   }
+
+  private[spatial]
+  val encodeIndex = (index: Long, max: Int) => {
+    index.toString.reverse.padTo(max, '0').reverse
+  }
 }

--- a/spark/src/main/scala/geotrellis/spark/utils/TaskUtils.scala
+++ b/spark/src/main/scala/geotrellis/spark/utils/TaskUtils.scala
@@ -19,10 +19,10 @@ object TaskUtils extends App {
     def retryEBO(p: (Throwable => Boolean) ): Task[A] = {
       def help(count: Int): Future[Throwable \/ A] = {        
         val base: Duration = 52.milliseconds
-        val timeout = base * Random.nextInt(math.pow(2,count).toInt) // .extInt is [), implying -1        
+        val timeout = base * Random.nextInt(math.pow(2,count).toInt) // .extInt is [), implying -1
         task.get flatMap {
           case -\/(e) if p(e) =>
-            help(count +1) after timeout
+            help(count + 1) after timeout
           case x => Future.now(x)
         }
       }


### PR DESCRIPTION
S3 Catalog had some issues:
 - reader was not truncating/padding indexes like writer was
 - some indexes were being skipped over by readKeys logic
 - configuration was not being passed to the AmazonS3Client.