### PR TITLE
ZCurve index build by pattern support

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/index/ZCurveKeyIndexMethod.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/ZCurveKeyIndexMethod.scala
@@ -16,9 +16,15 @@ object ZCurveKeyIndexMethod extends ZCurveKeyIndexMethod {
 
   def byYear = 
     new KeyIndexMethod[SpaceTimeKey] {
-      def createIndex(keyBounds: KeyBounds[SpaceTimeKey]) = ZSpaceTimeKeyIndex.byYear
+      def createIndex(keyBounds: KeyBounds[SpaceTimeKey]) = ZSpaceTimeKeyIndex.byYear()
     }
 
+  def byPattern(pattern: String) =
+    new KeyIndexMethod[SpaceTimeKey] {
+      def createIndex(keyBounds: KeyBounds[SpaceTimeKey]) = ZSpaceTimeKeyIndex.byPattern(pattern)
+    }
+
+  /** Note: the function timeToGrid have to be in a project scope. */
   def by(timeToGrid: DateTime => Int) = 
     new KeyIndexMethod[SpaceTimeKey] {
       def createIndex(keyBounds: KeyBounds[SpaceTimeKey]) = ZSpaceTimeKeyIndex(timeToGrid)

--- a/spark/src/main/scala/geotrellis/spark/io/index/zcurve/ZSpaceTimeKeyIndex.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/zcurve/ZSpaceTimeKeyIndex.scala
@@ -12,6 +12,11 @@ object ZSpaceTimeKeyIndex {
 
   def byYear(): ZSpaceTimeKeyIndex = 
     new ZSpaceTimeKeyIndex({ dt => dt.getYear })
+
+  def byPattern(pattern: String): ZSpaceTimeKeyIndex =
+    new ZSpaceTimeKeyIndex({ dt =>
+      DateTimeFormat.forPattern(pattern).print(dt).toInt
+    })
 }
 
 class ZSpaceTimeKeyIndex(timeToGrid: DateTime => Int) extends KeyIndex[SpaceTimeKey] {

--- a/spark/src/test/scala/geotrellis/spark/io/index/zcurve/ZSpaceTimeKeyIndexSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/index/zcurve/ZSpaceTimeKeyIndexSpec.scala
@@ -8,7 +8,6 @@ import scala.collection.immutable.TreeSet
 class ZSpaceTimeKeySpec extends FunSpec with Matchers{
   val y2k = new DateTime(2000, 1, 1, 0, 0)
   val upperBound = 8
-  val ymPattern = "YM"
 
   describe("ZSpaceTimeKey test"){
 
@@ -94,7 +93,8 @@ class ZSpaceTimeKeySpec extends FunSpec with Matchers{
     }
 
     it("generates indexes by string pattern") {
-      val zst = ZSpaceTimeKeyIndex.byPattern(ymPattern)
+      val pattern = "YM" //by months
+      val zst = ZSpaceTimeKeyIndex.byPattern(pattern)
 
       val keys =
         for(col <- 0 until upperBound;

--- a/spark/src/test/scala/geotrellis/spark/io/index/zcurve/ZSpaceTimeKeyIndexSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/index/zcurve/ZSpaceTimeKeyIndexSpec.scala
@@ -8,6 +8,7 @@ import scala.collection.immutable.TreeSet
 class ZSpaceTimeKeySpec extends FunSpec with Matchers{
   val y2k = new DateTime(2000, 1, 1, 0, 0)
   val upperBound = 8
+  val ymPattern = "YM"
 
   describe("ZSpaceTimeKey test"){
 
@@ -28,7 +29,7 @@ class ZSpaceTimeKeySpec extends FunSpec with Matchers{
 
     it("generates indexes you can check by hand 2x2x2"){
      val zst = ZSpaceTimeKeyIndex({dt => dt.getMillis.toInt})
-     var idx = List[SpaceTimeKey](
+     val idx = List[SpaceTimeKey](
                                   SpaceTimeKey(0,0, y2k),
                                   SpaceTimeKey(1,0, y2k),
                                   SpaceTimeKey(0,1, y2k),
@@ -90,6 +91,21 @@ class ZSpaceTimeKeySpec extends FunSpec with Matchers{
       idx = zst.indexRanges((SpaceTimeKey(0,0,y2k), SpaceTimeKey(1,1,y2k)))
       idx.length should be (1)
       (idx(0)._2 - idx(0)._1) should be (3) 
+    }
+
+    it("generates indexes by string pattern") {
+      val zst = ZSpaceTimeKeyIndex.byPattern(ymPattern)
+
+      val keys =
+        for(col <- 0 until upperBound;
+            row <- 0 until upperBound;
+            t <- 0 until upperBound) yield {
+          zst.toIndex(SpaceTimeKey(row,col,y2k.plusMonths(t)))
+        }
+
+        keys.distinct.size should be (upperBound * upperBound * upperBound)
+        keys.min should be (zst.toIndex(SpaceTimeKey(0,0,y2k)))
+        keys.max should be (zst.toIndex(SpaceTimeKey(upperBound-1, upperBound-1, y2k.plusMonths(upperBound-1))))
     }
   }
 }


### PR DESCRIPTION
A function `timeToGrid: DateTime => Int` have to be in a project scope, otherwise there would be `Unable to find class` error on workers, trying to read tiles stored in a custom way, but without having the definition of the exact ingest job in the result assembly.

P.S. tried to save code style, but it is possible to reduce code by using wildcards.