### PR TITLE
Moving Cache class hierarchy to spark sub-project

### DIFF
--- a/engine/src/main/scala/geotrellis/engine/Cache.scala
+++ b/engine/src/main/scala/geotrellis/engine/Cache.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2014 Azavea.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.engine
+
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+import scala.collection.mutable.HashMap
+import scala.collection.mutable.ListBuffer
+import scala.collection.mutable
+
+/**
+ * Trait for a T-keyed, any valued cache.
+ */
+trait Cache[T] extends Serializable {
+  /** Lookup the value for key k
+   * @return Some(v) if the value was cached, None otherwise
+   */
+  def lookup[V](k: T):Option[V]
+
+  /** Insert the value v (keyed by k) into the cache
+   * @return true if the value was inserted into the cache
+   */
+  def insert[V](k: T, v: V):Boolean
+
+  /** Remove k from the cache */
+  def remove[V](k: T):Option[V]
+
+  /** Lookup the value for key k
+   * If the value is in the cache, return it.
+   * Otherwise, insert the value v and return it
+   *
+   * Note: This method does not guarantee that v will be in the cache when it returns
+   *
+   * @return the cached value keyed to k or the computed value of v
+   */
+  def getOrInsert[V](k: T, vv: => V):V = lookup(k) match {
+    case Some(v) => v
+    case None => {insert(k, vv); vv}
+  }
+}
+
+/**
+ * Simple HashMap backed cache keyed by String and can hold any type.
+ */
+class HashCache[T] extends Cache[T] {
+  val cache = new mutable.HashMap[T,Any].empty
+
+  def lookup[V](k: T):Option[V] =
+    cache.get(k) match {
+      case Some(v) => Some(v.asInstanceOf[V])
+      case None => None
+    }
+
+  def remove[V](k: T):Option[V] =
+    cache.remove(k) match {
+      case Some(v) => Some(v.asInstanceOf[V])
+      case None => None
+    }
+
+  def insert[V](k: T, v: V):Boolean = { cache.put(k,v.asInstanceOf[Any]); true }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/Cache.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/Cache.scala
@@ -1,7 +1,0 @@
-package geotrellis.spark.io
-
-trait Cache[K, V] {
-  def contains(key: K): Boolean
-  def apply(key: K): Option[V]
-  def update(key: K, value: V): Unit
-}

--- a/spark/src/main/scala/geotrellis/spark/io/FileCache.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/FileCache.scala
@@ -3,27 +3,34 @@ package geotrellis.spark.io
 import java.io.{File, FileInputStream, FileOutputStream}
 
 import org.apache.commons.io.IOUtils
+import geotrellis.spark.utils.cache._
 
-class FileCache(cacheDirectory: String, fileChunk: Long => String) extends Cache[Long, Array[Byte]] {
+class FileCache(cacheDirectory: String, fileChunk: Long => String) extends CacheStrategy[Long, Array[Byte]] {
   val cacheRoot = new File(cacheDirectory)
   require(cacheRoot.isDirectory, s"$cacheRoot must be a directory")
+  cacheRoot.mkdirs()
 
-  def contains(key: Long) = {
-    new File(cacheDirectory, fileChunk(key)).exists
-  }
+  private def getPath(k: Long) = new File(cacheDirectory, fileChunk(k))
 
-  def update(key: Long, value: Array[Byte]) = {
-    val path = new File(cacheDirectory, fileChunk(key))
-    val cacheOut = new FileOutputStream(path)
-    try { cacheOut.write(value) }
-    finally { cacheOut.close() }
-  }
-
-  def apply(key: Long) = {
-    val path = new File(cacheDirectory, fileChunk(key))
+  def lookup(k: Long):Option[Array[Byte]] = {
+    val path = getPath(k)
     if (path.exists)
       Some(IOUtils.toByteArray(new FileInputStream(path)))
     else
       None
+  }
+
+  def insert(k: Long, v: Array[Byte]):Boolean = {
+    val path = getPath(k)
+    val cacheOut = new FileOutputStream(path)
+    try {cacheOut.write(v); true}
+    catch { case e: Exception => false }
+    finally { cacheOut.close() }
+  }
+
+  def remove(k: Long):Option[Array[Byte]] = {
+    val ans = lookup(k)
+    if (ans.isDefined) getPath(k).delete()
+    ans
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3LayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3LayerReader.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
 class S3LayerReader[K: Boundable: JsonFormat: ClassTag, V: ClassTag, Container](
     val attributeStore: AttributeStore[JsonFormat],
     rddReader: S3RDDReader[K, V],
-    getCache: Option[LayerId => CacheStrategy[Long, Array[Byte]]] = None)
+    getCache: Option[LayerId => Cache[Long, Array[Byte]]] = None)
   (implicit sc: SparkContext, val cons: ContainerConstructor[K, V, Container])
   extends FilteringLayerReader[LayerId, K, Container] with LazyLogging {
 
@@ -62,7 +62,7 @@ object S3LayerReader {
   def apply[K: Boundable: AvroRecordCodec: JsonFormat: ClassTag, V: AvroRecordCodec: ClassTag, Container[_]](
       bucket: String,
       prefix: String,
-      getCache: Option[LayerId => CacheStrategy[Long, Array[Byte]]] = None)
+      getCache: Option[LayerId => Cache[Long, Array[Byte]]] = None)
     (implicit sc: SparkContext, cons: ContainerConstructor[K, V, Container[K]]): S3LayerReader[K, V, Container[K]] =
     new S3LayerReader(
       new S3AttributeStore(bucket, prefix),

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3LayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3LayerReader.scala
@@ -7,6 +7,7 @@ import geotrellis.spark.io.json._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index.KeyIndex
 import org.apache.avro.Schema
+import geotrellis.spark.utils.cache._
 import org.apache.spark.SparkContext
 import spray.json.{JsObject, JsonFormat}
 import spray.json.DefaultJsonProtocol._
@@ -27,7 +28,7 @@ import scala.reflect.ClassTag
 class S3LayerReader[K: Boundable: JsonFormat: ClassTag, V: ClassTag, Container](
     val attributeStore: AttributeStore[JsonFormat],
     rddReader: S3RDDReader[K, V],
-    getCache: Option[LayerId => Cache[Long, Array[Byte]]] = None)
+    getCache: Option[LayerId => CacheStrategy[Long, Array[Byte]]] = None)
   (implicit sc: SparkContext, val cons: ContainerConstructor[K, V, Container])
   extends FilteringLayerReader[LayerId, K, Container] with LazyLogging {
 
@@ -61,7 +62,7 @@ object S3LayerReader {
   def apply[K: Boundable: AvroRecordCodec: JsonFormat: ClassTag, V: AvroRecordCodec: ClassTag, Container[_]](
       bucket: String,
       prefix: String,
-      getCache: Option[LayerId => Cache[Long, Array[Byte]]] = None)
+      getCache: Option[LayerId => CacheStrategy[Long, Array[Byte]]] = None)
     (implicit sc: SparkContext, cons: ContainerConstructor[K, V, Container[K]]): S3LayerReader[K, V, Container[K]] =
     new S3LayerReader(
       new S3AttributeStore(bucket, prefix),

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
@@ -7,7 +7,7 @@ import geotrellis.spark.io.avro.codecs.KeyValueRecordCodec
 import geotrellis.spark.io.index.{MergeQueue, KeyIndex}
 import geotrellis.spark.io.avro.{AvroEncoder, AvroRecordCodec}
 import geotrellis.spark.utils.KryoWrapper
-import geotrellis.spark.utils.cache.CacheStrategy
+import geotrellis.spark.utils.cache.Cache
 import org.apache.avro.Schema
 import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkContext
@@ -26,7 +26,7 @@ class S3RDDReader[K: Boundable: AvroRecordCodec: ClassTag, V: AvroRecordCodec: C
     queryKeyBounds: Seq[KeyBounds[K]],
     decomposeBounds: KeyBounds[K] => Seq[(Long, Long)],
     writerSchema: Option[Schema] = None,
-    cache: Option[CacheStrategy[Long, Array[Byte]]] = None,
+    cache: Option[Cache[Long, Array[Byte]]] = None,
     numPartitions: Int = sc.defaultParallelism
   ): RDD[(K, V)] = {
     val ranges = if (queryKeyBounds.length > 1)

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
@@ -3,12 +3,11 @@ package geotrellis.spark.io.s3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import geotrellis.spark._
-import geotrellis.spark.io.Cache
 import geotrellis.spark.io.avro.codecs.KeyValueRecordCodec
 import geotrellis.spark.io.index.{MergeQueue, KeyIndex}
 import geotrellis.spark.io.avro.{AvroEncoder, AvroRecordCodec}
 import geotrellis.spark.utils.KryoWrapper
-import org.apache.accumulo.core.data.Range
+import geotrellis.spark.utils.cache.CacheStrategy
 import org.apache.avro.Schema
 import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkContext
@@ -27,7 +26,7 @@ class S3RDDReader[K: Boundable: AvroRecordCodec: ClassTag, V: AvroRecordCodec: C
     queryKeyBounds: Seq[KeyBounds[K]],
     decomposeBounds: KeyBounds[K] => Seq[(Long, Long)],
     writerSchema: Option[Schema] = None,
-    cache: Option[Cache[Long, Array[Byte]]] = None,
+    cache: Option[CacheStrategy[Long, Array[Byte]]] = None,
     numPartitions: Int = sc.defaultParallelism
   ): RDD[(K, V)] = {
     val ranges = if (queryKeyBounds.length > 1)
@@ -61,11 +60,7 @@ class S3RDDReader[K: Boundable: AvroRecordCodec: ClassTag, V: AvroRecordCodec: C
                 val bytes: Array[Byte] =
                   cache match {
                     case Some(cache) =>
-                      cache(index).getOrElse {
-                        val s3Bytes = getS3Bytes()
-                        cache.update(index, s3Bytes)
-                        s3Bytes
-                      }
+                      cache.getOrInsert(index, getS3Bytes())
                     case None =>
                       getS3Bytes()
                   }

--- a/spark/src/main/scala/geotrellis/spark/utils/cache/FileCache.scala
+++ b/spark/src/main/scala/geotrellis/spark/utils/cache/FileCache.scala
@@ -1,14 +1,14 @@
-package geotrellis.spark.io
+package geotrellis.spark.utils.cache
 
 import java.io.{File, FileInputStream, FileOutputStream}
 
 import org.apache.commons.io.IOUtils
-import geotrellis.spark.utils.cache._
 
 class FileCache(cacheDirectory: String, fileChunk: Long => String) extends CacheStrategy[Long, Array[Byte]] {
   val cacheRoot = new File(cacheDirectory)
+  if (! cacheRoot.exists) cacheRoot.mkdirs()
   require(cacheRoot.isDirectory, s"$cacheRoot must be a directory")
-  cacheRoot.mkdirs()
+
 
   private def getPath(k: Long) = new File(cacheDirectory, fileChunk(k))
 

--- a/spark/src/main/scala/geotrellis/spark/utils/cache/FileCache.scala
+++ b/spark/src/main/scala/geotrellis/spark/utils/cache/FileCache.scala
@@ -4,7 +4,7 @@ import java.io.{File, FileInputStream, FileOutputStream}
 
 import org.apache.commons.io.IOUtils
 
-class FileCache(cacheDirectory: String, fileChunk: Long => String) extends CacheStrategy[Long, Array[Byte]] {
+class FileCache(cacheDirectory: String, fileChunk: Long => String) extends Cache[Long, Array[Byte]] {
   val cacheRoot = new File(cacheDirectory)
   if (! cacheRoot.exists) cacheRoot.mkdirs()
   require(cacheRoot.isDirectory, s"$cacheRoot must be a directory")

--- a/spark/src/main/scala/geotrellis/spark/utils/cache/cache.scala
+++ b/spark/src/main/scala/geotrellis/spark/utils/cache/cache.scala
@@ -22,58 +22,6 @@ import scala.collection.mutable.HashMap
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable
 
-/**
- * Trait for a T-keyed, any valued cache.
- */
-trait Cache[T] extends Serializable {
-  /** Lookup the value for key k
-   * @return Some(v) if the value was cached, None otherwise
-   */
-  def lookup[V](k: T):Option[V]
-
-  /** Insert the value v (keyed by k) into the cache
-   * @return true if the value was inserted into the cache
-   */
-  def insert[V](k: T, v: V):Boolean
-
-  /** Remove k from the cache */
-  def remove[V](k: T):Option[V]
-
-  /** Lookup the value for key k
-   * If the value is in the cache, return it.
-   * Otherwise, insert the value v and return it
-   *
-   * Note: This method does not guarantee that v will be in the cache when it returns
-   *
-   * @return the cached value keyed to k or the computed value of v
-   */
-  def getOrInsert[V](k: T, vv: => V):V = lookup(k) match {
-    case Some(v) => v
-    case None => {insert(k, vv); vv}
-  }
-}
-
-/**
- * Simple HashMap backed cache keyed by String and can hold any type.
- */
-class HashCache[T] extends Cache[T] {
-  val cache = new mutable.HashMap[T,Any].empty
-
-  def lookup[V](k: T):Option[V] =
-    cache.get(k) match {
-      case Some(v) => Some(v.asInstanceOf[V])
-      case None => None
-    }
-
-  def remove[V](k: T):Option[V] =
-    cache.remove(k) match {
-      case Some(v) => Some(v.asInstanceOf[V])
-      case None => None
-    }
-
-  def insert[V](k: T, v: V):Boolean = { cache.put(k,v.asInstanceOf[Any]); true }
-}
-
 /** Base trait for a caching strategy
  *
  * K is the cache key

--- a/spark/src/main/scala/geotrellis/spark/utils/cache/cache.scala
+++ b/spark/src/main/scala/geotrellis/spark/utils/cache/cache.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package geotrellis.engine
+package geotrellis.spark.utils.cache
 
 import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
@@ -79,7 +79,7 @@ class HashCache[T] extends Cache[T] {
  * K is the cache key
  * V is the cache value
  */
-trait CacheStrategy[K,V] {
+trait CacheStrategy[K,V] extends Serializable {
 
   /** Lookup the value for key k
    * @return Some(v) if the value was cached, None otherwise

--- a/spark/src/test/scala/geotrellis/spark/utils/cache/CacheSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/utils/cache/CacheSpec.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-
-package geotrellis.engine
+package geotrellis.spark.utils.cache
 
 import org.scalatest._
 
@@ -23,32 +22,32 @@ import scala.concurrent.Lock
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.ExecutionContextExecutorService
 
-class LRUCacheSpec extends FunSpec with MustMatchers {
-  
-  def f(x: Int):Int = x*100 
+class CacheSpec extends FunSpec with MustMatchers {
+
+  def f(x: Int):Int = x*100
 
   def hashCacheTest(mkCache: Int => HashBackedCache[Int,Int]) {
     describe("Hash Cache Test Cache") {
-      
-      def getCache(max:Int = 5) = 
+
+      def getCache(max:Int = 5) =
         mkCache(max)
-      
+
       it("should be able to handle simple set/get case") {
         val cache = getCache()
-        
+
         for(j <- 1 to 5)
           cache.getOrInsert(j,f(j))
-        
+
         for(j <- 1 to 5)
           cache.lookup(j) must equal(Some(f(j)))
       }
-      
+
       it("should not update if using getOrInsert multiple times") {
         val cache = getCache()
-        
+
         for(j <- 1 to 100)
           cache.getOrInsert(1,f(j))
-        
+
         cache.cache.size must equal(1)
         cache.lookup(1) must equal(Some(f(1))) // Pairs are assume to be immutable
       }
@@ -61,10 +60,10 @@ class LRUCacheSpec extends FunSpec with MustMatchers {
 
       it("should evict from cache") {
         val cache = mkCache(1) // Max size 1
-        
+
         cache.getOrInsert(1, f(1))
         cache.lookup(1) must equal(Some(f(1)))
-        
+
         cache.getOrInsert(2, f(2))
         cache.lookup(2) must equal(Some(f(2)))
         cache.lookup(1) must equal(None)
@@ -76,95 +75,95 @@ class LRUCacheSpec extends FunSpec with MustMatchers {
 
 
   describe("LRU cache") {
-    
-    def getCache(max: Int) = 
+
+    def getCache(max: Int) =
       new LRUCache[Int,Int](max, (v: Int) => 1)
-     
+
     hashCacheTest(getCache _)
     boundedCacheTest(getCache _)
- 
+
     it("should be contain at most maxSize number of items") {
       val cache = getCache(5)
-      
+
       for(j <- 1 to 100)
         cache.getOrInsert(j,f(j))
-      
-        cache.cache.size must equal(5)
-      
+
+      cache.cache.size must equal(5)
+
       for(j <- 1 to 95)
         cache.lookup(j) must equal(None)
       for(j <- 96 to 100)
         cache.lookup(j) must equal(Some(f(j)))
     }
-    
+
     it("should evict the item accessed longest ago") {
       val cache = getCache(2)
-      
+
       cache.insert(1, f(1))
       cache.insert(2, f(2))
       cache.lookup(1) must equal(Some(f(1)))
       cache.lookup(2) must equal(Some(f(2)))
-        
+
       cache.lookup(1) // Make 1 newer than 2
-        
+
       cache.insert(3, f(3))
       cache.lookup(1) must equal(Some(f(1)))
       cache.lookup(2) must equal(None)
       cache.lookup(3) must equal(Some(f(3)))
-      
+
       cache.insert(4, f(4))
       cache.lookup(1) must equal(None)
       cache.lookup(2) must equal(None)
       cache.lookup(3) must equal(Some(f(3)))
       cache.lookup(4) must equal(Some(f(4)))
-      
+
     }
   }
 
   describe("MRU cache") {
-    
-    def getCache(max: Int) = 
+
+    def getCache(max: Int) =
       new MRUCache[Int,Int](max, (v: Int) => 1)
-     
+
     hashCacheTest(getCache _)
     boundedCacheTest(getCache _)
- 
+
     it("should be contain at most maxSize number of items") {
       val cache = getCache(5)
-      
+
       for(j <- 1 to 100)
         cache.getOrInsert(j,f(j))
-      
-        cache.cache.size must equal(5)
-      
+
+      cache.cache.size must equal(5)
+
       for(j <- 5 to 99)
         cache.lookup(j) must equal(None)
       for(j <- 1 to 4)
         cache.lookup(j) must equal(Some(f(j)))
       cache.lookup(100) must equal(Some(f(100)))
     }
-    
+
     it("should evict the item accessed most recently") {
       val cache = getCache(2)
-      
+
       cache.insert(1, f(1))
       cache.insert(2, f(2))
       cache.lookup(1) must equal(Some(f(1)))
       cache.lookup(2) must equal(Some(f(2)))
-        
+
       cache.lookup(1) // Make 1 newer than 2
-        
+
       cache.insert(3, f(3))
       cache.lookup(1) must equal(None)
       cache.lookup(2) must equal(Some(f(2)))
       cache.lookup(3) must equal(Some(f(3)))
-      
+
       cache.insert(4, f(4))
       cache.lookup(1) must equal(None)
       cache.lookup(2) must equal(Some(f(2)))
       cache.lookup(3) must equal(None)
       cache.lookup(4) must equal(Some(f(4)))
-      
+
     }
   }
 }


### PR DESCRIPTION
GeoTrellis engine has a nice set of caching functionality that is not at all used there. Caching has recently useful in spark subproject where it is used `S3LayerReader` and some client code.

This PR moves those cache implementations over, merges them with `FileCache` class and cleans up some naming issues.