### PR TITLE
Added a toGeometry method to GeometryResult

### DIFF
--- a/vector-test/src/test/scala/spec/geotrellis/vector/GeometryResultSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/GeometryResultSpec.scala
@@ -1,0 +1,23 @@
+package geotrellis.vector
+
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+
+import geotrellis.vector.affine._
+
+class GeometryResultSpec extends FunSpec with Matchers {
+  describe("GeoetryResult") {
+    it("should return Some(Geometry) for intersection") {
+      val p = Polygon(Line(List[(Double,Double)]((0,0),(1,0),(1,1),(0,1),(0,0))))
+      val p2 = p.translate(0.5, 0.5)
+
+      (p & p2).toGeometry.isDefined should be (true)
+    }
+
+    it("should return None for empty intersection") {
+      val p = Polygon(Line(List[(Double,Double)]((0,0),(1,0),(1,1),(0,1),(0,0))))
+      val p2 = p.translate(5.0, 5.0)
+      (p & p2).toGeometry.isDefined should be (false)
+    }
+  }
+}

--- a/vector/src/main/scala/geotrellis/vector/Results.scala
+++ b/vector/src/main/scala/geotrellis/vector/Results.scala
@@ -18,8 +18,12 @@ package geotrellis.vector
 
 import com.vividsolutions.jts.{geom => jts}
 
