### PR TITLE
Fixes to Bilinear, type conversion macro fix

### DIFF
--- a/macros/src/main/scala/geotrellis/macros/TypeConversionMacros.scala
+++ b/macros/src/main/scala/geotrellis/macros/TypeConversionMacros.scala
@@ -6,107 +6,107 @@ object TypeConversionMacros {
 
   def b2s_impl(c: Context)(n: c.Expr[Byte]): c.Expr[Short] = {
     import c.universe._
-    c.Expr(q"""if($n == Byte.MinValue) { Short.MinValue } else { ${n}.toShort }""")
+    c.Expr(q"""{ val n = $n ; if(n == Byte.MinValue) { Short.MinValue } else { n.toShort } }""")
   }
 
   def b2i_impl(c: Context)(n: c.Expr[Byte]): c.Expr[Int] = {
     import c.universe._
-    c.Expr(q"""if($n == Byte.MinValue) { Int.MinValue } else { ${n}.toInt }""")
+    c.Expr(q"""{ val n = $n ; if(n == Byte.MinValue) { Int.MinValue } else { n.toInt } }""")
   }
 
   def b2f_impl(c: Context)(n: c.Expr[Byte]): c.Expr[Float] = {
     import c.universe._
-    c.Expr(q"""if($n == Byte.MinValue) { Float.NaN } else { ${n}.toFloat }""")
+    c.Expr(q"""{ val n = $n ; if(n == Byte.MinValue) { Float.NaN } else { $n.toFloat } }""")
   }
 
   def b2d_impl(c: Context)(n: c.Expr[Byte]): c.Expr[Double] = {
     import c.universe._
-    c.Expr(q"""if($n == Byte.MinValue) { Double.NaN } else { ${n}.toDouble }""")
+    c.Expr(q"""{ val n = $n ; if(n == Byte.MinValue) { Double.NaN } else { n.toDouble } }""")
   }
 
 
 
   def s2b_impl(c: Context)(n: c.Expr[Short]): c.Expr[Byte] = {
     import c.universe._
-    c.Expr(q"""if($n == Short.MinValue) { Byte.MinValue } else { ${n}.toByte }""")
+    c.Expr(q"""{ val n = $n ; if(n == Short.MinValue) { Byte.MinValue } else { n.toByte } }""")
   }
 
   def s2i_impl(c: Context)(n: c.Expr[Short]): c.Expr[Int] = {
     import c.universe._
-    c.Expr(q"""if($n == Short.MinValue) { Int.MinValue } else { ${n}.toInt }""")
+    c.Expr(q"""{ val n = $n ; if(n == Short.MinValue) { Int.MinValue } else { n.toInt } }""")
   }
 
   def s2f_impl(c: Context)(n: c.Expr[Short]): c.Expr[Float] = {
     import c.universe._
-    c.Expr(q"""if($n == Short.MinValue) { Float.NaN } else { ${n}.toFloat }""")
+    c.Expr(q"""{ val n = $n ; if(n == Short.MinValue) { Float.NaN } else { n.toFloat } }""")
   }
 
   def s2d_impl(c: Context)(n: c.Expr[Short]): c.Expr[Double] = {
     import c.universe._
-    c.Expr(q"""if($n == Short.MinValue) { Double.NaN } else { ${n}.toDouble }""")
+    c.Expr(q"""{ val n = $n ; if(n == Short.MinValue) { Double.NaN } else { n.toDouble } }""")
   }
 
 
   def i2b_impl(c: Context)(n: c.Expr[Int]): c.Expr[Byte] = {
     import c.universe._
-    c.Expr(q"""if($n == Int.MinValue) { Byte.MinValue } else { ${n}.toByte }""")
+    c.Expr(q"""{ val n = $n ; if(n == Int.MinValue) { Byte.MinValue } else { n.toByte } }""")
   }
 
   def i2s_impl(c: Context)(n: c.Expr[Int]): c.Expr[Short] = {
     import c.universe._
-    c.Expr(q"""if($n == Int.MinValue) { Short.MinValue } else { ${n}.toShort }""")
+    c.Expr(q"""{ val n = $n ; if(n == Int.MinValue) { Short.MinValue } else { n.toShort } }""")
   }
 
   def i2f_impl(c: Context)(n: c.Expr[Int]): c.Expr[Float] = {
     import c.universe._
-    c.Expr(q"""if($n == Int.MinValue) { Float.NaN } else { ${n}.toFloat }""")
+    c.Expr(q"""{ val n = $n ; if(n == Int.MinValue) { Float.NaN } else { n.toFloat } }""")
   }
 
   def i2d_impl(c: Context)(n: c.Expr[Int]): c.Expr[Double] = {
     import c.universe._
-    c.Expr(q"""if($n == Int.MinValue) { Double.NaN } else { ${n}.toDouble }""")
+    c.Expr(q"""{ val n = $n ; if(n == Int.MinValue) { Double.NaN } else { n.toDouble } }""")
   }
 
 
   def f2b_impl(c: Context)(n: c.Expr[Float]): c.Expr[Byte] = {
     import c.universe._
-    c.Expr(q"""if(java.lang.Float.isNaN($n)) { Byte.MinValue } else { ${n}.toByte }""")
+    c.Expr(q"""{ val n = $n ; if(java.lang.Float.isNaN(n)) { Byte.MinValue } else { n.toByte } }""")
   }
 
   def f2s_impl(c: Context)(n: c.Expr[Float]): c.Expr[Short] = {
     import c.universe._
-    c.Expr(q"""if(java.lang.Float.isNaN($n)) { Short.MinValue } else { ${n}.toShort }""")
+    c.Expr(q"""{ val n = $n ; if(java.lang.Float.isNaN(n)) { Short.MinValue } else { n.toShort } }""")
   }
 
   def f2i_impl(c: Context)(n: c.Expr[Float]): c.Expr[Int] = {
     import c.universe._
-    c.Expr(q"""if(java.lang.Float.isNaN($n)) { Int.MinValue } else { ${n}.toInt }""")
+    c.Expr(q"""{ val n = $n ; if(java.lang.Float.isNaN(n)) { Int.MinValue } else { n.toInt } }""")
   }
 
   def f2d_impl(c: Context)(n: c.Expr[Float]): c.Expr[Double] = {
     import c.universe._
-    c.Expr(q"""if(java.lang.Float.isNaN($n)) { Double.NaN } else { ${n}.toDouble }""")
+    c.Expr(q"""{ val n = $n ; if(java.lang.Float.isNaN(n)) { Double.NaN } else { n.toDouble } }""")
   }
 
 
   def d2b_impl(c: Context)(n: c.Expr[Double]): c.Expr[Byte] = {
     import c.universe._
-    c.Expr(q"""if(java.lang.Double.isNaN($n)) { Byte.MinValue } else { ${n}.toByte }""")
+    c.Expr(q"""{ val n = $n ; if(java.lang.Double.isNaN(n)) { Byte.MinValue } else { n.toByte } }""")
   }
 
   def d2s_impl(c: Context)(n: c.Expr[Double]): c.Expr[Short] = {
     import c.universe._
-    c.Expr(q"""if(java.lang.Double.isNaN($n)) { Short.MinValue } else { ${n}.toShort }""")
+    c.Expr(q"""{ val n = $n ; if(java.lang.Double.isNaN(n)) { Short.MinValue } else { n.toShort } }""")
   }
 
   def d2i_impl(c: Context)(n: c.Expr[Double]): c.Expr[Int] = {
     import c.universe._
-    c.Expr(q"""if(java.lang.Double.isNaN($n)) { Int.MinValue } else { ${n}.toInt }""")
+    c.Expr(q"""{ val n = $n ; if(java.lang.Double.isNaN(n)) { Int.MinValue } else { n.toInt } }""")
   }
 
   def d2f_impl(c: Context)(n: c.Expr[Double]): c.Expr[Float] = {
     import c.universe._
-    c.Expr(q"""if(java.lang.Double.isNaN($n)) { Float.NaN } else { ${n}.toFloat }""")
+    c.Expr(q"""{ val n = $n ; if(java.lang.Double.isNaN(n)) { Float.NaN } else { n.toFloat } }""")
   }
 
 }

