### PR TITLE
Unify catalog exceptions

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStore.scala
@@ -43,9 +43,9 @@ class AccumuloAttributeStore(connector: Connector, val attributeTable: String) e
     val values = fetch(Some(layerId), attributeName)
 
     if(values.size == 0) {
-      sys.error(s"Attribute $attributeName not found for layer $layerId")
+      throw new AttributeNotFoundError(attributeName, layerId)
     } else if(values.size > 1) {
-      sys.error(s"Multiple attributes found for $attributeName for layer $layerId")
+      throw new CatalogError(s"Multiple attributes found for $attributeName for layer $layerId")
     } else {
       values.head.toString.parseJson.convertTo[(LayerId, T)]._2
     }

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/RasterRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/RasterRDDWriter.scala
@@ -121,7 +121,7 @@ trait RasterRDDWriter[K] {
           fs.delete(outPath, true)
           fs.delete(failuresPath, true)
         } else {
-          sys.error(s"Accumulo bulk ingest for $layerId failed at $ingestPath")
+          throw new LayerWriteError(layerId, s"Accumulo bulk ingest failed at $ingestPath")
         }
       }
 

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/TileReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/TileReader.scala
@@ -1,6 +1,7 @@
 package geotrellis.spark.io.accumulo
 
 import geotrellis.spark._
+import geotrellis.spark.io._
 import geotrellis.spark.io.index._
 import geotrellis.raster._
 import geotrellis.spark.utils._
