### PR TITLE
GeoTiff Byte NoData handling

### DIFF
--- a/project/Environment.scala
+++ b/project/Environment.scala
@@ -22,7 +22,7 @@ object Environment {
 
   lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.2.0")
   lazy val sparkVersion   = either("SPARK_VERSION", "1.4.1")
-  lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-SNAPSHOT")
+  lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-97834e6")
 
   lazy val javaGdalDir    = either("JAVA_GDAL_DIR", "/usr/local/lib")
 }

--- a/project/Environment.scala
+++ b/project/Environment.scala
@@ -22,7 +22,7 @@ object Environment {
 
   lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.2.0")
   lazy val sparkVersion   = either("SPARK_VERSION", "1.4.1")
-  lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-97834e6")
+  lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-SNAPSHOT")
 
   lazy val javaGdalDir    = either("JAVA_GDAL_DIR", "/usr/local/lib")
 }

--- a/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
@@ -44,7 +44,8 @@ object ByteArrayTile {
         val v = bytes(i)
         if(v == replaceNoData)
           arr(i) = byteNODATA
-        arr(i) = bytes(i)
+        else
+          arr(i) = bytes(i)
       }
       ByteArrayTile(arr, cols, rows)
     }

--- a/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
@@ -45,7 +45,7 @@ object ByteArrayTile {
         if(v == replaceNoData)
           arr(i) = byteNODATA
         else
-          arr(i) = bytes(i)
+          arr(i) = v
       }
       ByteArrayTile(arr, cols, rows)
     }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffSegment.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffSegment.scala
@@ -11,12 +11,11 @@ import spire.syntax.cfor._
 
 class NoDataByteGeoTiffSegment(bytes: Array[Byte], noDataValue: Byte) extends ByteGeoTiffSegment(bytes) {
   override
-  def get(i: Int): Int =
+  def get(i: Int): Byte =
     if (bytes(i) == noDataValue)
-      NODATA
+      byteNODATA
     else
       bytes(i)
-
 }
 
 class ByteGeoTiffSegment(val bytes: Array[Byte]) extends GeoTiffSegment {
@@ -24,8 +23,7 @@ class ByteGeoTiffSegment(val bytes: Array[Byte]) extends GeoTiffSegment {
 
   def getInt(i: Int): Int = get(i)
   def getDouble(i: Int): Double = i2d(get(i))
-  def get(i: Int): Int = bytes(i)
-  def getRaw(i: Int): Byte = bytes(i)
+  def get(i: Int): Byte = bytes(i)
 
   def convert(cellType: CellType): Array[Byte] =
     cellType match {
@@ -33,7 +31,7 @@ class ByteGeoTiffSegment(val bytes: Array[Byte]) extends GeoTiffSegment {
         val bs = new BitSet(size)
         cfor(0)(_ < size, _ + 1) { i => if ((get(i) & 1) == 0) { bs.set(i) } }
         bs.toByteArray()
-      case TypeByte | TypeUByte =>       
+      case TypeByte | TypeUByte =>
         bytes
       case TypeShort | TypeUShort =>
         val arr = Array.ofDim[Short](size)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffSegment.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffSegment.scala
@@ -9,13 +9,22 @@ import java.util.BitSet
 import spire.syntax.cfor._
 
 
+class NoDataByteGeoTiffSegment(bytes: Array[Byte], noDataValue: Byte) extends ByteGeoTiffSegment(bytes) {
+  override
+  def get(i: Int): Int =
+    if (bytes(i) == noDataValue)
+      NODATA
+    else
+      bytes(i)
+
+}
+
 class ByteGeoTiffSegment(val bytes: Array[Byte]) extends GeoTiffSegment {
   val size: Int = bytes.size
 
   def getInt(i: Int): Int = get(i)
   def getDouble(i: Int): Double = i2d(get(i))
-
-  def get(i: Int): Int = bytes(i) & 0xFF
+  def get(i: Int): Int = bytes(i)
   def getRaw(i: Int): Byte = bytes(i)
 
   def convert(cellType: CellType): Array[Byte] =
@@ -24,7 +33,7 @@ class ByteGeoTiffSegment(val bytes: Array[Byte]) extends GeoTiffSegment {
         val bs = new BitSet(size)
         cfor(0)(_ < size, _ + 1) { i => if ((get(i) & 1) == 0) { bs.set(i) } }
         bs.toByteArray()
-      case TypeByte | TypeUByte => 
+      case TypeByte | TypeUByte =>       
         bytes
       case TypeShort | TypeUShort =>
         val arr = Array.ofDim[Short](size)
@@ -52,7 +61,7 @@ class ByteGeoTiffSegment(val bytes: Array[Byte]) extends GeoTiffSegment {
     arr
   }
 
-  def mapDouble(f: Double => Double): Array[Byte] = 
+  def mapDouble(f: Double => Double): Array[Byte] =
     map(z => d2i(f(i2d(z))))
 
   def mapWithIndex(f: (Int, Int) => Int): Array[Byte] = {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffSegmentCollection.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffSegmentCollection.scala
@@ -12,5 +12,10 @@ trait ByteGeoTiffSegmentCollection extends GeoTiffSegmentCollection {
   val noDataValue: Option[Double]
 
   val createSegment: Int => ByteGeoTiffSegment =
-    { i: Int => new ByteGeoTiffSegment(getDecompressedBytes(i)) }
+    noDataValue match {
+      case Some(nd) if isData(nd) && Byte.MinValue.toDouble <= nd && nd <= Byte.MaxValue.toDouble =>        
+        { i: Int => new NoDataByteGeoTiffSegment(getDecompressedBytes(i), nd.toByte) }
+      case _ =>
+        { i: Int => new ByteGeoTiffSegment(getDecompressedBytes(i)) }
+    }
 }


### PR DESCRIPTION
Fixes two use cases:
- ByteArrayTile.fromBytes, which used when we decompress GeoTiff into array tiles 
- NoDataByteGeoTiffSegment, which is used when reading GeoTiff segment by segment.

This also removes "& FF" on get from ByteGeoTiffArrayTile, leaving it as a signed byte container.