-abstract sealed trait GeometryResult
+private[vector] trait GeometryResultMethods { def toGeometry(): Option[Geometry] }
+abstract sealed trait GeometryResult extends GeometryResultMethods
 object GeometryResult {
+  implicit def resultToGeometry(result: GeometryResult): Option[Geometry] =
+    result.toGeometry
+
   implicit def jtsToResult(geom: jts.Geometry): GeometryResult =
     geom match {
       case null => NoResult
@@ -38,7 +42,7 @@ object GeometryResult {
 
 // -- Intersection
 
-abstract sealed trait PointGeometryIntersectionResult
+abstract sealed trait PointGeometryIntersectionResult extends GeometryResultMethods
 object PointGeometryIntersectionResult {
   implicit def jtsToResult(geom: jts.Geometry): PointGeometryIntersectionResult =
     geom match {
@@ -49,7 +53,7 @@ object PointGeometryIntersectionResult {
     }
 }
 
-abstract sealed trait OneDimensionAtLeastOneDimensionIntersectionResult
+abstract sealed trait OneDimensionAtLeastOneDimensionIntersectionResult extends GeometryResultMethods
 object OneDimensionAtLeastOneDimensionIntersectionResult {
   implicit def jtsToResult(geom: jts.Geometry): OneDimensionAtLeastOneDimensionIntersectionResult =
     geom match {
@@ -64,7 +68,7 @@ object OneDimensionAtLeastOneDimensionIntersectionResult {
     }
 }
 
-abstract sealed trait TwoDimensionsTwoDimensionsIntersectionResult
+abstract sealed trait TwoDimensionsTwoDimensionsIntersectionResult extends GeometryResultMethods
 object TwoDimensionsTwoDimensionsIntersectionResult {
   implicit def jtsToResult(geom: jts.Geometry): TwoDimensionsTwoDimensionsIntersectionResult =
     geom match {
@@ -81,7 +85,7 @@ object TwoDimensionsTwoDimensionsIntersectionResult {
     }
 }
 
-abstract sealed trait MultiLineMultiLineIntersectionResult
+abstract sealed trait MultiLineMultiLineIntersectionResult extends GeometryResultMethods
 object MultiLineMultiLineIntersectionResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiLineMultiLineIntersectionResult =
     geom match {
@@ -95,7 +99,7 @@ object MultiLineMultiLineIntersectionResult {
     }
 }
 
-abstract sealed trait MultiPointMultiPointIntersectionResult
+abstract sealed trait MultiPointMultiPointIntersectionResult extends GeometryResultMethods
 object MultiPointMultiPointIntersectionResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointMultiPointIntersectionResult =
     geom match {
@@ -107,7 +111,7 @@ object MultiPointMultiPointIntersectionResult {
     }
 }
 
-abstract sealed trait MultiPolygonMultiPolygonIntersectionResult
+abstract sealed trait MultiPolygonMultiPolygonIntersectionResult extends GeometryResultMethods
 object MultiPolygonMultiPolygonIntersectionResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPolygonMultiPolygonIntersectionResult =
     geom match {
@@ -123,7 +127,7 @@ object MultiPolygonMultiPolygonIntersectionResult {
     }
 }
 
-abstract sealed trait MultiPointAtLeastOneDimensionIntersectionResult
+abstract sealed trait MultiPointAtLeastOneDimensionIntersectionResult extends GeometryResultMethods
 object MultiPointAtLeastOneDimensionIntersectionResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointAtLeastOneDimensionIntersectionResult =
     geom match {
@@ -137,7 +141,7 @@ object MultiPointAtLeastOneDimensionIntersectionResult {
 
 // -- Union
 
-abstract sealed trait PointZeroDimensionsUnionResult
+abstract sealed trait PointZeroDimensionsUnionResult extends GeometryResultMethods
 object PointZeroDimensionsUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): PointZeroDimensionsUnionResult =
     geom match {
@@ -148,7 +152,7 @@ object PointZeroDimensionsUnionResult {
     }
 }
 
-abstract sealed trait MultiPointMultiPointUnionResult
+abstract sealed trait MultiPointMultiPointUnionResult extends GeometryResultMethods
 object MultiPointMultiPointUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointMultiPointUnionResult =
     geom match {
@@ -160,7 +164,7 @@ object MultiPointMultiPointUnionResult {
     }
 }
 
-abstract sealed trait ZeroDimensionsLineUnionResult
+abstract sealed trait ZeroDimensionsLineUnionResult extends GeometryResultMethods
 object ZeroDimensionsLineUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): ZeroDimensionsLineUnionResult =
     geom match {
@@ -171,7 +175,7 @@ object ZeroDimensionsLineUnionResult {
     }
 }
 
-abstract sealed trait PointMultiLineUnionResult
+abstract sealed trait PointMultiLineUnionResult extends GeometryResultMethods
 object PointMultiLineUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): PointMultiLineUnionResult =
     geom match {
@@ -184,7 +188,7 @@ object PointMultiLineUnionResult {
     }
 }
 
-abstract sealed trait MultiPointMultiLineUnionResult
+abstract sealed trait MultiPointMultiLineUnionResult extends GeometryResultMethods
 object MultiPointMultiLineUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointMultiLineUnionResult =
     geom match {
@@ -198,7 +202,7 @@ object MultiPointMultiLineUnionResult {
     }
 }
 
-abstract sealed trait LineOneDimensionUnionResult
+abstract sealed trait LineOneDimensionUnionResult extends GeometryResultMethods
 object LineOneDimensionUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): LineOneDimensionUnionResult =
     geom match {
@@ -209,7 +213,7 @@ object LineOneDimensionUnionResult {
     }
 }
 
-abstract sealed trait MultiLineMultiLineUnionResult
+abstract sealed trait MultiLineMultiLineUnionResult extends GeometryResultMethods
 object MultiLineMultiLineUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiLineMultiLineUnionResult =
     geom match {
@@ -221,7 +225,7 @@ object MultiLineMultiLineUnionResult {
     }
 }
 
-abstract sealed trait AtMostOneDimensionPolygonUnionResult
+abstract sealed trait AtMostOneDimensionPolygonUnionResult extends GeometryResultMethods
 object AtMostOneDimensionPolygonUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): AtMostOneDimensionPolygonUnionResult =
     geom match {
@@ -232,7 +236,7 @@ object AtMostOneDimensionPolygonUnionResult {
     }
 }
 
-abstract sealed trait TwoDimensionsTwoDimensionsUnionResult
+abstract sealed trait TwoDimensionsTwoDimensionsUnionResult extends GeometryResultMethods
 object TwoDimensionsTwoDimensionsUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): TwoDimensionsTwoDimensionsUnionResult =
     geom match {
@@ -243,7 +247,7 @@ object TwoDimensionsTwoDimensionsUnionResult {
     }
 }
 
-abstract sealed trait PointMultiPolygonUnionResult
+abstract sealed trait PointMultiPolygonUnionResult extends GeometryResultMethods
 object PointMultiPolygonUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): PointMultiPolygonUnionResult =
     geom match {
@@ -256,7 +260,7 @@ object PointMultiPolygonUnionResult {
     }
 }
 
-abstract sealed trait LineMultiPolygonUnionResult
+abstract sealed trait LineMultiPolygonUnionResult extends GeometryResultMethods
 object LineMultiPolygonUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): LineMultiPolygonUnionResult =
     geom match {
@@ -269,7 +273,7 @@ object LineMultiPolygonUnionResult {
     }
 }
 
