### PR TITLE
Refactored Feature to include Geometry type as type param.

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/reproject/RowTransformCheck.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/reproject/RowTransformCheck.scala
@@ -57,7 +57,7 @@ object RowTransformCheck_LatLngToWebMercator extends Properties("RowTransform") 
   case class Threshold(v: Double)
   lazy val genThreshold: Gen[Threshold] = 
     for {
-      v <- choose(0.0, 5.0)
+      v <- choose(0.1, 5.0)
     } yield Threshold(v)
 
   implicit lazy val arbThreshold: Arbitrary[Threshold] =

--- a/vector-test/src/test/scala/spec/geotrellis/vector/io/json/GeoJsonSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/io/json/GeoJsonSpec.scala
@@ -37,7 +37,6 @@ class GeoJsonSpec extends FlatSpec with Matchers {
     val json = """{"type":"Feature","geometry":{"type":"Point","coordinates":[1.0,1.0]},"properties":"Data"}"""
     val expected = PointFeature(Point(1,1), "Data")
 
-    GeoJson.parse[Feature[String]](json) should equal (expected)
     GeoJson.parse[PointFeature[String]](json) should equal (expected)
   }
 

--- a/vector/src/main/scala/geotrellis/vector/Feature.scala
+++ b/vector/src/main/scala/geotrellis/vector/Feature.scala
@@ -19,28 +19,49 @@ package geotrellis.vector
 import com.vividsolutions.jts.{geom => jts}
 import spray.json._
 
