### PR TITLE
Fixed UInt16GeoTiff reader bug and added a test

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTileSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTileSpec.scala
@@ -1,0 +1,24 @@
+package geotrellis.raster.io.geotiff
+
+import geotrellis.raster.TypeInt
+import geotrellis.testkit.{TileBuilders, TestEngine}
+import org.scalatest.{BeforeAndAfterAll, Matchers, FunSpec}
+
+
+class UInt16GeoTiffTileSpec extends FunSpec
+with Matchers
+with BeforeAndAfterAll
+with TestEngine
+with GeoTiffTestUtils
+with TileBuilders {
+
+  describe("UInt16GeoTiffTile") {
+   it("should read landsat 8 data correctly") {
+     val actualImage = SingleBandGeoTiff(geoTiffPath(s"ls8_uint16.tif")).convert(TypeInt)
+     val expectedImage = SingleBandGeoTiff(geoTiffPath(s"ls8_int32.tif"))
+
+     assertEqual(actualImage.tile, expectedImage.tile)
+
+   }
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffSegment.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffSegment.scala
@@ -22,7 +22,7 @@ class UInt16GeoTiffSegment(val bytes: Array[Byte]) extends GeoTiffSegment {
 
   val size: Int = bytes.size / 2
 
-  def get(i: Int): Int = buffer.get(i) % 0xFFFF
+  def get(i: Int): Int = buffer.get(i) & 0xFFFF
 
   def getInt(i: Int): Int = get(i)
   def getDouble(i: Int): Double = i2d(get(i))


### PR DESCRIPTION
UInt16GeoTIFFs were not being read correctly and needed to be converted to signed Ints. 

The added test only passes after this fix.