-abstract sealed trait MultiPointMultiPolygonUnionResult
+abstract sealed trait MultiPointMultiPolygonUnionResult extends GeometryResultMethods
 object MultiPointMultiPolygonUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointMultiPolygonUnionResult =
     geom match {
@@ -283,7 +287,7 @@ object MultiPointMultiPolygonUnionResult {
     }
 }
 
-abstract sealed trait MultiLineMultiPolygonUnionResult
+abstract sealed trait MultiLineMultiPolygonUnionResult extends GeometryResultMethods
 object MultiLineMultiPolygonUnionResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiLineMultiPolygonUnionResult =
     geom match {
@@ -299,7 +303,7 @@ object MultiLineMultiPolygonUnionResult {
 
 // -- Difference
 
-abstract sealed trait PointGeometryDifferenceResult
+abstract sealed trait PointGeometryDifferenceResult extends GeometryResultMethods
 object PointGeometryDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): PointGeometryDifferenceResult =
     geom match {
@@ -310,7 +314,7 @@ object PointGeometryDifferenceResult {
     }
 }
 
-abstract sealed trait LineAtLeastOneDimensionDifferenceResult
+abstract sealed trait LineAtLeastOneDimensionDifferenceResult extends GeometryResultMethods
 object LineAtLeastOneDimensionDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): LineAtLeastOneDimensionDifferenceResult =
     geom match {
@@ -322,7 +326,7 @@ object LineAtLeastOneDimensionDifferenceResult {
     }
 }
 
-abstract sealed trait PolygonAtMostOneDimensionDifferenceResult
+abstract sealed trait PolygonAtMostOneDimensionDifferenceResult extends GeometryResultMethods
 object PolygonAtMostOneDimensionDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): PolygonAtMostOneDimensionDifferenceResult =
     geom match {
@@ -332,7 +336,7 @@ object PolygonAtMostOneDimensionDifferenceResult {
     }
 }
 
-abstract sealed trait TwoDimensionsTwoDimensionsDifferenceResult
+abstract sealed trait TwoDimensionsTwoDimensionsDifferenceResult extends GeometryResultMethods
 object TwoDimensionsTwoDimensionsDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): TwoDimensionsTwoDimensionsDifferenceResult =
     geom match {
@@ -344,7 +348,7 @@ object TwoDimensionsTwoDimensionsDifferenceResult {
     }
 }
 
-abstract sealed trait MultiPointGeometryDifferenceResult
+abstract sealed trait MultiPointGeometryDifferenceResult extends GeometryResultMethods
 object MultiPointGeometryDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointGeometryDifferenceResult =
     geom match {
@@ -356,7 +360,7 @@ object MultiPointGeometryDifferenceResult {
     }
 }
 
-abstract sealed trait MultiLineGeometryDifferenceResult
+abstract sealed trait MultiLineGeometryDifferenceResult extends GeometryResultMethods
 object MultiLineGeometryDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiLineGeometryDifferenceResult =
     geom match {
@@ -368,7 +372,7 @@ object MultiLineGeometryDifferenceResult {
     }
 }
 
