### PR TITLE
Fix Reading GeoTiff NoData tags <= 4 bytes

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/utils/ByteBufferExtensions.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/utils/ByteBufferExtensions.scala
@@ -120,7 +120,7 @@ trait ByteBufferExtensions {
       if (length <= 4) {
         val bb = ByteBuffer.allocate(4).order(byteBuffer.order).putInt(0, offset)
         cfor(0)( _ < length, _ + 1) { i =>
-          sb.append(byteBuffer.get.toChar)
+          sb.append(bb.get.toChar)
         }
       } else {
         val oldPos = byteBuffer.position


### PR DESCRIPTION
When a tiff tag value is less than or equal to four bytes the offset (int32) of the tag metadata contains the actual value rather then the byte offset of where the value is written.

For instance a common NoData value of "0" would be encoded as count=2 offset=48

In this case we read the wrong ByteBuffer looking for the value.