### PR TITLE
geotrellis.vector API functionality: implicits for arrays and Result conversions

### DIFF
--- a/vector-test/src/test/scala/spec/geotrellis/vector/GeometryResultSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/GeometryResultSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.Matchers
 import geotrellis.vector.affine._
 
 class GeometryResultSpec extends FunSpec with Matchers {
-  describe("GeoetryResult") {
+  describe("GeometryResult") {
     it("should return Some(Geometry) for intersection") {
       val p = Polygon(Line(List[(Double,Double)]((0,0),(1,0),(1,1),(0,1),(0,0))))
       val p2 = p.translate(0.5, 0.5)
@@ -18,6 +18,30 @@ class GeometryResultSpec extends FunSpec with Matchers {
       val p = Polygon(Line(List[(Double,Double)]((0,0),(1,0),(1,1),(0,1),(0,0))))
       val p2 = p.translate(5.0, 5.0)
       (p & p2).toGeometry.isDefined should be (false)
+    }
+
+    it("should use asMultiLine to be able to union over a set of lines") {
+      val lines = 
+        Seq(
+          Line((0,0), (2,2)),
+          Line((1,1), (3,3)),
+          Line((0,2), (2,0))
+        )
+
+      val result = 
+        lines.foldLeft(None: Option[MultiLine]) { (union, line) =>
+          union match {
+            case Some(l1) => (l1 | line).asMultiLine
+            case None => Some(MultiLine(line))
+          }
+        }
+      result.isDefined should be (true)
+      result.get should be (
+        MultiLine(
+          Line((0,0), (3,3)),
+          Line((0,2), (2,0))
+        )
+      )
     }
   }
 }

--- a/vector/src/main/scala/geotrellis/vector/MultiLine.scala
+++ b/vector/src/main/scala/geotrellis/vector/MultiLine.scala
@@ -30,8 +30,18 @@ object MultiLine {
   def apply(ls: Line*): MultiLine = 
     MultiLine(ls)
 
-  def apply(ls: Traversable[Line])(implicit d: DummyImplicit): MultiLine = 
+  def apply(ls: Traversable[Line]): MultiLine = 
     MultiLine(factory.createMultiLineString(ls.map(_.jtsGeom).toArray))
+
+  def apply(ls: Array[Line]): MultiLine = {
+    val len = ls.length
+    val arr = Array.ofDim[jts.LineString](len)
+    cfor(0)(_ < len, _ + 1) { i =>
+      arr(i) = ls(i).jtsGeom
+    }
+
+    MultiLine(factory.createMultiLineString(arr))
+  }
 
   implicit def jts2MultiLine(jtsGeom: jts.MultiLineString): MultiLine = apply(jtsGeom)
 }

--- a/vector/src/main/scala/geotrellis/vector/MultiPoint.scala
+++ b/vector/src/main/scala/geotrellis/vector/MultiPoint.scala
@@ -31,6 +31,16 @@ object MultiPoint {
   def apply(ps: Traversable[Point]): MultiPoint =
     MultiPoint(factory.createMultiPoint(ps.map(_.jtsGeom).toArray))
 
+  def apply(ps: Array[Point]): MultiPoint = {
+    val len = ps.length
+    val arr = Array.ofDim[jts.Point](len)
+    cfor(0)(_ < len, _ + 1) { i =>
+      arr(i) = ps(i).jtsGeom
+    }
+
+    MultiPoint(factory.createMultiPoint(arr))
+  }
+
   def apply(ps: Traversable[(Double, Double)])(implicit d: DummyImplicit): MultiPoint =
     MultiPoint(factory.createMultiPoint(ps.map { p => new jts.Coordinate(p._1, p._2) }.toArray))
 

--- a/vector/src/main/scala/geotrellis/vector/MultiPolygon.scala
+++ b/vector/src/main/scala/geotrellis/vector/MultiPolygon.scala
@@ -32,6 +32,16 @@ object MultiPolygon {
   def apply(ps: Traversable[Polygon]): MultiPolygon =
     MultiPolygon(factory.createMultiPolygon(ps.map(_.jtsGeom).toArray))
 
+  def apply(ps: Array[Polygon]): MultiPolygon = {
+    val len = ps.length
+    val arr = Array.ofDim[jts.Polygon](len)
+    cfor(0)(_ < len, _ + 1) { i =>
+      arr(i) = ps(i).jtsGeom
+    }
+
+    MultiPolygon(factory.createMultiPolygon(arr))
+  }
+
   implicit def jts2MultiPolygon(jtsGeom: jts.MultiPolygon): MultiPolygon = apply(jtsGeom)
 }
 

--- a/vector/src/main/scala/geotrellis/vector/Polygon.scala
+++ b/vector/src/main/scala/geotrellis/vector/Polygon.scala
@@ -26,6 +26,9 @@ object Polygon {
   implicit def jtsToPolygon(jtsGeom: jts.Polygon): Polygon =
     Polygon(jtsGeom)
 
+  def apply(exterior: Seq[Point]): Polygon =
+    apply(Line(exterior), Set())
+
   def apply(exterior: Line): Polygon =
     apply(exterior, Set())
 

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -88,10 +88,13 @@ package object vector extends SeqMethods {
   }
 
   implicit def seqPointToMultiPoint(ps: Seq[Point]): MultiPoint = MultiPoint(ps)
+  implicit def arrayPointToMultiPoint(ps: Array[Point]): MultiPoint = MultiPoint(ps)
 
   implicit def seqLineToMultiLine(ps: Seq[Line]): MultiLine = MultiLine(ps)
+  implicit def arrayLineToMultiLine(ps: Array[Line]): MultiLine = MultiLine(ps)
 
   implicit def seqPolygonToMultiPolygon(ps: Seq[Polygon]): MultiPolygon = MultiPolygon(ps)
+  implicit def arrayPolygonToMultiPolygon(ps: Array[Polygon]): MultiPolygon = MultiPolygon(ps)
 
   implicit def seqGeometryToGeometryCollection(gs: Seq[Geometry]): GeometryCollection = {
     val points = mutable.ListBuffer[Point]()


### PR DESCRIPTION
This adds implicits of Arrays of Point, Line, and Polygon to MultiPoint, MultiLine, and MultiPolygon.

It also adds methods on GeometryResult that aims to make extracting expected geometry types out of operation results.