-abstract sealed trait MultiPolygonXDifferenceResult
+abstract sealed trait MultiPolygonXDifferenceResult extends GeometryResultMethods
 object MultiPolygonXDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPolygonXDifferenceResult =
     geom match {
@@ -379,7 +383,7 @@ object MultiPolygonXDifferenceResult {
 }
 
 
-abstract sealed trait MultiLineMultiLineDifferenceResult
+abstract sealed trait MultiLineMultiLineDifferenceResult extends GeometryResultMethods
 object MultiLineMultiLineDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiLineMultiLineDifferenceResult =
     geom match {
@@ -393,7 +397,7 @@ object MultiLineMultiLineDifferenceResult {
     }
 }
 
-abstract sealed trait MultiPointMultiPointDifferenceResult
+abstract sealed trait MultiPointMultiPointDifferenceResult extends GeometryResultMethods
 object MultiPointMultiPointDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointMultiPointDifferenceResult =
     geom match {
@@ -405,7 +409,7 @@ object MultiPointMultiPointDifferenceResult {
     }
 }
 
-abstract sealed trait MultiPolygonMultiPolygonDifferenceResult
+abstract sealed trait MultiPolygonMultiPolygonDifferenceResult extends GeometryResultMethods
 object MultiPolygonMultiPolygonDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPolygonMultiPolygonDifferenceResult =
     geom match {
@@ -422,7 +426,7 @@ object MultiPolygonMultiPolygonDifferenceResult {
 }
 // -- Boundary
 
-abstract sealed trait OneDimensionBoundaryResult
+abstract sealed trait OneDimensionBoundaryResult extends GeometryResultMethods
 object OneDimensionBoundaryResult {
   implicit def jtsToResult(geom: jts.Geometry): OneDimensionBoundaryResult =
     geom match {
@@ -433,7 +437,7 @@ object OneDimensionBoundaryResult {
     }
 }
 
-abstract sealed trait PolygonBoundaryResult
+abstract sealed trait PolygonBoundaryResult extends GeometryResultMethods
 object PolygonBoundaryResult {
   implicit def jtsToResult(geom: jts.Geometry): PolygonBoundaryResult =
     geom match {
@@ -446,7 +450,7 @@ object PolygonBoundaryResult {
 
 // -- SymDifference
 
-abstract sealed trait PointPointSymDifferenceResult
+abstract sealed trait PointPointSymDifferenceResult extends GeometryResultMethods
 object PointPointSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): PointPointSymDifferenceResult =
     geom match {
@@ -458,7 +462,7 @@ object PointPointSymDifferenceResult {
     }
 }
 
-abstract sealed trait ZeroDimensionsMultiPointSymDifferenceResult
+abstract sealed trait ZeroDimensionsMultiPointSymDifferenceResult extends GeometryResultMethods
 object ZeroDimensionsMultiPointSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): ZeroDimensionsMultiPointSymDifferenceResult =
     geom match {
@@ -470,7 +474,7 @@ object ZeroDimensionsMultiPointSymDifferenceResult {
     }
 }
 
-abstract sealed trait ZeroDimensionsLineSymDifferenceResult
+abstract sealed trait ZeroDimensionsLineSymDifferenceResult extends GeometryResultMethods
 object ZeroDimensionsLineSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): ZeroDimensionsLineSymDifferenceResult =
     geom match {
@@ -481,7 +485,7 @@ object ZeroDimensionsLineSymDifferenceResult {
     }
 }
 
-abstract sealed trait PointMultiLineSymDifferenceResult
+abstract sealed trait PointMultiLineSymDifferenceResult extends GeometryResultMethods
 object PointMultiLineSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): PointMultiLineSymDifferenceResult =
     geom match {
@@ -494,7 +498,7 @@ object PointMultiLineSymDifferenceResult {
     }
 }
 
-abstract sealed trait MultiPointMultiLineSymDifferenceResult
+abstract sealed trait MultiPointMultiLineSymDifferenceResult extends GeometryResultMethods
 object MultiPointMultiLineSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointMultiLineSymDifferenceResult =
     geom match {
@@ -508,7 +512,7 @@ object MultiPointMultiLineSymDifferenceResult {
     }
 }
 
-abstract sealed trait PointMultiPolygonSymDifferenceResult
+abstract sealed trait PointMultiPolygonSymDifferenceResult extends GeometryResultMethods
 object PointMultiPolygonSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): PointMultiPolygonSymDifferenceResult =
     geom match {
@@ -521,7 +525,7 @@ object PointMultiPolygonSymDifferenceResult {
     }
 }
 
-abstract sealed trait MultiPointMultiPolygonSymDifferenceResult
+abstract sealed trait MultiPointMultiPolygonSymDifferenceResult extends GeometryResultMethods
 object MultiPointMultiPolygonSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointMultiPolygonSymDifferenceResult =
     geom match {
@@ -535,7 +539,7 @@ object MultiPointMultiPolygonSymDifferenceResult {
     }
 }
 
-abstract sealed trait OneDimensionOneDimensionSymDifferenceResult
+abstract sealed trait OneDimensionOneDimensionSymDifferenceResult extends GeometryResultMethods
 object OneDimensionOneDimensionSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): OneDimensionOneDimensionSymDifferenceResult =
     geom match {
@@ -547,7 +551,7 @@ object OneDimensionOneDimensionSymDifferenceResult {
     }
 }
 
