### PR TITLE
Set a more precise WebMercator world extent.

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/tiling/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/package.scala
@@ -39,14 +39,12 @@ package object tiling {
   implicit class CRSWorldExtent(crs: CRS) {
     def worldExtent: Extent =
       crs match {
-        case LatLng =>
+        case x if x == LatLng =>
           WORLD_WSG84
-        case WebMercator =>
-          Extent(-180, -85.05, 179.99999, 85.05).reproject(LatLng, WebMercator)
+        case x if x == WebMercator =>
+          Extent(-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244)
         case _ =>
           WORLD_WSG84.reproject(LatLng, crs)
       }
-
   }
-
 }


### PR DESCRIPTION
This is what gdal2tiles uses, see here for an explanation: https://github.com/pramsey/gdal2tilesp/blob/master/gdal2tilesp.py#L141