### PR TITLE
Added JsonReader and JsonWriter for Feature[D]

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-./sbt -J-Xmx2G "project spark" test  || { exit 1; }
-./sbt -J-Xmx2G "project index" test || { exit 1; }
-./sbt -J-Xmx2G "project raster-test" test || { exit 1; } 
-./sbt -J-Xmx2G "project vector-test" test || { exit 1; }
-./sbt -J-Xmx2G "project engine-test" test || { exit 1; } 
-./sbt -J-Xmx2G "project benchmark" compile || { exit 1; } 
 ./sbt -J-Xmx2G "project proj4" test || { exit 1; } 
+./sbt -J-Xmx2G "project vector-test" test || { exit 1; }
+./sbt -J-Xmx2G "project raster-test" test || { exit 1; } 
+./sbt -J-Xmx2G "project spark" test  || { exit 1; }
+./sbt -J-Xmx2G "project engine-test" test || { exit 1; } 
+./sbt -J-Xmx2G "project index" test || { exit 1; }
+./sbt -J-Xmx2G "project benchmark" compile || { exit 1; } 
 ./sbt -J-Xmx2G "project slick" test:compile || { exit 1; } 
 ./sbt -J-Xmx2G "project gdal" test:compile || { exit 1; }
 ./sbt -J-Xmx2G "project geotools" compile || { exit 1; } 

--- a/vector-test/src/test/scala/spec/geotrellis/vector/io/json/CrsSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/io/json/CrsSpec.scala
@@ -88,6 +88,9 @@ class CrsSpec extends FlatSpec with Matchers with GeoJsonSupport {
         |}""".stripMargin
     )
 
+//    implicitly[spray.httpx.unmarshalling.Unmarshaller[geotrellis.vector.PointFeature[String]]]
+//    implicitly[spray.httpx.unmarshalling.Unmarshaller[geotrellis.vector.io.json.WithCrs[geotrellis.vector.PointFeature[String]]]]
+
     marshal(f.withCrs(crs)) should equal (Right(body))
     body.as[WithCrs[PointFeature[String]]] should equal (Right(WithCrs(f, crs)))
   }

--- a/vector-test/src/test/scala/spec/geotrellis/vector/io/json/FeatureFormatsSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/io/json/FeatureFormatsSpec.scala
@@ -10,6 +10,7 @@ import spray.http._
 import HttpCharsets._
 import MediaTypes._
 
+import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 class FeatureFormatsSpec extends FlatSpec with Matchers with GeoJsonSupport {
@@ -164,9 +165,11 @@ class FeatureFormatsSpec extends FlatSpec with Matchers with GeoJsonSupport {
     features.length should be (2)
   }
 
-  case class SomeData(name: String, value: Double)
-  implicit val someDataFormat = jsonFormat2(SomeData)
   it should "be able to handle Feature with custom data" in {
+    case class SomeData(name: String, value: Double)
+    val format = jsonFormat2(SomeData)
+    implicit val someDataFormat: JsonReader[SomeData] = format
+
     val f = PointFeature(Point(1,44), SomeData("Bob", 32.2))
 
     val body =
@@ -184,6 +187,7 @@ class FeatureFormatsSpec extends FlatSpec with Matchers with GeoJsonSupport {
         |}""".stripMargin
       )
 
+    implicit val _format: JsonFormat[SomeData] = format
     marshal(f) should equal (Right(body))
     body.as[PointFeature[SomeData]] should equal (Right(f))
   }

--- a/vector/src/main/scala/geotrellis/vector/io/json/FeatureFormats.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/FeatureFormats.scala
@@ -50,7 +50,6 @@ trait FeatureFormats {
     }
   }
 