-abstract sealed trait AtMostOneDimensionPolygonSymDifferenceResult
+abstract sealed trait AtMostOneDimensionPolygonSymDifferenceResult extends GeometryResultMethods
 object AtMostOneDimensionPolygonSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): AtMostOneDimensionPolygonSymDifferenceResult =
     geom match {
@@ -558,7 +562,7 @@ object AtMostOneDimensionPolygonSymDifferenceResult {
     }
 }
 
-abstract sealed trait LineMultiPolygonSymDifferenceResult
+abstract sealed trait LineMultiPolygonSymDifferenceResult extends GeometryResultMethods
 object LineMultiPolygonSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): LineMultiPolygonSymDifferenceResult =
     geom match {
@@ -571,7 +575,7 @@ object LineMultiPolygonSymDifferenceResult {
     }
 }
 
-abstract sealed trait MultiLineMultiPolygonSymDifferenceResult
+abstract sealed trait MultiLineMultiPolygonSymDifferenceResult extends GeometryResultMethods
 object MultiLineMultiPolygonSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiLineMultiPolygonSymDifferenceResult =
     geom match {
@@ -585,7 +589,7 @@ object MultiLineMultiPolygonSymDifferenceResult {
     }
 }
 
-abstract sealed trait TwoDimensionsTwoDimensionsSymDifferenceResult
+abstract sealed trait TwoDimensionsTwoDimensionsSymDifferenceResult extends GeometryResultMethods
 object TwoDimensionsTwoDimensionsSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): TwoDimensionsTwoDimensionsSymDifferenceResult =
     geom match {
@@ -597,7 +601,7 @@ object TwoDimensionsTwoDimensionsSymDifferenceResult {
     }
 }
 
-abstract sealed trait MultiLineMultiLineSymDifferenceResult
+abstract sealed trait MultiLineMultiLineSymDifferenceResult extends GeometryResultMethods
 object MultiLineMultiLineSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiLineMultiLineSymDifferenceResult =
     geom match {
@@ -611,7 +615,7 @@ object MultiLineMultiLineSymDifferenceResult {
     }
 }
 
-abstract sealed trait MultiPointMultiPointSymDifferenceResult
+abstract sealed trait MultiPointMultiPointSymDifferenceResult extends GeometryResultMethods
 object MultiPointMultiPointSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPointMultiPointSymDifferenceResult =
     geom match {
@@ -623,7 +627,7 @@ object MultiPointMultiPointSymDifferenceResult {
     }
 }
 
