### PR TITLE
Add support for additional projections in geotiffs

### DIFF
--- a/proj4/src/main/scala/geotrellis/proj4/CRS.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/CRS.scala
@@ -97,12 +97,6 @@ object CRS {
   }
 
   private def readEPSGCodeFromFile(proj4String: String): Option[String] = {
-    def code(line: String): Option[String] = {
-      val array = line.split(" ")
-      val length = array(0).length
-      Some(array(0).substring(1, length - 1))
-    }
-
     Source.fromFile(s"${filePrefix}epsg")
       .getLines
       .find { line =>
@@ -110,9 +104,10 @@ object CRS {
         val proj4Body = line.split("proj")(1)
         s"+proj$proj4Body" == proj4String
       }
-    }.map { line => code(line) } match {
-      case Some(value) => value
-      case None => throw new NotFoundException(s"The EPSG code cannot be found for the proj4 string $proj4String")
+    }.flatMap { l =>
+        val array = l.split(" ")
+        val length = array(0).length
+        Some(array(0).substring(1, length - 1))
     }
   }
 }

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -190,8 +190,8 @@ class GeoTiffReaderSpec extends FunSpec
         case None => fail
       }
 
-      val sampleFormat = 
-        (tiffTags 
+      val sampleFormat =
+        (tiffTags
           &|-> TiffTags._dataSampleFormatTags
           ^|-> DataSampleFormatTags._sampleFormat get)
       sampleFormat should be (3)
@@ -311,6 +311,29 @@ class GeoTiffReaderSpec extends FunSpec
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
 
       crs should equal(correctCRS)
+    }
+
+    it("should read ndvi-web-mercator.tif CS correctly") {
+      val crs = SingleBandGeoTiff.compressed(geoTiffPath("ndvi-web-mercator.tif")).crs
+
+      val correctCRS = CRS.fromString("+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs")
+
+      crs.toProj4String should equal(correctCRS.toProj4String)
+    }
+
+    it("should read ny-state-plane.tif CS correctly") {
+      val crs = SingleBandGeoTiff.compressed(geoTiffPath("ny-state-plane.tif")).crs
+
+      val correctCRS = CRS.fromString("+proj=tmerc +lat_0=40 +lon_0=-74.33333333333333 +k=0.999966667 +x_0=152400.3048006096 +y_0=0 +datum=NAD27 +units=us-ft +no_defs ")
+
+      crs.toProj4String should equal(correctCRS.toProj4String)
+    }
+
+    it("should read alaska-polar-3572.tif CS correctly") {
+      val crs = SingleBandGeoTiff.compressed(geoTiffPath("alaska-polar-3572.tif")).crs
+
+      val correctCRS = CRS.fromString("+proj=laea +lat_0=90 +lon_0=-150 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ")
+      crs.toProj4String should equal(correctCRS.toProj4String)
     }
 
   }

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -38,10 +38,7 @@ class GeoTiffWriterSpec extends FunSpec
 
   override def afterAll = purge
 
-  private val testProj4String =
-    "+proj=lcc +lat_0=33.750000000 +lon_0=-79.000000000 +lat_1=36.166666667 +lat_2=34.333333333 +x_0=609601.220 +y_0=0.000 +units=m"
-
-  private val testCRS = CRS.fromString(testProj4String)
+  private val testCRS = CRS.fromName("EPSG:3857")
 
   describe ("writing GeoTiffs without errors and with correct tiles, crs and extent") {
 
@@ -59,6 +56,38 @@ class GeoTiffWriterSpec extends FunSpec
       actual should be (expected)
     }
 