-
   implicit def featureFormat[D: JsonFormat] = new RootJsonFormat[Feature[D]] {
     override def read(json: JsValue): Feature[D] =
       readFeatureJson[D, Geometry, Feature[D]](json) {
@@ -69,44 +68,111 @@ trait FeatureFormats {
       writeFeatureJson(obj)
   }
 
+
+  implicit def pointFeatureReader[D: JsonReader] = new RootJsonReader[PointFeature[D]] {
+    override def read(json: JsValue): PointFeature[D] =
+      readFeatureJson[D, Point, PointFeature[D]](json){PointFeature.apply}
+  }
+
+  implicit def pointFeatureWriter[D: JsonWriter] = new RootJsonWriter[PointFeature[D]] {
+    override def write(obj: PointFeature[D]): JsValue =
+      writeFeatureJson(obj)
+  }
+
   implicit def pointFeatureFormat[D: JsonFormat] = new RootJsonFormat[PointFeature[D]] {
     override def read(json: JsValue): PointFeature[D] =
       readFeatureJson[D, Point, PointFeature[D]](json){PointFeature.apply}
+
     override def write(obj: PointFeature[D]): JsValue =
+      writeFeatureJson(obj)
+  }
+
+  implicit def lineFeatureReader[D: JsonReader] = new RootJsonReader[LineFeature[D]] {
+    override def read(json: JsValue): LineFeature[D] =
+      readFeatureJson[D, Line, LineFeature[D]](json){LineFeature.apply}
+  }
+
+  implicit def lineFeatureWriter[D: JsonWriter] = new RootJsonWriter[LineFeature[D]] {
+    override def write(obj: LineFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def lineFeatureFormat[D: JsonFormat] = new RootJsonFormat[LineFeature[D]] {
     override def read(json: JsValue): LineFeature[D] =
       readFeatureJson[D, Line, LineFeature[D]](json){LineFeature.apply}
+
     override def write(obj: LineFeature[D]): JsValue =
+      writeFeatureJson(obj)
+  }
+
+  implicit def polygonFeatureReader[D: JsonReader] = new RootJsonReader[PolygonFeature[D]] {
+    override def read(json: JsValue): PolygonFeature[D] =
+      readFeatureJson[D, Polygon, PolygonFeature[D]](json){PolygonFeature.apply}
+  }
+
+  implicit def polygonFeatureWriter[D: JsonWriter] = new RootJsonWriter[PolygonFeature[D]] {
+    override def write(obj: PolygonFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def polygonFeatureFormat[D: JsonFormat] = new RootJsonFormat[PolygonFeature[D]] {
     override def read(json: JsValue): PolygonFeature[D] =
       readFeatureJson[D, Polygon, PolygonFeature[D]](json){PolygonFeature.apply}
+
     override def write(obj: PolygonFeature[D]): JsValue =
+      writeFeatureJson(obj)
+  }
+
+  implicit def multiPointFeatureReader[D: JsonReader] = new RootJsonReader[MultiPointFeature[D]] {
+    override def read(json: JsValue): MultiPointFeature[D] =
+      readFeatureJson[D, MultiPoint, MultiPointFeature[D]](json){MultiPointFeature.apply}
+  }
+
+  implicit def multiPointFeatureWriter[D: JsonWriter] = new RootJsonWriter[MultiPointFeature[D]] {
+    override def write(obj: MultiPointFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def multiPointFeatureFormat[D: JsonFormat] = new RootJsonFormat[MultiPointFeature[D]] {
     override def read(json: JsValue): MultiPointFeature[D] =
       readFeatureJson[D, MultiPoint, MultiPointFeature[D]](json){MultiPointFeature.apply}
+
     override def write(obj: MultiPointFeature[D]): JsValue =
+      writeFeatureJson(obj)
+  }
+
+  implicit def multiLineFeatureReader[D: JsonReader] = new RootJsonReader[MultiLineFeature[D]] {
+    override def read(json: JsValue): MultiLineFeature[D] =
+      readFeatureJson[D, MultiLine, MultiLineFeature[D]](json){MultiLineFeature.apply}
+  }
+
+  implicit def multiLineFeatureWriter[D: JsonWriter] = new RootJsonWriter[MultiLineFeature[D]] {
+    override def write(obj: MultiLineFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def multiLineFeatureFormat[D: JsonFormat] = new RootJsonFormat[MultiLineFeature[D]] {
     override def read(json: JsValue): MultiLineFeature[D] =
       readFeatureJson[D, MultiLine, MultiLineFeature[D]](json){MultiLineFeature.apply}
+
     override def write(obj: MultiLineFeature[D]): JsValue =
+      writeFeatureJson(obj)
+  }
+
+  implicit def multiPolygonFeatureReader[D: JsonReader] = new RootJsonReader[MultiPolygonFeature[D]] {
+    override def read(json: JsValue): MultiPolygonFeature[D] =
+      readFeatureJson[D, MultiPolygon, MultiPolygonFeature[D]](json){MultiPolygonFeature.apply}
+  }
+
+  implicit def multiPolygonFeatureWriter[D: JsonWriter] = new RootJsonWriter[MultiPolygonFeature[D]] {
+    override def write(obj: MultiPolygonFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def multiPolygonFeatureFormat[D: JsonFormat] = new RootJsonFormat[MultiPolygonFeature[D]] {
     override def read(json: JsValue): MultiPolygonFeature[D] =
       readFeatureJson[D, MultiPolygon, MultiPolygonFeature[D]](json){MultiPolygonFeature.apply}
+
     override def write(obj: MultiPolygonFeature[D]): JsValue =
       writeFeatureJson(obj)
   }

--- a/vector/src/main/scala/geotrellis/vector/io/json/GeoJson.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/GeoJson.scala
@@ -4,10 +4,10 @@ import spray.json._
 import spray.json.JsonFormat
 
 object GeoJson {
-  def parse[T: JsonFormat](json: String) = 
+  def parse[T: JsonReader](json: String) = 
     json.parseJson.convertTo[T]
 
-  def fromFile[T: JsonFormat](path: String) = {
+  def fromFile[T: JsonReader](path: String) = {
     val src = scala.io.Source.fromFile(path)
     val txt = 
       try {

--- a/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollection.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollection.scala
@@ -59,7 +59,7 @@ class JsonFeatureCollection(features: List[JsValue] = Nil) {
    * @tparam F type of Feature to return
    * @return Vector or Feature objects that were successfully parsed
    */
-  def getAll[F :JsonFormat]: Vector[F] = {
+  def getAll[F: JsonReader]: Vector[F] = {
     val ret = new VectorBuilder[F]()
     features.foreach{ f =>
       Try(f.convertTo[F]) match {
@@ -71,15 +71,15 @@ class JsonFeatureCollection(features: List[JsValue] = Nil) {
     ret.result()
   }
 
-  def getAllFeatures[F <: Feature[_] :JsonFormat]: Vector[F] = 
+  def getAllFeatures[F <: Feature[_] :JsonReader]: Vector[F] = 
     getAll[F]
 
-  def getAllPointFeatures[D: JsonFormat]()         = getAll[PointFeature[D]]
-  def getAllLineFeatures[D: JsonFormat]()          = getAll[LineFeature[D]]
-  def getAllPolygonFeatures[D: JsonFormat]()       = getAll[PolygonFeature[D]]
-  def getAllMultiPointFeatures[D: JsonFormat]()    = getAll[MultiPointFeature[D]]
-  def getAllMultiLineFeatures[D: JsonFormat]()     = getAll[MultiLineFeature[D]]
-  def getAllMultiPolygonFeatures[D: JsonFormat]()  = getAll[MultiPolygonFeature[D]]
+  def getAllPointFeatures[D: JsonReader]()         = getAll[PointFeature[D]]
+  def getAllLineFeatures[D: JsonReader]()          = getAll[LineFeature[D]]
+  def getAllPolygonFeatures[D: JsonReader]()       = getAll[PolygonFeature[D]]
+  def getAllMultiPointFeatures[D: JsonReader]()    = getAll[MultiPointFeature[D]]
+  def getAllMultiLineFeatures[D: JsonReader]()     = getAll[MultiLineFeature[D]]
+  def getAllMultiPolygonFeatures[D: JsonReader]()  = getAll[MultiPolygonFeature[D]]
 
   def getAllPoints()         = getAll[Point]
   def getAllLines()          = getAll[Line]

--- a/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollectionMap.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollectionMap.scala
@@ -57,7 +57,6 @@ class JsonFeatureCollectionMap(features: List[JsValue] = Nil) {
     }
   }
 
-
   //-- Used for Deserialization
   /**
    * This method locates the correct JsonFormat for F through implicit scope and
@@ -66,7 +65,7 @@ class JsonFeatureCollectionMap(features: List[JsValue] = Nil) {
    * @tparam F type of Feature to return
    * @return Vector or Feature objects that were successfully parsed
    */
-  def getAll[F :JsonFormat]: Map[String, F] = {
+  def getAll[F :JsonReader]: Map[String, F] = {
     var ret = Map[String, F]()
     features.foreach{ f =>
       Try(f.convertTo[F]) match {
@@ -78,15 +77,15 @@ class JsonFeatureCollectionMap(features: List[JsValue] = Nil) {
     ret.toMap
   }
 
-  def getAllFeatures[F <: Feature[_] :JsonFormat]: Map[String, F] =
+  def getAllFeatures[F <: Feature[_] :JsonReader]: Map[String, F] =
     getAll[F]
 
-  def getAllPointFeatures[D: JsonFormat]()         = getAll[PointFeature[D]]
-  def getAllLineFeatures[D: JsonFormat]()          = getAll[LineFeature[D]]
-  def getAllPolygonFeatures[D: JsonFormat]()       = getAll[PolygonFeature[D]]
-  def getAllMultiPointFeatures[D: JsonFormat]()    = getAll[MultiPointFeature[D]]
-  def getAllMultiLineFeatures[D: JsonFormat]()     = getAll[MultiLineFeature[D]]
-  def getAllMultiPolygonFeatures[D: JsonFormat]()  = getAll[MultiPolygonFeature[D]]
+  def getAllPointFeatures[D: JsonReader]()         = getAll[PointFeature[D]]
+  def getAllLineFeatures[D: JsonReader]()          = getAll[LineFeature[D]]
+  def getAllPolygonFeatures[D: JsonReader]()       = getAll[PolygonFeature[D]]
+  def getAllMultiPointFeatures[D: JsonReader]()    = getAll[MultiPointFeature[D]]
+  def getAllMultiLineFeatures[D: JsonReader]()     = getAll[MultiLineFeature[D]]
+  def getAllMultiPolygonFeatures[D: JsonReader]()  = getAll[MultiPolygonFeature[D]]
 
   def getAllPoints()         = getAll[Point]
   def getAllLines()          = getAll[Line]

--- a/vector/src/main/scala/geotrellis/vector/io/json/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/package.scala
@@ -17,7 +17,7 @@ package object json extends GeoJsonSupport {
     }
   }
 
-  implicit class FeaturesToGeoJson[D: JsonFormat](features: Traversable[Feature[D]]) {
+  implicit class FeaturesToGeoJson[D: JsonWriter](features: Traversable[Feature[D]]) {
     def toGeoJson: String = {
       JsonFeatureCollection(features).toJson.compactPrint
     }
@@ -29,13 +29,13 @@ package object json extends GeoJsonSupport {
     def withCrs(crs: CRS) = WithCrs(geom, crs)
   }
 
-  implicit class RichFeature[D: JsonFormat](feature: Feature[D]){
+  implicit class RichFeature[D: JsonWriter](feature: Feature[D]){
     def toGeoJson: String = writeFeatureJson[D](feature).compactPrint
 
     def withCrs(crs: CRS) = WithCrs(feature, crs)
   }
 
   implicit class RichString(val s: String) extends AnyVal {
-    def parseGeoJson[T: JsonFormat] = s.parseJson.convertTo[T]
+    def parseGeoJson[T: JsonReader] = s.parseJson.convertTo[T]
   }
 }


### PR DESCRIPTION
Before this, if we had the situation where we'd like to read a GeoJSON feature collection data property into a class but had no interest in ever writing it through GeoJSON, we'd have to do something like this:

```scala
  case class NeighborhoodData(name: String, listName: String)

  implicit object NeighborhoodDataFormat extends JsonFormat[NeighborhoodData] {
    def write(obj: NeighborhoodData): JsValue = ???

    def read(value: JsValue): NeighborhoodData = 
      value.asJsObject.getFields("name", "listname") match {
        case Seq(JsString(name), JsString(listName)) =>
          NeighborhoodData(name, listName)
        case _ => throw new DeserializationException("Couldn't read neighborhood data")
      }
  }

  def fromJson(path: String): Seq[MultiPolygonFeature[String]] =
      Source.fromFile(path)
        .getLines
        .mkString
        .parseGeoJson[JsonFeatureCollection]
        .getAllMultiPolygonFeatures[NeighborhoodData]
        .map { feature => MultiPolygonFeature(feature.geom, feature.data.name) }
```

with this change, we can just implement the reader if we want to read, and the writer if we want to write.

The `JsonFormat` is still defined specifically because spray's implicit marsheller requires a JsonFormat, not a Reader or a Writer.