-abstract class Feature[D] {
-  type G <: Geometry
-  val geom: G ; val data: D
+case class Feature[+G <: Geometry, D](geom: G, data: D) {
+  def mapGeom[T <: Geometry](f: G => T): Feature[T, D] =
+    Feature(f(geom), data)
+
+  def mapData[T](f: D => T): Feature[G, T] =
+    Feature(geom, f(data))
 }
 
-case class PointFeature[D](geom: Point, data: D) extends Feature[D] {type G = Point}
-object PointFeature { implicit def feature2Geom[D](f: PointFeature[D]): Point = f.geom }
+object Feature {
+  implicit def featureToGeometry[G <: Geometry](f: Feature[G, _]): G = f.geom  
+}
 
-case class LineFeature[D](geom: Line, data: D) extends Feature[D] {type G = Line}
-object LineFeature { implicit def feature2Geom[D](f: LineFeature[D]): Line = f.geom }
+object PointFeature {
+  def apply[D](geom: Point, data: D): Feature[Point, D] =
+    Feature(geom, data)
+}
 
-case class PolygonFeature[D](geom: Polygon, data: D) extends Feature[D] {type G = Polygon}
-object PolygonFeature { implicit def feature2Geom[D](f: PolygonFeature[D]): Polygon = f.geom }
+object LineFeature {
+  def apply[D](geom: Line, data: D): Feature[Line, D] =
+    Feature(geom, data)
+}
 
-case class MultiPointFeature[D](geom: MultiPoint, data: D) extends Feature[D] {type G = MultiPoint}
-object MultiPointFeature { implicit def feature2Geom[D](f: MultiPointFeature[D]): MultiPoint = f.geom }
+object PolygonFeature {
+  def apply[D](geom: Polygon, data: D): Feature[Polygon, D] =
+    Feature(geom, data)
+}
 
-case class MultiLineFeature[D](geom: MultiLine, data: D) extends Feature[D] {type G = MultiLine}
-object MultiLineFeature { implicit def feature2Geom[D](f: MultiLineFeature[D]): MultiLine = f.geom }
+object MultiPointFeature {
+  def apply[D](geom: MultiPoint, data: D): Feature[MultiPoint, D] =
+    Feature(geom, data)
+}
 
-case class MultiPolygonFeature[D](geom: MultiPolygon, data: D) extends Feature[D] {type G = MultiPolygon}
-object MultiPolygonFeature { implicit def feature2Geom[D](f: MultiPolygonFeature[D]): MultiPolygon = f.geom }
+object MultiLineFeature {
+  def apply[D](geom: MultiLine, data: D): Feature[MultiLine, D] =
+    Feature(geom, data)
+}
 
-case class GeometryCollectionFeature[D](geom: GeometryCollection, data: D) extends Feature[D] {type G = GeometryCollection}
-object GeometryCollectionFeature { implicit def feature2Geom[D](f: GeometryCollectionFeature[D]): GeometryCollection = f.geom }
+object MultiPolygonFeature {
+  def apply[D](geom: MultiPolygon, data: D): Feature[MultiPolygon, D] =
+    Feature(geom, data)
+}
+
+object GeometryCollectionFeature {
+  def apply[D](geom: GeometryCollection, data: D): Feature[GeometryCollection, D] =
+    Feature(geom, data)
+}

--- a/vector/src/main/scala/geotrellis/vector/io/json/FeatureFormats.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/FeatureFormats.scala
@@ -12,7 +12,7 @@ trait FeatureFormats {
     * @tparam The type (which must have an implicit method to resolve the transformation from json)
     * @return The GeoJson compliant spray.JsValue
     */
-  def writeFeatureJson[D: JsonWriter](obj: Feature[D]): JsValue = {
+  def writeFeatureJson[G <: Geometry, D: JsonWriter](obj: Feature[G, D]): JsValue = {
     JsObject(
       "type" -> JsString("Feature"),
       "geometry" -> GeometryFormat.write(obj.geom),
@@ -20,7 +20,7 @@ trait FeatureFormats {
     )
   }
 
-  def writeFeatureJsonWithID[D: JsonWriter](idFeature: (String, Feature[D])): JsValue = {
+  def writeFeatureJsonWithID[G <: Geometry, D: JsonWriter](idFeature: (String, Feature[G, D])): JsValue = {
     JsObject(
       "type" -> JsString("Feature"),
       "geometry" -> GeometryFormat.write(idFeature._2.geom),
@@ -29,49 +29,30 @@ trait FeatureFormats {
     )
   }
 
-  def readFeatureJson[D: JsonReader, G <: Geometry: JsonReader, F <: Feature[D]](value: JsValue)(create : (G, D) => F): F = {
+  def readFeatureJson[D: JsonReader, G <: Geometry: JsonReader](value: JsValue): Feature[G, D] = {
     value.asJsObject.getFields("type", "geometry", "properties") match {
       case Seq(JsString("Feature"), geom, data) =>
         val g = geom.convertTo[G]
         val d = data.convertTo[D]
-        create(g,d)
+        Feature(g, d)
       case _ => throw new DeserializationException("Feature expected")
     }
   }
 
-  def readFeatureJsonWithID[D: JsonReader, G <: Geometry: JsonReader, F <: Feature[D]](value: JsValue)(create : (G, D, String) => (String, F)): (String, F) = {
+  def readFeatureJsonWithID[D: JsonReader, G <: Geometry: JsonReader](value: JsValue): (String, Feature[G, D]) = {
     value.asJsObject.getFields("type", "geometry", "properties", "id") match {
       case Seq(JsString("Feature"), geom, data, id) =>
         val g = geom.convertTo[G]
         val d = data.convertTo[D]
         val i = id.toString
-        create(g, d, i)
+        (i, Feature(g, d))
       case _ => throw new DeserializationException("Feature expected")
     }
   }
 
-  implicit def featureFormat[D: JsonFormat] = new RootJsonFormat[Feature[D]] {
-    override def read(json: JsValue): Feature[D] =
-      readFeatureJson[D, Geometry, Feature[D]](json) {
-        case (geom, d) => geom match {
-          case g: Point => PointFeature(g, d)
-          case g: Line => LineFeature(g, d)
-          case g: Polygon => PolygonFeature(g, d)
-          case g: MultiPoint => MultiPointFeature(g, d)
-          case g: MultiLine => MultiLineFeature(g, d)
-          case g: MultiPolygon => MultiPolygonFeature(g, d)
-          case g: GeometryCollection => GeometryCollectionFeature(g, d)
-        }
-      }
-
-    override def write(obj: Feature[D]): JsValue =
-      writeFeatureJson(obj)
-  }
-
-
   implicit def pointFeatureReader[D: JsonReader] = new RootJsonReader[PointFeature[D]] {
     override def read(json: JsValue): PointFeature[D] =
-      readFeatureJson[D, Point, PointFeature[D]](json){PointFeature.apply}
+      readFeatureJson[D, Point](json)
   }
 
   implicit def pointFeatureWriter[D: JsonWriter] = new RootJsonWriter[PointFeature[D]] {
@@ -81,15 +62,14 @@ trait FeatureFormats {
 
   implicit def pointFeatureFormat[D: JsonFormat] = new RootJsonFormat[PointFeature[D]] {
     override def read(json: JsValue): PointFeature[D] =
-      readFeatureJson[D, Point, PointFeature[D]](json){PointFeature.apply}
-
+      readFeatureJson[D, Point](json)
     override def write(obj: PointFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def lineFeatureReader[D: JsonReader] = new RootJsonReader[LineFeature[D]] {
     override def read(json: JsValue): LineFeature[D] =
-      readFeatureJson[D, Line, LineFeature[D]](json){LineFeature.apply}
+      readFeatureJson[D, Line](json)
   }
 
   implicit def lineFeatureWriter[D: JsonWriter] = new RootJsonWriter[LineFeature[D]] {
@@ -99,15 +79,14 @@ trait FeatureFormats {
 
   implicit def lineFeatureFormat[D: JsonFormat] = new RootJsonFormat[LineFeature[D]] {
     override def read(json: JsValue): LineFeature[D] =
-      readFeatureJson[D, Line, LineFeature[D]](json){LineFeature.apply}
-
+      readFeatureJson[D, Line](json)
     override def write(obj: LineFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def polygonFeatureReader[D: JsonReader] = new RootJsonReader[PolygonFeature[D]] {
     override def read(json: JsValue): PolygonFeature[D] =
-      readFeatureJson[D, Polygon, PolygonFeature[D]](json){PolygonFeature.apply}
+      readFeatureJson[D, Polygon](json)
   }
 
   implicit def polygonFeatureWriter[D: JsonWriter] = new RootJsonWriter[PolygonFeature[D]] {
@@ -117,15 +96,14 @@ trait FeatureFormats {
 
   implicit def polygonFeatureFormat[D: JsonFormat] = new RootJsonFormat[PolygonFeature[D]] {
     override def read(json: JsValue): PolygonFeature[D] =
-      readFeatureJson[D, Polygon, PolygonFeature[D]](json){PolygonFeature.apply}
-
+      readFeatureJson[D, Polygon](json)
     override def write(obj: PolygonFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def multiPointFeatureReader[D: JsonReader] = new RootJsonReader[MultiPointFeature[D]] {
     override def read(json: JsValue): MultiPointFeature[D] =
-      readFeatureJson[D, MultiPoint, MultiPointFeature[D]](json){MultiPointFeature.apply}
+      readFeatureJson[D, MultiPoint](json)
   }
 
   implicit def multiPointFeatureWriter[D: JsonWriter] = new RootJsonWriter[MultiPointFeature[D]] {
@@ -135,15 +113,14 @@ trait FeatureFormats {
 
   implicit def multiPointFeatureFormat[D: JsonFormat] = new RootJsonFormat[MultiPointFeature[D]] {
     override def read(json: JsValue): MultiPointFeature[D] =
-      readFeatureJson[D, MultiPoint, MultiPointFeature[D]](json){MultiPointFeature.apply}
-
+      readFeatureJson[D, MultiPoint](json)
     override def write(obj: MultiPointFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def multiLineFeatureReader[D: JsonReader] = new RootJsonReader[MultiLineFeature[D]] {
     override def read(json: JsValue): MultiLineFeature[D] =
-      readFeatureJson[D, MultiLine, MultiLineFeature[D]](json){MultiLineFeature.apply}
+      readFeatureJson[D, MultiLine](json)
   }
 
   implicit def multiLineFeatureWriter[D: JsonWriter] = new RootJsonWriter[MultiLineFeature[D]] {
@@ -153,15 +130,14 @@ trait FeatureFormats {
 
   implicit def multiLineFeatureFormat[D: JsonFormat] = new RootJsonFormat[MultiLineFeature[D]] {
     override def read(json: JsValue): MultiLineFeature[D] =
-      readFeatureJson[D, MultiLine, MultiLineFeature[D]](json){MultiLineFeature.apply}
-
+      readFeatureJson[D, MultiLine](json)
     override def write(obj: MultiLineFeature[D]): JsValue =
       writeFeatureJson(obj)
   }
 
   implicit def multiPolygonFeatureReader[D: JsonReader] = new RootJsonReader[MultiPolygonFeature[D]] {
     override def read(json: JsValue): MultiPolygonFeature[D] =
-      readFeatureJson[D, MultiPolygon, MultiPolygonFeature[D]](json){MultiPolygonFeature.apply}
+      readFeatureJson[D, MultiPolygon](json)
   }
 
   implicit def multiPolygonFeatureWriter[D: JsonWriter] = new RootJsonWriter[MultiPolygonFeature[D]] {
@@ -171,8 +147,7 @@ trait FeatureFormats {
 
   implicit def multiPolygonFeatureFormat[D: JsonFormat] = new RootJsonFormat[MultiPolygonFeature[D]] {
     override def read(json: JsValue): MultiPolygonFeature[D] =
-      readFeatureJson[D, MultiPolygon, MultiPolygonFeature[D]](json){MultiPolygonFeature.apply}
-
+      readFeatureJson[D, MultiPolygon](json)
     override def write(obj: MultiPolygonFeature[D]): JsValue =
       writeFeatureJson(obj)
   }

--- a/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollection.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollection.scala
@@ -27,14 +27,14 @@ class JsonFeatureCollection(features: List[JsValue] = Nil) {
   private var buffer = features
 
   //-- Used for Serialization
-  def add[D: JsonWriter](feature: Feature[D]) =
-    buffer = writeFeatureJson[D](feature) :: buffer
-  def +=[D: JsonWriter](feature: Feature[D]) = add(feature)
+  def add[G <: Geometry, D: JsonWriter](feature: Feature[G, D]) =
+    buffer = writeFeatureJson(feature) :: buffer
+  def +=[G <: Geometry, D: JsonWriter](feature: Feature[G, D]) = add(feature)
 
-  def addAll[D: JsonWriter](features: Seq[Feature[D]]) =
-    features.foreach{ f => buffer = writeFeatureJson[D](f) :: buffer }
+  def addAll[G <: Geometry, D: JsonWriter](features: Seq[Feature[G, D]]) =
+    features.foreach{ f => buffer = writeFeatureJson(f) :: buffer }
 
-  def ++=[D: JsonWriter](features: Seq[Feature[D]]) = addAll(features)
+  def ++=[G <: Geometry, D: JsonWriter](features: Seq[Feature[G, D]]) = addAll(features)
 
   def add(geometry: Geometry) =
     buffer = geometry.toJson :: buffer
@@ -71,7 +71,7 @@ class JsonFeatureCollection(features: List[JsValue] = Nil) {
     ret.result()
   }
 
-  def getAllFeatures[F <: Feature[_] :JsonReader]: Vector[F] = 
+  def getAllFeatures[F <: Feature[_, _] :JsonReader]: Vector[F] = 
     getAll[F]
 
   def getAllPointFeatures[D: JsonReader]()         = getAll[PointFeature[D]]
@@ -93,7 +93,7 @@ class JsonFeatureCollection(features: List[JsValue] = Nil) {
 object JsonFeatureCollection{
   def apply() = new JsonFeatureCollection()
 
-  def apply[D: JsonWriter](features: Traversable[Feature[D]]) = {
+  def apply[G <: Geometry, D: JsonWriter](features: Traversable[Feature[G, D]]) = {
     val fc = new JsonFeatureCollection()
     fc ++= features.toList
     fc

--- a/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollectionMap.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollectionMap.scala
@@ -26,13 +26,13 @@ class JsonFeatureCollectionMap(features: List[JsValue] = Nil) {
   private var buffer = features
 
   //-- Used for Serialization
-  def add[D: JsonWriter](featureMap: (String, Feature[D])) =
-    buffer = writeFeatureJsonWithID[D](featureMap) :: buffer
-  def +=[D: JsonWriter](featureMap: (String, Feature[D])) = add(featureMap)
+  def add[G <: Geometry, D: JsonWriter](featureMap: (String, Feature[G, D])) =
+    buffer = writeFeatureJsonWithID(featureMap) :: buffer
+  def +=[G <: Geometry, D: JsonWriter](featureMap: (String, Feature[G, D])) = add(featureMap)
 
-  def addAll[D: JsonWriter](featureMaps: Seq[(String, Feature[D])]) =
-    featureMaps.foreach{ f => buffer = writeFeatureJsonWithID[D](f) :: buffer }
-  def ++=[D: JsonWriter](featureMaps: Seq[(String, Feature[D])]) = addAll(featureMaps)
+  def addAll[G <: Geometry, D: JsonWriter](featureMaps: Seq[(String, Feature[G, D])]) =
+    featureMaps.foreach{ f => buffer = writeFeatureJsonWithID(f) :: buffer }
+  def ++=[G <: Geometry, D: JsonWriter](featureMaps: Seq[(String, Feature[G, D])]) = addAll(featureMaps)
 
   def add(geometry: Geometry) =
     buffer = geometry.toJson :: buffer
@@ -77,7 +77,7 @@ class JsonFeatureCollectionMap(features: List[JsValue] = Nil) {
     ret.toMap
   }
 
-  def getAllFeatures[F <: Feature[_] :JsonReader]: Map[String, F] =
+  def getAllFeatures[F <: Feature[_, _] :JsonReader]: Map[String, F] =
     getAll[F]
 
   def getAllPointFeatures[D: JsonReader]()         = getAll[PointFeature[D]]
@@ -99,7 +99,7 @@ class JsonFeatureCollectionMap(features: List[JsValue] = Nil) {
 object JsonFeatureCollectionMap {
   def apply() = new JsonFeatureCollectionMap()
 
-  def apply[D: JsonWriter](features: Traversable[(String, Feature[D])]) = {
+  def apply[G <: Geometry, D: JsonWriter](features: Traversable[(String, Feature[G, D])]) = {
     val fc = new JsonFeatureCollectionMap()
     fc ++= features.toList
     fc

--- a/vector/src/main/scala/geotrellis/vector/io/json/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/package.scala
@@ -17,7 +17,7 @@ package object json extends GeoJsonSupport {
     }
   }
 
-  implicit class FeaturesToGeoJson[D: JsonWriter](features: Traversable[Feature[D]]) {
+  implicit class FeaturesToGeoJson[G <: Geometry, D: JsonWriter](features: Traversable[Feature[G, D]]) {
     def toGeoJson: String = {
       JsonFeatureCollection(features).toJson.compactPrint
     }
@@ -29,8 +29,8 @@ package object json extends GeoJsonSupport {
     def withCrs(crs: CRS) = WithCrs(geom, crs)
   }
 
-  implicit class RichFeature[D: JsonWriter](feature: Feature[D]){
-    def toGeoJson: String = writeFeatureJson[D](feature).compactPrint
+  implicit class RichFeature[G <: Geometry, D: JsonWriter](feature: Feature[G, D]){
+    def toGeoJson: String = writeFeatureJson(feature).compactPrint
 
     def withCrs(crs: CRS) = WithCrs(feature, crs)
   }

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -23,6 +23,15 @@ import scala.collection.JavaConversions._
 
 package object vector extends SeqMethods {
 
+  type PointFeature[D] = Feature[Point, D]
+  type LineFeature[D] = Feature[Line, D]
+  type PolygonFeature[D] = Feature[Polygon, D]
+  type MultiPointFeature[D] = Feature[MultiPoint, D]
+  type MultiLineFeature[D] = Feature[MultiLine, D]
+  type MultiPolygonFeature[D] = Feature[MultiPolygon, D]
+  type GeometryCollectionFeature[D] = Feature[GeometryCollection, D]
+
+
   implicit def tupleOfIntToPoint(t: (Double, Double)): Point =
     Point(t._1,t._2)
 
@@ -118,7 +127,4 @@ package object vector extends SeqMethods {
                        multiPoints, multiLines, multiPolygons,
                        geometryCollections)
   }
-
-  implicit def featureToGeometry(f: Feature[_]): Geometry = f.geom
-
 }

--- a/vector/src/main/scala/geotrellis/vector/reproject/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/reproject/package.scala
@@ -3,6 +3,8 @@ package geotrellis.vector
 import geotrellis.proj4._
 
 package object reproject {
+  type DI = DummyImplicit
+
   object Reproject {
     def apply(t: (Double, Double), src: CRS, dest: CRS): (Double, Double) =
       apply(t, Transform(src, dest))
@@ -16,10 +18,11 @@ package object reproject {
     def apply(p: Point, transform: Transform): Point =
       transform(p.x, p.y)
 
-    def apply[D](pf:PointFeature[D], src: CRS, dest: CRS): PointFeature[D] =
+    // For features, name explicitly, or else type erasure kicks in.
+    def pointFeature[D](pf: PointFeature[D], src: CRS, dest: CRS): PointFeature[D] =
       PointFeature[D](apply(pf.geom, src, dest), pf.data)
 
-    def apply[D](pf:PointFeature[D], transform: Transform): PointFeature[D] =
+    def pointFeature[D](pf: PointFeature[D], transform: Transform): PointFeature[D] =
       PointFeature[D](apply(pf.geom, transform), pf.data)
 
     def apply(l: Line, src: CRS, dest: CRS): Line =
@@ -28,10 +31,10 @@ package object reproject {
     def apply(l: Line, transform: Transform): Line =
       Line(l.points.map { p => transform(p.x, p.y) })
 
-    def apply[D](lf: LineFeature[D], src: CRS, dest: CRS): LineFeature[D] =
+    def lineFeature[D](lf: LineFeature[D], src: CRS, dest: CRS): LineFeature[D] =
       LineFeature(apply(lf.geom, src, dest), lf.data)
 
-    def apply[D](lf: LineFeature[D], transform: Transform): LineFeature[D] =
+    def lineFeature[D](lf: LineFeature[D], transform: Transform): LineFeature[D] =
       LineFeature(apply(lf.geom, transform), lf.data)
 
     def apply(p: Polygon, src: CRS, dest: CRS): Polygon = 
@@ -48,13 +51,13 @@ package object reproject {
       val f = Transform(src, dest)
       val sw = f(extent.xmin, extent.ymin)
       val ne = f(extent.xmax, extent.ymax)
-      Extent(sw._1,sw._2,ne._1,ne._2)
+      Extent(sw._1, sw._2, ne._1, ne._2)
     }
 
-    def apply[D](pf: PolygonFeature[D], src: CRS, dest: CRS): PolygonFeature[D] =
+    def polygonFeature[D](pf: PolygonFeature[D], src: CRS, dest: CRS): PolygonFeature[D] =
       PolygonFeature(apply(pf.geom, src, dest), pf.data)
 
-    def apply[D](pf: PolygonFeature[D], transform: Transform): PolygonFeature[D] =
+    def polygonFeature[D](pf: PolygonFeature[D], transform: Transform): PolygonFeature[D] =
       PolygonFeature(apply(pf.geom, transform), pf.data)
 
     def apply(mp: MultiPoint, src: CRS, dest: CRS): MultiPoint =
@@ -63,10 +66,10 @@ package object reproject {
     def apply(mp: MultiPoint, transform: Transform): MultiPoint =
       MultiPoint(mp.points.map { p => transform(p.x, p.y) })
 
-    def apply[D](mpf: MultiPointFeature[D], src: CRS, dest: CRS): MultiPointFeature[D] =
+    def multiPointFeature[D](mpf: MultiPointFeature[D], src: CRS, dest: CRS): MultiPointFeature[D] =
       MultiPointFeature(apply(mpf.geom, src, dest), mpf.data)
 
-    def apply[D](mpf: MultiPointFeature[D], transform: Transform): MultiPointFeature[D] =
+    def multiPointFeature[D](mpf: MultiPointFeature[D], transform: Transform): MultiPointFeature[D] =
       MultiPointFeature(apply(mpf.geom, transform), mpf.data)
 
     def apply(ml: MultiLine, src: CRS, dest: CRS): MultiLine =
@@ -75,10 +78,10 @@ package object reproject {
     def apply(ml: MultiLine, transform: Transform): MultiLine =
       MultiLine(ml.lines.map(apply(_, transform)))
 
-    def apply[D](mlf: MultiLineFeature[D], src: CRS, dest: CRS): MultiLineFeature[D] =
+    def multiLineFeature[D](mlf: MultiLineFeature[D], src: CRS, dest: CRS): MultiLineFeature[D] =
       MultiLineFeature(apply(mlf, src, dest), mlf.data)
 
-    def apply[D](mlf: MultiLineFeature[D], transform: Transform): MultiLineFeature[D] =
+    def multiLineFeature[D](mlf: MultiLineFeature[D], transform: Transform): MultiLineFeature[D] =
       MultiLineFeature(apply(mlf, transform), mlf.data)
 
     def apply(mp: MultiPolygon, src: CRS, dest: CRS): MultiPolygon =
@@ -87,10 +90,10 @@ package object reproject {
     def apply(mp: MultiPolygon, transform: Transform): MultiPolygon =
       MultiPolygon(mp.polygons.map(apply(_, transform)))
 
-    def apply[D](mpf: MultiPolygonFeature[D], src: CRS, dest: CRS): MultiPolygonFeature[D] =
+    def multiPolygonFeature[D](mpf: MultiPolygonFeature[D], src: CRS, dest: CRS): MultiPolygonFeature[D] =
       MultiPolygonFeature(apply(mpf.geom, src, dest), mpf.data)
 
-    def apply[D](mpf: MultiPolygonFeature[D], transform: Transform): MultiPolygonFeature[D] =
+    def multiPolygonFeature[D](mpf: MultiPolygonFeature[D], transform: Transform): MultiPolygonFeature[D] =
       MultiPolygonFeature(apply(mpf.geom, transform: Transform), mpf.data)
 
     def apply(gc: GeometryCollection, src: CRS, dest: CRS): GeometryCollection = 
@@ -116,10 +119,10 @@ package object reproject {
       )
 
 
-    def apply[D](gcf: GeometryCollectionFeature[D], src: CRS, dest: CRS): GeometryCollectionFeature[D] =
+    def geometryCollectionFeature[D](gcf: GeometryCollectionFeature[D], src: CRS, dest: CRS): GeometryCollectionFeature[D] =
       GeometryCollectionFeature(apply(gcf.geom, src, dest), gcf.data)
 
-    def apply[D](gcf: GeometryCollectionFeature[D], transform: Transform): GeometryCollectionFeature[D] =
+    def geometryCollectionFeature[D](gcf: GeometryCollectionFeature[D], transform: Transform): GeometryCollectionFeature[D] =
       GeometryCollectionFeature(apply(gcf.geom, transform), gcf.data)
 
     def apply(g: Geometry, src: CRS, dest: CRS): Geometry =
@@ -137,22 +140,22 @@ package object reproject {
       }
 
 
-    def apply[D](f: Feature[D], src: CRS, dest: CRS): Feature[D] =
-      apply(f, Transform(src, dest))
+    def geometryFeature[D](f: Feature[Geometry, D], src: CRS, dest: CRS): Feature[Geometry, D] =
+      geometryFeature(f, Transform(src, dest))
 
-    def apply[D](f: Feature[D], transform: Transform): Feature[D] =
-      f match {
-        case pf: PointFeature[D] => apply(pf, transform)
-        case lf: LineFeature[D] => apply(lf, transform)
-        case pf: PolygonFeature[D] => apply(pf, transform)
-        case mpf: MultiPointFeature[D] => apply(mpf, transform)
-        case mlf: MultiLineFeature[D] => apply(mlf, transform)
-        case mpf: MultiPolygonFeature[D] => apply(mpf, transform)
-        case gcf: GeometryCollectionFeature[D] => apply(gcf, transform)
+    def geometryFeature[D](f: Feature[Geometry, D], transform: Transform): Feature[Geometry, D] =
+      f.geom match {
+        case p: Point => pointFeature(Feature(p, f.data), transform)
+        case l: Line => lineFeature(Feature(l, f.data), transform)
+        case p: Polygon => polygonFeature(Feature(p, f.data), transform)
+        case mp: MultiPoint => multiPointFeature(Feature(mp, f.data), transform)
+        case ml: MultiLine => multiLineFeature(Feature(ml, f.data), transform)
+        case mp: MultiPolygon => multiPolygonFeature(Feature(mp, f.data), transform)
+        case gc: GeometryCollection => geometryCollectionFeature(Feature(gc, f.data), transform)
       }
   }
 
-  implicit class ReprojectTuple(t: (Double,Double)) { 
+  implicit class ReprojectTuple(t: (Double, Double)) { 
     def reproject(src: CRS, dest: CRS): (Double, Double) = Reproject(t, src, dest) 
     def reproject(transform: Transform): (Double, Double) = Reproject(t, transform) 
   }
@@ -163,8 +166,8 @@ package object reproject {
   }
 
   implicit class ReprojectPointFeature[D](pf: PointFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): PointFeature[D] = Reproject(pf, src, dest) 
-    def reproject(transform: Transform): PointFeature[D] = Reproject(pf, transform) 
+    def reproject(src: CRS, dest: CRS): PointFeature[D] = Reproject.pointFeature(pf, src, dest) 
+    def reproject(transform: Transform): PointFeature[D] = Reproject.pointFeature(pf, transform) 
   }
 
   implicit class ReprojectLine(l: Line) { 
@@ -173,8 +176,8 @@ package object reproject {
   }
 
   implicit class ReprojectLineFeature[D](lf: LineFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): LineFeature[D] = Reproject(lf, src, dest) 
-    def reproject(transform: Transform): LineFeature[D] = Reproject(lf, transform) 
+    def reproject(src: CRS, dest: CRS): LineFeature[D] = Reproject.lineFeature(lf, src, dest) 
+    def reproject(transform: Transform): LineFeature[D] = Reproject.lineFeature(lf, transform) 
   }
 
   implicit class ReprojectPolygon(p: Polygon) { 
@@ -188,8 +191,8 @@ package object reproject {
   }
 
   implicit class ReprojectPolygonFeature[D](pf: PolygonFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): PolygonFeature[D] = Reproject(pf, src, dest) 
-    def reproject(transform: Transform): PolygonFeature[D] = Reproject(pf, transform) 
+    def reproject(src: CRS, dest: CRS): PolygonFeature[D] = Reproject.polygonFeature(pf, src, dest) 
+    def reproject(transform: Transform): PolygonFeature[D] = Reproject.polygonFeature(pf, transform) 
   }
 
   implicit class ReprojectMultiPoint(mp: MultiPoint) { 
@@ -198,8 +201,8 @@ package object reproject {
   }
 
   implicit class ReprojectMultiPointFeature[D](mpf: MultiPointFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): MultiPointFeature[D] = Reproject(mpf, src, dest) 
-    def reproject(transform: Transform): MultiPointFeature[D] = Reproject(mpf, transform) 
+    def reproject(src: CRS, dest: CRS): MultiPointFeature[D] = Reproject.multiPointFeature(mpf, src, dest) 
+    def reproject(transform: Transform): MultiPointFeature[D] = Reproject.multiPointFeature(mpf, transform)
   }
 
   implicit class ReprojectMutliLine(ml: MultiLine) { 
@@ -208,8 +211,8 @@ package object reproject {
   }
 
   implicit class ReprojectMutliLineFeature[D](mlf: MultiLineFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): MultiLineFeature[D] = Reproject(mlf, src, dest) 
-    def reproject(transform: Transform): MultiLineFeature[D] = Reproject(mlf, transform) 
+    def reproject(src: CRS, dest: CRS): MultiLineFeature[D] = Reproject.multiLineFeature(mlf, src, dest) 
+    def reproject(transform: Transform): MultiLineFeature[D] = Reproject.multiLineFeature(mlf, transform) 
   }
 
   implicit class ReprojectMutliPolygon(mp: MultiPolygon) { 
@@ -218,8 +221,8 @@ package object reproject {
   }
 
   implicit class ReprojectMutliPolygonFeature[D](mpf: MultiPolygonFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): MultiPolygonFeature[D] = Reproject(mpf, src, dest) 
-    def reproject(transform: Transform): MultiPolygonFeature[D] = Reproject(mpf, transform) 
+    def reproject(src: CRS, dest: CRS): MultiPolygonFeature[D] = Reproject.multiPolygonFeature(mpf, src, dest) 
+    def reproject(transform: Transform): MultiPolygonFeature[D] = Reproject.multiPolygonFeature(mpf, transform)
   }
 
   implicit class ReprojectGeometryCollection(gc: GeometryCollection) { 
@@ -228,8 +231,8 @@ package object reproject {
   }
 
   implicit class ReprojectGeometryCollectionFeature[D](gcf: GeometryCollectionFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): GeometryCollectionFeature[D] = Reproject(gcf, src, dest) 
-    def reproject(transform: Transform): GeometryCollectionFeature[D] = Reproject(gcf, transform) 
+    def reproject(src: CRS, dest: CRS): GeometryCollectionFeature[D] = Reproject.geometryCollectionFeature(gcf, src, dest) 
+    def reproject(transform: Transform): GeometryCollectionFeature[D] = Reproject.geometryCollectionFeature(gcf, transform)
   }
 
   implicit class ReprojectGeometry(g: Geometry) { 
@@ -237,8 +240,8 @@ package object reproject {
     def reproject(transform: Transform): Geometry = Reproject(g, transform) 
   }
 
-  implicit class ReprojectFeature[D](f: Feature[D]) { 
-    def reproject(src: CRS, dest: CRS): Feature[D] = Reproject(f, src, dest) 
-    def reproject(transform: Transform): Feature[D] = Reproject(f, transform) 
+  implicit class ReprojectFeature[D](f: Feature[Geometry, D]) { 
+    def reproject(src: CRS, dest: CRS): Feature[Geometry, D] = Reproject.geometryFeature(f, src, dest) 
+    def reproject(transform: Transform): Feature[Geometry, D] = Reproject.geometryFeature(f, transform) 
   }
 }

--- a/vector/src/main/scala/geotrellis/vector/reproject/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/reproject/package.scala
@@ -3,8 +3,6 @@ package geotrellis.vector
 import geotrellis.proj4._
 
 package object reproject {
-  type DI = DummyImplicit
-
   object Reproject {
     def apply(t: (Double, Double), src: CRS, dest: CRS): (Double, Double) =
       apply(t, Transform(src, dest))


### PR DESCRIPTION
This PR changes `abstract class Feature[D] { type G <: Geometry }` into `case class Feature[G <: Geometry, D](...)`. This fell out of me wanting to write a simple `mapData` method, and the current type architecture not allowing me to. This mostly affects internal code; the API should remain the same as long as users use things like `PointFeature[D]`, etc.