+    it("should write web mercator correctly") {
+      val path = "/tmp/geotiff-writer.tif"
+      val geoTiff = SingleBandGeoTiff(geoTiffPath("ndvi-web-mercator.tif"))
+
+      addToPurge(path)
+      geoTiff.write(path)
+      val actualCRS = SingleBandGeoTiff(path).crs
+
+      actualCRS.epsgCode should be (geoTiff.crs.epsgCode)
+    }
+
+    it("should write NY State Plane correctly") {
+      val path = "/tmp/geotiff-writer.tif"
+      val geoTiff = SingleBandGeoTiff(geoTiffPath("ny-state-plane.tif"))
+
+      addToPurge(path)
+      geoTiff.write(path)
+      val actualCRS = SingleBandGeoTiff(path).crs
+
+      actualCRS.epsgCode should be (geoTiff.crs.epsgCode)
+    }
+
+    it ("should write Polar stereographic correctly") {
+      val path = "/tmp/geotiff-writer.tif"
+      val geoTiff = SingleBandGeoTiff(geoTiffPath("alaska-polar-3572.tif"))
+
+      addToPurge(path)
+      geoTiff.write(path)
+      val actualCRS = SingleBandGeoTiff(path).crs
+
+      actualCRS.epsgCode should be (geoTiff.crs.epsgCode)
+    }
 
     it ("should write floating point rasters correct") {
       val e = Extent(100.0, 400.0, 120.0, 420.0)
@@ -92,7 +121,7 @@ class GeoTiffWriterSpec extends FunSpec
       addToPurge(path)
 
       val SingleBandGeoTiff(actualTile, actualExtent, actualCrs, _) = SingleBandGeoTiff(path)
-      
+
       actualExtent should equal (extent)
       crs should equal (LatLng)
       assertEqual(actualTile, tile)
@@ -108,7 +137,7 @@ class GeoTiffWriterSpec extends FunSpec
       addToPurge(path)
 
       val gt = MultiBandGeoTiff(path)
-      
+
       gt.extent should equal (geoTiff.extent)
       gt.crs should equal (geoTiff.crs)
       gt.tile.bandCount should equal (geoTiff.tile.bandCount)
@@ -137,7 +166,7 @@ class GeoTiffWriterSpec extends FunSpec
       addToPurge(path)
 
       val gt = MultiBandGeoTiff(path)
-      
+
       gt.extent should equal (geoTiff.extent)
       gt.crs should equal (geoTiff.crs)
       gt.tile.bandCount should equal (tile.bandCount)
@@ -162,7 +191,7 @@ class GeoTiffWriterSpec extends FunSpec
       val bytes = GeoTiffWriter.write(geoTiff)
 
       val gt = MultiBandGeoTiff(bytes)
-      
+
       gt.extent should equal (geoTiff.extent)
       gt.crs should equal (geoTiff.crs)
       gt.tile.bandCount should equal (tile.bandCount)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffCSParser.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffCSParser.scala
@@ -78,6 +78,8 @@ class GeoTiffCSParser(directory: TiffTags) {
 
   def getProj4String: Option[String] = getProj4String(createGeoTiffGDALParameters)
 
+  lazy val pcs: Int = createGeoTiffGDALParameters.pcs
+
   private def createGeoTiffGDALParameters: GeoTiffGDALParameters = {
     val gtgp = GeoTiffGDALParameters()
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyConstants.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyConstants.scala
@@ -1975,6 +1975,8 @@ object ProjectionTypesMap {
   import EPSGProjectionTypes._
   import GDALEPSGProjectionTypes._
 
+  val UserDefinedProjectionType = 32767
+
   val projectionTypesMap = HashMap[Int, Int](
     PCS_NAD83_Alabama_East -> Proj_Alabama_CS83_East,
     PCS_NAD83_Alabama_West -> Proj_Alabama_CS83_West,

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyDirectory.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyDirectory.scala
@@ -1,5 +1,6 @@
 package geotrellis.raster.io.geotiff.tags
 
+import ProjectionTypesMap._
 import geotrellis.raster.io.geotiff.reader.MalformedGeoTiffException
 import geotrellis.raster.io.geotiff.utils._
 
@@ -96,7 +97,7 @@ case class GeogCSParameterKeys(
 
 @Lenses("_")
 case class ProjectedCSParameterKeys(
-  projectedCSType: Int = -1,
+  projectedCSType: Int = UserDefinedProjectionType,
   pcsCitation: Option[Array[String]] = None,
   projection: Option[Int] = None,
   projCoordTrans: Option[Int] = None,

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
@@ -196,15 +196,15 @@ case class TiffTags(
     }
   }
 
-  def pcs: Int = try {
+  def projectedCoordinateSystem: Int = try {
     GeoTiffCSTags.pcs
   } catch {
     case e: Exception => 32767
   }
 
   lazy val crs: CRS = {
-    if (pcs != 32767) {
-      CRS.fromName(s"EPSG:${pcs}")
+    if (projectedCoordinateSystem != 32767) {
+      CRS.fromName(s"EPSG:${projectedCoordinateSystem}")
     } else {
       proj4String match {
         case Some(s) => CRS.fromString(s)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -32,7 +32,7 @@ case class TiffTagFieldValue(
 }
 
 object TiffTagFieldValue {
-  def apply(tag: Int, fieldType: Int, length: Int, value: Int)(implicit toBytes: ToBytes): TiffTagFieldValue = 
+  def apply(tag: Int, fieldType: Int, length: Int, value: Int)(implicit toBytes: ToBytes): TiffTagFieldValue =
     fieldType match {
       case ShortsFieldType => TiffTagFieldValue(tag, fieldType, length, toBytes(value.toShort))
       case IntsFieldType => TiffTagFieldValue(tag, fieldType, length, toBytes(value))
@@ -80,8 +80,7 @@ object TiffTagFieldValue {
     fieldValues += TiffTagFieldValue(ModelTiePointsTag, DoublesFieldType, 6, toBytes(Array(0.0, 0.0, 0.0, extent.xmin, extent.ymax, 0.0)))
 
     // GeoKeyDirectory: Tags that describe the CRS
-
-    val GeoDirectoryTags(shortGeoKeys, doubleGeoKeys) = Proj4StringParser.parse(geoTiff.crs.toProj4String)
+    val GeoDirectoryTags(shortGeoKeys, doubleGeoKeys) = CoordinateSystemParser.parse(geoTiff.crs)
 
     // Write the short values of the GeoKeyDirectory
     val shortValues = Array.ofDim[Short]( (shortGeoKeys.length + 1) * 4)
@@ -117,13 +116,13 @@ object TiffTagFieldValue {
           fieldValues += TiffTagFieldValue(TileWidthTag, IntsFieldType, 1, toBytes(tileCols))
           fieldValues += TiffTagFieldValue(TileLengthTag, IntsFieldType, 1, toBytes(tileRows))
           fieldValues += TiffTagFieldValue(TileByteCountsTag, IntsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
-          
+
           { offsets: Array[Int] => TiffTagFieldValue(TileOffsetsTag, IntsFieldType, offsets.length, toBytes(offsets)) }
         case s: Striped =>
           val rowsPerStrip = imageData.segmentLayout.tileLayout.tileRows
           fieldValues += TiffTagFieldValue(RowsPerStripTag, IntsFieldType, 1, toBytes(rowsPerStrip))
           fieldValues += TiffTagFieldValue(StripByteCountsTag, IntsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
-          
+
           { offsets: Array[Int] => TiffTagFieldValue(StripOffsetsTag, IntsFieldType, offsets.length, toBytes(offsets)) }
       }
 


### PR DESCRIPTION
This commit improves support for projections when reading and writing
GeoTiffs. Before this commit, it looks as though almost all projections
were read as custom user projections, ignoring and not setting the
`ProjectedCSTypeGeoKey` properly in the process. In the suggestions for
geocoding rasters in the GeoTiff spec, if this code is set (e.g. an EPSG
code) then other parameters are unecessary.

This commit adds support for reading/writing the `ProjectedCSTypeGeoKey`
value properly to enable reading/writing projections like EPSG:3857 (web
-mercator) properly. Tests have been added for this purpose.

In the process of writing this task, I found
http://download.osgeo.org/pub/geotiff/samples/README which describes
additional GeoTiffs GeoTrellis should aim to support reading/writing
with to be on par with GDAL.