--- a/raster/src/main/scala/geotrellis/raster/resample/BilinearResample.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/BilinearResample.scala
@@ -42,18 +42,20 @@ class BilinearResample(tile: Tile, extent: Extent)
     (leftCol, topRow, xRatio, yRatio)
   }
 
-  def bilinearInt(leftCol: Int, topRow: Int, xRatio: Double, yRatio: Double): Int =
-    d2i(bilinearDouble(leftCol, topRow, xRatio, yRatio))
+  def bilinearInt(leftCol: Int, topRow: Int, xRatio: Double, yRatio: Double): Int = {
+    val v = bilinear(leftCol, topRow, xRatio, yRatio)
+    if(isData(v)) { math.round(v).toInt }
+    else NODATA
+  }
 
   def bilinearDouble(leftCol: Int, topRow: Int, xRatio: Double, yRatio: Double): Double =
-    bilinear(leftCol, topRow, xRatio, yRatio, tile.getDouble)
+    bilinear(leftCol, topRow, xRatio, yRatio)
 
   private def bilinear(
     leftCol: Int,
     topRow: Int,
     xRatio: Double,
-    yRatio: Double,
-    f: (Int, Int) => Double): Double = {
+    yRatio: Double): Double = {
     val (rightCol, bottomRow) = (leftCol + 1, topRow + 1)
     val (invXR, invYR) = (1 - xRatio, 1 - yRatio)
 
@@ -61,38 +63,38 @@ class BilinearResample(tile: Tile, extent: Extent)
     var accumDivisor = 0.0
 
     if (leftCol >= 0 && topRow >= 0 && leftCol < cols && topRow < rows) {
-      val z = f(leftCol, topRow)
+      val z = tile.getDouble(leftCol, topRow)
       if(isData(z)) {
         val mult = invXR * invYR
         accumDivisor += mult
-        accum += f(leftCol, topRow) * mult
+        accum += z * mult
       }
     }
 
     if (rightCol >= 0 && topRow >= 0 && rightCol < cols && topRow < rows) {
-      val z = f(rightCol, topRow)
+      val z = tile.getDouble(rightCol, topRow)
       if(isData(z)) {
         val mult = (1 - invXR) * invYR
         accumDivisor += mult
-        accum += f(rightCol, topRow) * mult
+        accum += z * mult
       }
     }
 
     if (leftCol >= 0 && bottomRow >= 0 && leftCol < cols && bottomRow < rows) {
-      val z = f(leftCol, bottomRow)
+      val z = tile.getDouble(leftCol, bottomRow)
       if(isData(z)) {
         val mult = invXR * (1 - invYR)
         accumDivisor += mult
-        accum += f(leftCol, bottomRow) * mult
+        accum += z * mult
       }
     }
 
     if (rightCol >= 0 && bottomRow >= 0 && rightCol < cols && bottomRow < rows) {
-      val z = f(rightCol, bottomRow)
+      val z = tile.getDouble(rightCol, bottomRow)
       if(isData(z)) {
         val mult = (1 - invXR) * (1 - invYR)
         accumDivisor += mult
-        accum += f(rightCol, bottomRow) * mult
+        accum += z * mult
       }
     }
 

--- a/raster/src/main/scala/geotrellis/raster/resample/CubicResample.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/CubicResample.scala
@@ -46,8 +46,9 @@ abstract class CubicResample(tile: Tile, extent: Extent, dimension: Int)
 
   override def resampleValid(x: Double, y: Double): Int = {
     val (leftCol, topRow, xRatio, yRatio) = resolveTopLeftCoordsAndRatios(x, y)
-    if (!validCubicCoords(leftCol, topRow)) bilinearInt(leftCol, topRow, xRatio, yRatio)
-    else {
+    if (!validCubicCoords(leftCol, topRow)) {
+      bilinearInt(leftCol, topRow, xRatio, yRatio)
+    } else {
       setCubicValues(leftCol, topRow, tile.get)
       cubicResample(cubicTile, xRatio, yRatio).round.toInt
     }
@@ -55,8 +56,9 @@ abstract class CubicResample(tile: Tile, extent: Extent, dimension: Int)
 
   override def resampleDoubleValid(x: Double, y: Double): Double = {
     val (leftCol, topRow, xRatio, yRatio) = resolveTopLeftCoordsAndRatios(x, y)
-    if (!validCubicCoords(leftCol, topRow)) bilinearDouble(leftCol, topRow, xRatio, yRatio)
-    else {
+    if (!validCubicCoords(leftCol, topRow)) {
+      bilinearDouble(leftCol, topRow, xRatio, yRatio)
+    } else {
       setCubicValues(leftCol, topRow, tile.getDouble)
       cubicResample(cubicTile, xRatio, yRatio)
     }


### PR DESCRIPTION
- In TypeConversionMacros, like `d2i`, there was an issue with the Expression possibly being evaluated twice. Capture the expression result in a `val` to prevent this.

- Fix to bilinear, it should round a double value instead of taking floor.