### PR TITLE
Fix s3 catalog rootpath

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
@@ -33,10 +33,10 @@ class S3AttributeStore(s3Client: S3Client, bucket: String, rootPath: String)
   def path(parts: String*) = parts.filter(_.nonEmpty).mkString("/")
 
   def attributePath(id: LayerId, attributeName: String): String =
-    path(rootPath, "_attributes", "${attributeName}__${id.name}__${id.zoom}.json")
+    path(rootPath, "_attributes", s"${attributeName}__${id.name}__${id.zoom}.json")
 
   def attributePrefix(attributeName: String): String =
-    path(rootPath, "_attributes", "${attributeName}__")
+    path(rootPath, "_attributes", s"${attributeName}__")
 
   private def readKey[T: ReadableWritable](key: String): Option[(LayerId, T)] = {
     val is = s3Client.getObject(bucket, key).getObjectContent()

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
@@ -30,11 +30,13 @@ class S3AttributeStore(s3Client: S3Client, bucket: String, rootPath: String)
    * It could be remedied by some kind of time-out cache for both read/write in this class.
    */
 
+  def path(parts: String*) = parts.filter(_.nonEmpty).mkString("/")
+
   def attributePath(id: LayerId, attributeName: String): String =
-    s"$rootPath/_attributes/${attributeName}__${id.name}__${id.zoom}.json"
+    path(rootPath, "_attributes", "${attributeName}__${id.name}__${id.zoom}.json")
 
   def attributePrefix(attributeName: String): String =
-    s"$rootPath/_attributes/${attributeName}__"
+    path(rootPath, "_attributes", "${attributeName}__")
 
   private def readKey[T: ReadableWritable](key: String): Option[(LayerId, T)] = {
     val is = s3Client.getObject(bucket, key).getObjectContent()

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3RasterCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3RasterCatalog.scala
@@ -29,6 +29,8 @@ object S3RasterCatalog {
   private def layerPath(layerId: LayerId) = 
     s"${layerId.name}/${layerId.zoom}"  
 
+  def apply(bucket: String) = apply(bucket, "", defaultS3Client)
+
   def apply(bucket: String, rootPath: String, s3client: () => S3Client = defaultS3Client)
     (implicit sc: SparkContext): S3RasterCatalog = {
     
@@ -86,11 +88,7 @@ class S3RasterCatalog(
       def write(layerId: LayerId, rdd: RasterRDD[K]): Unit = {
         rdd.persist()
 
-        val path = 
-          if (subDir != "")
-            s"${rootPath}/${subDir}/${layerPath(layerId)}"
-          else
-            s"${rootPath}/${layerPath(layerId)}"
+        val path = List(rootPath, subDir, layerPath(layerId)).filter(_.nonEmpty).mkString("/")
 
         val md = S3LayerMetaData(
             layerId = layerId,

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3RasterCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3RasterCatalog.scala
@@ -29,7 +29,8 @@ object S3RasterCatalog {
   private def layerPath(layerId: LayerId) = 
     s"${layerId.name}/${layerId.zoom}"  
 
-  def apply(bucket: String) = apply(bucket, "", defaultS3Client)
+  def apply(bucket: String)(implicit sc: SparkContext): S3RasterCatalog =
+    apply(bucket, "", defaultS3Client)
 
   def apply(bucket: String, rootPath: String, s3client: () => S3Client = defaultS3Client)
     (implicit sc: SparkContext): S3RasterCatalog = {


### PR DESCRIPTION
Fixes issue with S3 catalog where using empty rootPath would result in path of "/layerName/zoom". The leading slash is interpreted as a folder with empty name by S3 browser.