@@ -34,9 +35,9 @@ trait TileReader[K] {
     val values = collectTile(instance, layerId, index, tileTable, key)
     val value =
       if(values.size == 0) {
-        sys.error(s"Tile with key $key not found for layer $layerId")
+        throw new TileNotFoundError(key, layerId)        
       } else if(values.size > 1) {
-        sys.error(s"Multiple tiles found for $key for layer $layerId")
+        throw new CatalogError(s"Multiple tiles found for $key for layer $layerId")
       } else {
         values.head
       }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
@@ -51,7 +51,7 @@ class HadoopAttributeStore(hadoopConfiguration: Configuration, attributeDir: Pat
   def read[T: ReadableWritable](layerId: LayerId, attributeName: String): T =
     readFile[T](attributePath(layerId, attributeName)) match {
       case Some((id, value)) => value
-      case None => throw new LayerNotFoundError(layerId)
+      case None => throw new AttributeNotFoundError(attributeName, layerId)
     }
 
   def readAll[T: RootJsonFormat](attributeName: String): Map[LayerId,T] = {
@@ -60,7 +60,7 @@ class HadoopAttributeStore(hadoopConfiguration: Configuration, attributeDir: Pat
       .map{ path: Path => 
         readFile[T](path) match {
           case Some(tup) => tup
-          case None => sys.error(s"Unable to read '$attributeName' attribute from $path")
+          case None => throw new CatalogError(s"Unable to list $attributeName attributes from $path") 
         }
       }
       .toMap

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/spacetime/SpaceTimeRasterRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/spacetime/SpaceTimeRasterRDDWriter.scala
@@ -2,6 +2,7 @@ package geotrellis.spark.io.hadoop.spacetime
 
 import geotrellis.spark._
 import geotrellis.spark.utils._
+import geotrellis.spark.io.{LayerWriteError}
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.hadoop.formats._
 import geotrellis.spark.io.index._
@@ -34,7 +35,7 @@ object SpaceTimeRasterRDDWriter extends RasterRDDWriter[SpaceTimeKey] with Loggi
         logDebug(s"Deleting $layerPath")
         fs.delete(layerPath, true)
       } else
-        sys.error(s"Directory already exists: $layerPath")
+        throw new LayerWriteError(layerId, s"Directory already exists: $layerPath")
     }
 
     val job = Job.getInstance(conf)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/spatial/SpatialRasterRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/spatial/SpatialRasterRDDWriter.scala
@@ -2,6 +2,7 @@ package geotrellis.spark.io.hadoop.spatial
 
 import geotrellis.spark._
 import geotrellis.spark.utils._
+import geotrellis.spark.io.{LayerWriteError}
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.hadoop.formats._
 import geotrellis.spark.io.index._
@@ -34,7 +35,7 @@ object SpatialRasterRDDWriter extends RasterRDDWriter[SpatialKey] with Logging {
         logDebug(s"Deleting $layerPath")
         fs.delete(layerPath, true)
       } else
-        sys.error(s"Directory already exists: $layerPath")
+        throw new LayerWriteError(layerId, s"Directory already exists: $layerPath")
     }
 
     val job = Job.getInstance(conf)

--- a/spark/src/main/scala/geotrellis/spark/io/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/package.scala
@@ -15,16 +15,19 @@ package object io {
   // Custom exceptions
   class CatalogError(val message: String) extends Exception(message)
 
-  class DriverNotFoundError[K: ClassTag]
-      extends CatalogError(s"Driver not found for key type '${classTag[K]}'")
-
   class LayerNotFoundError(layerId: LayerId)
       extends CatalogError(s"LayerMetaData not found for layer $layerId")
 
-  class MultipleMatchError(layerId: LayerId)
-    extends CatalogError(s"Multiple layers match id of $layerId")
-
   class LayerExistsError(layerId: LayerId) 
       extends CatalogError(s"Layer ${layerId} already exists in the catalog")
+
+  class LayerWriteError(layerId: LayerId, msg: String)
+      extends CatalogError(s"Failed to write ${layerId}: $msg")
+
+  class AttributeNotFoundError(attributeName: String, layerId: LayerId)
+    extends CatalogError(s"Attribute $attributeName not found for layer $layerId")
+   
+  class TileNotFoundError(key: Any, layerId: LayerId)
+    extends CatalogError(s"Tile with key $key not found for layer $layerId")
 
 }

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
@@ -47,7 +47,7 @@ class S3AttributeStore(s3Client: S3Client, bucket: String, rootPath: String)
   def read[T: ReadableWritable](layerId: LayerId, attributeName: String): T =
     readKey[T](attributePath(layerId, attributeName)) match {
       case Some((id, value)) => value
-      case None => throw new LayerNotFoundError(layerId)
+      case None => throw new AttributeNotFoundError(attributeName, layerId)
     }
 
   def readAll[T: ReadableWritable](attributeName: String): Map[LayerId, T] =    
@@ -56,7 +56,7 @@ class S3AttributeStore(s3Client: S3Client, bucket: String, rootPath: String)
       .map{ os =>       
         readKey[T](os.getKey) match {
           case Some(tup) => tup
-          case None => sys.error(s"Unable to read '$attributeName' attribute from ${os.getKey}")
+          case None => throw new CatalogError(s"Unable to list $attributeName attributes from $bucket/${os.getKey}") 
         }
       }
       .toMap

--- a/spark/src/main/scala/geotrellis/spark/io/s3/TileReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/TileReader.scala
@@ -1,6 +1,7 @@
 package geotrellis.spark.io.s3
 
 import geotrellis.spark._
+import geotrellis.spark.io._
 import geotrellis.spark.io.index._
 import geotrellis.raster._
 import geotrellis.spark.utils._
@@ -30,7 +31,7 @@ trait TileReader[K] {
       client.getObject(lmd.bucket, path).getObjectContent    
     } catch {
       case e: AmazonS3Exception if e.getStatusCode == 404 =>
-        sys.error(s"Tile with key $key not found for layer $layerId")
+        throw new TileNotFoundError(key, layerId)        
     }
 
     val (storedKey, tile) = KryoSerializer.deserializeStream[(K, Tile)](is)

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloRasterCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloRasterCatalogSpec.scala
@@ -76,7 +76,7 @@ class AccumuloRasterCatalogSpec extends FunSpec
         }
 
         it("should load out saved tiles, but only for the right zoom") {
-          intercept[RuntimeException] {
+          intercept[LayerNotFoundError] {
             catalog.query[SpatialKey](LayerId("ones", level.zoom + 1)).toRDD.count()
           }
         }
@@ -143,7 +143,7 @@ class AccumuloRasterCatalogSpec extends FunSpec
       }
 
       it("should load out saved tiles, but only for the right zoom") {
-        intercept[RuntimeException] {
+        intercept[LayerNotFoundError] {
           catalog.query[SpaceTimeKey](LayerId("coordinates", zoom + 1)).toRDD.count()
         }
       }

--- a/spark/src/test/scala/geotrellis/spark/io/s3/S3RasterCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/S3RasterCatalogSpec.scala
@@ -2,6 +2,7 @@ package geotrellis.spark.io.s3
 
 import org.scalatest._
 import geotrellis.spark._
+import geotrellis.spark.io._
 import geotrellis.spark.io.index._
 import geotrellis.spark.testfiles._
 import geotrellis.raster.GridBounds
@@ -58,7 +59,7 @@ class S3RasterCatalogSpec extends FunSpec
       it("should error on getting a tile that is not there"){
         val reader = catalog.tileReader[SpatialKey](id)
 
-        intercept[RuntimeException]{
+        intercept[TileNotFoundError]{
           val tile = reader(SpatialKey(200,200))
         }        
       }


### PR DESCRIPTION
This PR upgrade the use of `sys.error` in the catalog package to named exceptions that should make client code cleaner.
