### PR TITLE
scalaz-streams to 0.8

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,7 +59,7 @@ object Dependencies {
 
   val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.9.34"
 
-  val scalazStream  = "org.scalaz.stream" %% "scalaz-stream" % "0.7a"
+  val scalazStream  = "org.scalaz.stream" %% "scalaz-stream" % "0.8"
 
   val sparkCore     = "org.apache.spark" %% "spark-core" % Version.spark
   val hadoopClient  = "org.apache.hadoop" % "hadoop-client" % Version.hadoop

--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -15,7 +15,6 @@ libraryDependencies ++= Seq(
   nscalaTime,
   scalazStream,
   scalatest % "test")
-resolvers += "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases"
 
 fork := true
 parallelExecution in Test := false


### PR DESCRIPTION
It is now published to maven central, so we can remove a resolver.