### PR TITLE
Feature/catalog read

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloRasterCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloRasterCatalog.scala
@@ -1,16 +1,18 @@
 package geotrellis.spark.io.accumulo
 
-import com.typesafe.config.ConfigFactory
-import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.io.index._
+import geotrellis.raster._
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.SparkContext
-import spray.json._
+
+import com.typesafe.config.ConfigFactory
 
 import scala.reflect._
+import spray.json._
 
 object AccumuloRasterCatalog {
   def apply()(implicit instance: AccumuloInstance, sc: SparkContext): AccumuloRasterCatalog = {

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRasterCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRasterCatalog.scala
@@ -1,10 +1,11 @@
 package geotrellis.spark.io.hadoop
 
-import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.io.index._
+import geotrellis.raster._
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark._
 import spray.json._

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3RasterCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3RasterCatalog.scala
@@ -1,18 +1,19 @@
 package geotrellis.spark.io.s3
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.retry.PredefinedRetryPolicies
 import geotrellis.raster.Tile
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.io.index._
+
 import org.apache.spark._
 import spray.json.JsonFormat
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.retry.PredefinedRetryPolicies
 
 import scala.reflect._
 
-object S3RasterCatalog {  
+object S3RasterCatalog {
   def defaultS3Client = 
     () => {
       val provider = new DefaultAWSCredentialsProviderChain()

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloRasterCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloRasterCatalogSpec.scala
@@ -1,19 +1,20 @@
 package geotrellis.spark.io.accumulo
 
-import com.github.nscala_time.time.Imports._
 import geotrellis.proj4.LatLng
 import geotrellis.raster._
 import geotrellis.raster.op.local._
 import geotrellis.spark._
 import geotrellis.spark.ingest._
-import geotrellis.spark.io.LayerNotFoundError
-import geotrellis.spark.io.hadoop._
+import geotrellis.spark.io._
 import geotrellis.spark.io.index._
-import geotrellis.spark.testfiles._
+import geotrellis.spark.io.hadoop._
 import geotrellis.spark.tiling._
+import geotrellis.spark.testfiles._
 import geotrellis.vector._
-import org.apache.hadoop.fs.Path
+
 import org.scalatest._
+import org.apache.hadoop.fs.Path
+import com.github.nscala_time.time.Imports._
 
 class AccumuloRasterCatalogSpec extends FunSpec
     with RasterRDDMatchers

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopRasterCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopRasterCatalogSpec.scala
@@ -1,17 +1,18 @@
 package geotrellis.spark.io.hadoop
 
-import com.github.nscala_time.time.Imports._
-import geotrellis.proj4.LatLng
 import geotrellis.raster._
+import geotrellis.vector._
 import geotrellis.spark._
 import geotrellis.spark.ingest._
 import geotrellis.spark.io._
 import geotrellis.spark.io.index._
-import geotrellis.spark.testfiles._
 import geotrellis.spark.tiling._
-import geotrellis.vector._
-import org.apache.hadoop.fs.Path
+import geotrellis.proj4.LatLng
+import geotrellis.spark.testfiles._
+
 import org.scalatest._
+import org.apache.hadoop.fs.Path
+import com.github.nscala_time.time.Imports._
 import spray.json.JsonFormat
 
 import scala.reflect._

--- a/spark/src/test/scala/geotrellis/spark/io/s3/S3RasterCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/S3RasterCatalogSpec.scala
@@ -1,10 +1,11 @@
 package geotrellis.spark.io.s3
 
-import geotrellis.raster.GridBounds
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.index._
 import geotrellis.spark.testfiles._
+import geotrellis.raster.GridBounds
+
 import org.scalatest._
 
 class S3RasterCatalogSpec extends FunSpec


### PR DESCRIPTION
As discussed on Gitter, here is a way to get the whole raster with an overload of `read` (Accumulo, Hadoop, S3 catalogs). Context bound `Boundable` has been added to original read method for overloading purpose.