-abstract sealed trait MultiPolygonMultiPolygonSymDifferenceResult
+abstract sealed trait MultiPolygonMultiPolygonSymDifferenceResult extends GeometryResultMethods
 object MultiPolygonMultiPolygonSymDifferenceResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiPolygonMultiPolygonSymDifferenceResult =
     geom match {
@@ -641,7 +645,7 @@ object MultiPolygonMultiPolygonSymDifferenceResult {
 
 
 // -- Misc.
-abstract sealed trait PointOrNoResult
+abstract sealed trait PointOrNoResult extends GeometryResultMethods
 object PointOrNoResult {
   implicit def jtsToResult(geom: jts.Geometry): PointOrNoResult =
     geom match {
@@ -684,7 +688,9 @@ case object NoResult extends GeometryResult
     with MultiPolygonMultiPolygonSymDifferenceResult
     with MultiLineMultiLineDifferenceResult
     with MultiPointMultiPointDifferenceResult
-    with MultiPolygonMultiPolygonDifferenceResult
+    with MultiPolygonMultiPolygonDifferenceResult {
+  def toGeometry(): Option[Geometry] = None
+}
 
 case class PointResult(geom: Point) extends GeometryResult
     with PointGeometryIntersectionResult
@@ -710,7 +716,9 @@ case class PointResult(geom: Point) extends GeometryResult
     with MultiLineMultiLineDifferenceResult
     with MultiPointMultiPointDifferenceResult
     with MultiPolygonMultiPolygonDifferenceResult
-    with PointOrNoResult
+    with PointOrNoResult {
+  def toGeometry(): Option[Geometry] = Some(geom)
+}
 
 case class LineResult(geom: Line) extends GeometryResult
     with OneDimensionAtLeastOneDimensionIntersectionResult
@@ -734,7 +742,9 @@ case class LineResult(geom: Line) extends GeometryResult
     with MultiLineMultiLineSymDifferenceResult
     with MultiPolygonMultiPolygonSymDifferenceResult
     with MultiLineMultiLineDifferenceResult
-    with MultiPolygonMultiPolygonDifferenceResult
+    with MultiPolygonMultiPolygonDifferenceResult {
+  def toGeometry(): Option[Geometry] = Some(geom)
+}
 
 object LineResult {
   implicit def jtsToResult(geom: jts.Geometry): LineResult =
@@ -763,7 +773,9 @@ case class PolygonResult(geom: Polygon) extends GeometryResult
     with MultiLineMultiPolygonSymDifferenceResult
     with MultiPolygonMultiPolygonIntersectionResult
     with MultiPolygonMultiPolygonSymDifferenceResult
-    with MultiPolygonMultiPolygonDifferenceResult
+    with MultiPolygonMultiPolygonDifferenceResult {
+  def toGeometry(): Option[Geometry] = Some(geom)
+}
 
 case class MultiPointResult(geom: MultiPoint) extends GeometryResult
     with TwoDimensionsTwoDimensionsIntersectionResult
@@ -787,7 +799,9 @@ case class MultiPointResult(geom: MultiPoint) extends GeometryResult
     with MultiPolygonMultiPolygonSymDifferenceResult
     with MultiLineMultiLineDifferenceResult
     with MultiPointMultiPointDifferenceResult
-    with MultiPolygonMultiPolygonDifferenceResult
+    with MultiPolygonMultiPolygonDifferenceResult {
+  def toGeometry(): Option[Geometry] = Some(geom)
+}
 
 case class MultiLineResult(geom: MultiLine) extends GeometryResult
     with TwoDimensionsTwoDimensionsIntersectionResult
@@ -809,7 +823,9 @@ case class MultiLineResult(geom: MultiLine) extends GeometryResult
     with MultiLineMultiLineSymDifferenceResult
     with MultiPolygonMultiPolygonSymDifferenceResult
     with MultiLineMultiLineDifferenceResult
-    with MultiPolygonMultiPolygonDifferenceResult
+    with MultiPolygonMultiPolygonDifferenceResult {
+  def toGeometry(): Option[Geometry] = Some(geom)
+}
 
 object MultiLineResult {
   implicit def jtsToResult(geom: jts.Geometry): MultiLineResult =
@@ -836,7 +852,9 @@ case class MultiPolygonResult(geom: MultiPolygon) extends GeometryResult
     with MultiLineMultiPolygonSymDifferenceResult
     with MultiPolygonMultiPolygonIntersectionResult
     with MultiPolygonMultiPolygonSymDifferenceResult
-    with MultiPolygonMultiPolygonDifferenceResult
+    with MultiPolygonMultiPolygonDifferenceResult {
+  def toGeometry(): Option[Geometry] = Some(geom)
+}
 
 case class GeometryCollectionResult(geom: GeometryCollection) extends GeometryResult
     with TwoDimensionsTwoDimensionsIntersectionResult
@@ -856,4 +874,6 @@ case class GeometryCollectionResult(geom: GeometryCollection) extends GeometryRe
     with MultiPointMultiLineSymDifferenceResult
     with MultiPointMultiPolygonSymDifferenceResult
     with MultiLineMultiPolygonUnionResult
-    with MultiLineMultiPolygonSymDifferenceResult
+    with MultiLineMultiPolygonSymDifferenceResult {
+  def toGeometry(): Option[Geometry] = Some(geom)
+}


### PR DESCRIPTION
Simply adds a toGeometry method  to GeometryResult, so one could do something like:

```scala
(polygon & extent).toGeometry match {
  case Some(geom) => // deal with the geometry as a geotrellis.vector.Geometry
  case None => // same thing as NoResult
}
```