### PR TITLE
Removing sigar dependency

### DIFF
--- a/dev/build.sbt
+++ b/dev/build.sbt
@@ -1,6 +1,4 @@
 import Dependencies._
 
-libraryDependencies += sigar
 Keys.fork in run := true
 fork := true
-javaOptions in run += "-Djava.library.path=./sigar"

--- a/dev/src/main/scala/geotrellis/dev/RemoteClient.scala
+++ b/dev/src/main/scala/geotrellis/dev/RemoteClient.scala
@@ -58,7 +58,7 @@ import akka.cluster.ClusterEvent.MemberUp
 import akka.serialization._
 
 class RemoteClientApplication extends Bootable {
-  val server = new Engine("remoteEngine", Catalog.fromPath("raster-test/data/catalog.json"))
+  val server = new Engine("remoteEngine", Catalog.fromPath("../raster-test/data/catalog.json"))
   val router = server.getRouter()
 
   def startup() {

--- a/dev/src/main/scala/geotrellis/dev/RemoteServer.scala
+++ b/dev/src/main/scala/geotrellis/dev/RemoteServer.scala
@@ -49,7 +49,7 @@ class RemoteServerApplication extends Bootable {
   val id = "remoteServer"
 
   println()
-  val f = new java.io.File( "raster-test/data/catalog.json" ).getCanonicalPath
+  val f = new java.io.File( "../raster-test/data/catalog.json" ).getCanonicalPath
   println(f)
   //val f = "src/test/resources/catalog.json"
   val server = new Engine(id, Catalog.fromPath(f))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,6 @@ object Dependencies {
   val logging       = "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
   val scalatest     = "org.scalatest"       %%  "scalatest"      % "2.2.0"
   val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.11.1"
-  val sigar         = "org.hyperic"         %  "sigar"           % "1.6.4"
   val jts           = "com.vividsolutions"  %  "jts"             % "1.13"
 
   val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"    % Version.monocle


### PR DESCRIPTION
This is an optional dependency to get Akka cluster metrics. It seems to no longer be available with the old org id on maven central. Dropping it now to fix the build.