### PR TITLE
Catalog layer attribute caching

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/AttributeCaching.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/AttributeCaching.scala
@@ -1,0 +1,59 @@
+package geotrellis.spark.io
+
+import geotrellis.spark.{LayerId, KeyBounds}
+import geotrellis.spark.io.index.KeyIndex
+import scala.reflect._
+import scala.util.Try
+
+trait AttributeCaching[MetadataType] {
+
+  val attributeStore: AttributeStore
+
+  private val metadataCache = new collection.mutable.HashMap[LayerId, MetadataType]
+  private val keyBoundsCache     = new collection.mutable.HashMap[LayerId, KeyBounds[_]]
+  private val keyIndexCache      = new collection.mutable.HashMap[LayerId, KeyIndex[_]]
+
+  def getLayerMetadata(id: LayerId)(implicit ev: attributeStore.ReadableWritable[MetadataType]) = 
+    metadataCache
+      .getOrElseUpdate(
+        id,
+        attributeStore.read[MetadataType](id, "metadata"))    
+  
+  def getLayerKeyBounds[K: ClassTag](id: LayerId)(implicit ev: attributeStore.ReadableWritable[KeyBounds[K]]): KeyBounds[K] =    
+    keyBoundsCache
+      .getOrElseUpdate(
+        id, 
+        attributeStore.read[KeyBounds[K]](id, "keyBounds"))
+      .asInstanceOf[KeyBounds[K]]
+  
+  def getLayerKeyIndex[K: ClassTag](id: LayerId)(implicit ev: attributeStore.ReadableWritable[KeyIndex[K]]): KeyIndex[K] =
+    keyIndexCache
+      .getOrElseUpdate(
+        id, 
+        attributeStore.read[KeyIndex[K]](id, "keyIndex"))
+      .asInstanceOf[KeyIndex[K]]
+
+  def setLayerMetadata(id: LayerId, metadata: MetadataType)(implicit ev: attributeStore.ReadableWritable[MetadataType]) = {
+    attributeStore.write[MetadataType](id, "metadata", metadata)
+    metadataCache(id) = metadata
+  }
+  
+  def setLayerKeyBounds[K: ClassTag](id: LayerId, keyBounds: KeyBounds[K])(implicit ev: attributeStore.ReadableWritable[KeyBounds[K]]) = {
+    attributeStore.write[KeyBounds[K]](id, "keyBounds", keyBounds)
+    keyBoundsCache(id) = keyBounds
+  }
+  
+  def setLayerKeyIndex[K: ClassTag](id: LayerId, keyIndex: KeyIndex[K])(implicit ev: attributeStore.ReadableWritable[KeyIndex[K]])= {
+    attributeStore.write[KeyIndex[K]](id, "keyIndex", keyIndex)
+    keyIndexCache(id) = keyIndex
+  }
+
+  def layerExists(id: LayerId)(implicit ev: attributeStore.ReadableWritable[MetadataType]): Boolean = 
+    Try(getLayerMetadata(id)).isSuccess
+
+  def clearCache = {
+    metadataCache.clear()
+    keyBoundsCache.clear()
+    keyIndexCache.clear()
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3RasterCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3RasterCatalog.scala
@@ -40,13 +40,13 @@ class S3RasterCatalog(
   rootPath: String,
   val attributeStore: S3AttributeStore,    
   s3client: ()=>S3Client)
-(implicit sc: SparkContext) {
+(implicit sc: SparkContext) extends AttributeCaching[S3LayerMetaData] {
   import S3RasterCatalog._
 
   def read[K: RasterRDDReader: JsonFormat: ClassTag](layerId: LayerId, rasterQuery: RasterRDDQuery[K], numPartitions: Int = sc.defaultParallelism): RasterRDD[K] = {
-    val metadata  = attributeStore.read[S3LayerMetaData](layerId, "metadata")
-    val keyBounds = attributeStore.read[KeyBounds[K]](layerId, "keyBounds")
-    val index     = attributeStore.read[KeyIndex[K]](layerId, "keyIndex")
+    val metadata  = getLayerMetadata(layerId)
+    val keyBounds = getLayerKeyBounds(layerId)                
+    val index     = getLayerKeyIndex(layerId)
 
     val queryBounds = rasterQuery(metadata.rasterMetaData, keyBounds)
     implicitly[RasterRDDReader[K]].read(s3client, metadata, keyBounds, index, numPartitions)(layerId, queryBounds)
@@ -98,9 +98,9 @@ class S3RasterCatalog(
           keyIndexMethod.createIndex(indexKeyBounds)
         }
 
-        attributeStore.write(layerId, "keyIndex", index)
-        attributeStore.write(layerId, "keyBounds", keyBounds)
-        attributeStore.write(layerId, "metadata", md)
+        setLayerMetadata(layerId, md)
+        setLayerKeyBounds(layerId, keyBounds)
+        setLayerKeyIndex(layerId, index)
 
         val rddWriter = implicitly[RasterRDDWriter[K]]
         rddWriter.write(s3client, bucket, path, keyBounds, index, clobber)(layerId, rdd)
@@ -110,9 +110,9 @@ class S3RasterCatalog(
     }
 
   def tileReader[K: TileReader: JsonFormat: ClassTag](layerId: LayerId): K => Tile = {
-    val metaData  = attributeStore.read[S3LayerMetaData](layerId, "metadata")
-    val keyBounds = attributeStore.read[KeyBounds[K]](layerId, "keyBounds")
-    val index     = attributeStore.read[KeyIndex[K]](layerId, "keyIndex")
-    implicitly[TileReader[K]].read(s3client(), layerId, metaData, index, keyBounds)(_)    
+    val metadata  = getLayerMetadata(layerId)
+    val keyBounds = getLayerKeyBounds(layerId)                
+    val index     = getLayerKeyIndex(layerId)
+    implicitly[TileReader[K]].read(s3client(), layerId, metadata, index, keyBounds)(_)    
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopRasterCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopRasterCatalogSpec.scala
@@ -58,6 +58,11 @@ class HadoopRasterCatalogSpec extends FunSpec
           assert(fs.exists(new Path(catalogPath, "ones")))
         }
 
+        it("should know when layer exists"){
+          catalog.layerExists(LayerId("ones", level.zoom)) should be (true)
+          catalog.layerExists(LayerId("nope", 100)) should be (false)
+        }
+
         it("should succeed saving with single path Props"){
           catalog
             .writer[SpatialKey](RowMajorKeyIndexMethod, "sub1")
@@ -235,11 +240,11 @@ class HadoopRasterCatalogSpec extends FunSpec
         catalog
           .writer[SpaceTimeKey](ZCurveKeyIndexMethod.byYear)
           .write(LayerId("coordinates", 10), coordST)
-        rastersEqual(catalog.query[SpaceTimeKey](LayerId("coordinates", 10)).toRDD, coordST)
+        rastersEqual(catalog.query[SpaceTimeKey](LayerId("coordinates", 10)).toRDD, coordST)        
       }
 
       RasterRDDQueryTest.spaceTimeTest.foreach { test =>
-        it("ZCurveKeyIndexMethod.byYear: " + test.name){
+        it("ZCurveKeyIndexMethod.byYear: " + test.name){          
           val rdd = catalog.read[SpaceTimeKey](test.layerId, test.query)
           val found = rdd.map(_._1).collect
           info(s"missing: ${(test.expected diff found).toVector}")

--- a/spark/src/test/scala/geotrellis/spark/io/s3/S3RasterCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/S3RasterCatalogSpec.scala
@@ -23,6 +23,11 @@ class S3RasterCatalogSpec extends FunSpec
         catalog.writer[SpatialKey](ZCurveKeyIndexMethod).write(id, AllOnesTestFile)
       }
 
+      it("should know when layer exists"){
+        catalog.layerExists(id) should be (true)
+        catalog.layerExists(LayerId("nope", 100)) should be (false)
+      }
+
       it("should load from s3"){
         val rdd = catalog.query[SpatialKey](id).toRDD
         rdd.count should equal (42)


### PR DESCRIPTION
To read/write a catalog Metadata, KeyBounds and KeyIndex are required. This PR adds the `AttributeCaching` trait that keeps a simple in memory cache for these attributes. The catalogs take care to read/write attribute only through the methods on this trait, keeping it locally consistent.

There are no provision to keep the cache consistent across different instances of a catalog at the moment. As a final escape hatch `.clearCache` method is provided as part of the trait.