### PR TITLE
Added ability to color double tiles with double color breaks.

### DIFF
--- a/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourceMethods.scala
@@ -56,7 +56,7 @@ trait RenderRasterSourceMethods extends RasterSourceMethods {
     rasterSource.converge.map(_.renderPng(colorBreaks, noDataColor))
 
   def renderPng(ramp: ColorRamp, breaks: Array[Int]): ValueSource[Png] =
-    renderPng(ColorBreaks.assign(breaks, ramp.toArray))
+    renderPng(ColorBreaks(breaks, ramp.toArray))
 
   def renderPng(colors: Array[Int]): ValueSource[Png] =
     rasterSource.converge.map(_.renderPng(colors))

--- a/raster-test/src/test/scala/geotrellis/raster/render/RenderMethodsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/render/RenderMethodsSpec.scala
@@ -1,0 +1,46 @@
+package geotrellis.raster.render
+
+import geotrellis.raster._
+import geotrellis.testkit._
+
+import org.scalatest._
+
+class RenderMethodsSpec extends FunSpec with Matchers 
+                                        with TestEngine 
+                                        with TileBuilders {
+  describe("color") {
+    it("should color an int tile") {
+      val arr = (0 to 120).map { z => ((z.toDouble / 120) * 100).toInt }.toArray
+      val tile = createTile(arr, 10, 12)
+
+      val limits = Array(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
+      val colors = Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+      val colorBreaks = ColorBreaks(limits, colors)
+
+      val result = tile.color(colorBreaks, LessThanOrEqualTo)
+
+      result.foreachDouble { (col, row, z) =>
+        val i = tile.cols * row + col
+        val expected = ((i.toDouble / 120) * 10).toInt
+        z should be (expected)
+      }
+    }
+
+    it("should color a double tile") {
+      val arr = (0 to 120).map(_.toDouble / 120).toArray
+      val tile = createTile(arr, 10, 12)
+
+      val limits = Array(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
+      val colors = Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+      val colorBreaks = ColorBreaks(limits, colors)
+
+      val result = tile.color(colorBreaks, LessThanOrEqualTo)
+
+      result.foreachDouble { (col, row, z) =>
+        val i = tile.cols * row + col
+        val expected = ((i.toDouble / 120) * 10).toInt
+        z should be (expected)
+      }
+    }
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/render/ColorBreaks.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorBreaks.scala
@@ -21,30 +21,39 @@ import java.util.Locale
 
 /**
   * ColorBreaks describes a way to render a raster into a colored image.
+  */
+trait ColorBreaks extends Serializable {
+  def colors: Array[Int]
+  def length: Int
+  def replaceColors(newColors: Array[Int]): ColorBreaks
+  def mapColors(f: Int => Int): ColorBreaks
+  def toColorMap(): ColorMap = toColorMap(ColorMapOptions.Default)
+  def toColorMap(options: ColorMapOptions): ColorMap
+}
+
+/**
+  * IntColorBreaks describes a way to render a raster into a colored image.
   *
-  * This class defines a set of value ranges and assigns a color to
+  * This class defines a set of Int value ranges and assigns a color to
   * each value range.
   *
   * @param limits  An array with the maximum value of each range
   * @param colors  An array with the color assigned to each range
   */
-case class ColorBreaks(limits: Array[Int], colors: Array[Int]) {
+class IntColorBreaks(val limits: Array[Int], val colors: Array[Int]) extends ColorBreaks {
   assert(limits.length == colors.length)
   assert(colors.length > 0)
 
-  val lastColor = colors(colors.length - 1)
-
   def length = limits.length
 
-  def get(z: Int): Int = {
-    var i = 0
-    val last = colors.length - 1
-    while (i < last) {
-      if (z <= limits(i)) return colors(i)
-      i += 1
-    }
-    lastColor
-  }
+  def replaceColors(newColors: Array[Int]): ColorBreaks =
+    new IntColorBreaks(limits, newColors)
+
+  def mapColors(f: Int => Int): ColorBreaks =
+    new IntColorBreaks(limits, colors.map(f))
+
+  def toColorMap(options: ColorMapOptions = ColorMapOptions.Default): ColorMap =
+    ColorMap(limits, colors, options)
 
   override def toString = {
     val limitsStr = limits.mkString("Array(", ", ", ")")
@@ -52,9 +61,44 @@ case class ColorBreaks(limits: Array[Int], colors: Array[Int]) {
       colors
         .map("%08x" formatLocal(Locale.ENGLISH, _))
         .mkString("Array(", ", ", ")")
-    s"ColorBreaks($limitsStr, $colorsStr)"
+    s"IntColorBreaks($limitsStr, $colorsStr)"
   }
 }
+
+/**
+  * IntColorBreaks describes a way to render a raster into a colored image.
+  *
+  * This class defines a set of Int value ranges and assigns a color to
+  * each value range.
+  *
+  * @param limits  An array with the maximum value of each range
+  * @param colors  An array with the color assigned to each range
+  */
+class DoubleColorBreaks(val limits: Array[Double], val colors: Array[Int]) extends ColorBreaks {
+  assert(limits.length == colors.length)
+  assert(colors.length > 0)
+
+  def length = limits.length
+
+  def replaceColors(newColors: Array[Int]): ColorBreaks =
+    new DoubleColorBreaks(limits, newColors)
+
+  def mapColors(f: Int => Int): ColorBreaks =
+    new DoubleColorBreaks(limits, colors.map(f))
+
+  def toColorMap(options: ColorMapOptions = ColorMapOptions.Default): ColorMap =
+    ColorMap(limits, colors, options)
+
+  override def toString = {
+    val limitsStr = limits.mkString("Array(", ", ", ")")
+    val colorsStr =
+      colors
+        .map("%08x" formatLocal(Locale.ENGLISH, _))
+        .mkString("Array(", ", ", ")")
+    s"DoubleColorBreaks($limitsStr, $colorsStr)"
+  }
+}
+
 
 object ColorBreaks {
   /**
@@ -72,27 +116,33 @@ object ColorBreaks {
     * @param limits  An array of the maximum value of each range
     * @param colors  An array of RGBA color values
     */
-  def assign(limits: Array[Int], colors: Array[Int]) = {
-    if (limits.length != colors.length) {
-      val used = new Array[Int](limits.length)
+  private def sample(colors: Array[Int], numSamples: Int) = {
+    if (numSamples != colors.length) {
+      val used = new Array[Int](numSamples)
       used(0) = colors(0)
 
-      val b = limits.length - 1
+      val b = numSamples - 1
       val c = colors.length - 1
       var i = 1
-      while (i < limits.length) {
+      while (i < numSamples) {
         used(i) = colors(math.round(i.toDouble * c / b).toInt)
         i += 1
       }
 
-      new ColorBreaks(limits, used)
+      used
     } else {
-      new ColorBreaks(limits, colors)
+      colors
     }
   }
 
-  def apply(histogram: Histogram, colors: Array[Int]): ColorBreaks = {
+  def apply(limits: Array[Int], colors: Array[Int]): IntColorBreaks =
+    new IntColorBreaks(limits, sample(colors, limits.length))
+
+  def apply(limits: Array[Double], colors: Array[Int]): DoubleColorBreaks =
+    new DoubleColorBreaks(limits, sample(colors, limits.length))
+
+  def apply(histogram: Histogram, colors: Array[Int]): IntColorBreaks = {
     val limits = histogram.getQuantileBreaks(colors.length)
-    assign(limits, colors)
+    new IntColorBreaks(limits, sample(colors, limits.length))
   }
 }

--- a/raster/src/main/scala/geotrellis/raster/render/ColorBreaks.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorBreaks.scala
@@ -66,9 +66,9 @@ class IntColorBreaks(val limits: Array[Int], val colors: Array[Int]) extends Col
 }
 
 /**
-  * IntColorBreaks describes a way to render a raster into a colored image.
+  * DoubleColorBreaks describes a way to render a raster into a colored image.
   *
-  * This class defines a set of Int value ranges and assigns a color to
+  * This class defines a set of Double value ranges and assigns a color to
   * each value range.
   *
   * @param limits  An array with the maximum value of each range

--- a/raster/src/main/scala/geotrellis/raster/render/RenderMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/RenderMethods.scala
@@ -18,6 +18,12 @@ trait RenderMethods extends TileMethods {
   def color(breaksToColors: Map[Double, Int], options: ColorMapOptions)(implicit d: DI): Tile =
     DoubleColorMap(breaksToColors, options).render(tile)
 
+  def color(colorBreaks: ColorBreaks): Tile =
+    colorBreaks.toColorMap.render(tile)
+
+  def color(colorBreaks: ColorBreaks, options: ColorMapOptions): Tile =
+    colorBreaks.toColorMap(options).render(tile)
+
   /** Generate a PNG from a raster of RGBA integer values.
     *
     * Use this operation when you have created a raster whose values are already
@@ -71,13 +77,10 @@ trait RenderMethods extends TileMethods {
 
   private
   def renderPng(colorBreaks: ColorBreaks, noDataColor: Int, histogram: Option[Histogram]): Png = {
-    val breaks = colorBreaks.limits
-    val colors = colorBreaks.colors
-
     val renderer =
       histogram match {
-        case Some(h) => Renderer(breaks, colors, noDataColor, h)
-        case None => Renderer(breaks, colors, noDataColor)
+        case Some(h) => Renderer(colorBreaks, noDataColor, h)
+        case None => Renderer(colorBreaks, noDataColor)
       }
 
     val r2 = renderer.render(tile)
@@ -85,7 +88,7 @@ trait RenderMethods extends TileMethods {
   }
 
   def renderPng(ramp: ColorRamp, breaks: Array[Int]): Png =
-    renderPng(ColorBreaks.assign(breaks, ramp.toArray))
+    renderPng(ColorBreaks(breaks, ramp.toArray))
 
   def renderPng(colors: Array[Int]): Png = {
     val h = tile.histogram
@@ -95,9 +98,15 @@ trait RenderMethods extends TileMethods {
   def renderPng(colors: Array[Int], numColors: Int): Png =
     renderPng(Color.chooseColors(colors, numColors))
 
-  def renderPng(colors: Array[Int], breaks: Array[Int]): Png =
+  def renderPng(breaks: Array[Int], colors: Array[Int]): Png =
     renderPng(ColorBreaks(breaks, colors), 0)
 
-  def renderPng(colors: Array[Int], breaks: Array[Int], noDataColor: Int): Png =
+  def renderPng(breaks: Array[Int], colors: Array[Int], noDataColor: Int): Png =
+    renderPng(ColorBreaks(breaks, colors), noDataColor)
+
+  def renderPng(breaks: Array[Double], colors: Array[Int]): Png =
+    renderPng(ColorBreaks(breaks, colors), 0)
+
+  def renderPng(breaks: Array[Double], colors: Array[Int], noDataColor: Int): Png =
     renderPng(ColorBreaks(breaks, colors), noDataColor)
 }


### PR DESCRIPTION
Previously we weren't allowed to color a tile of doubles with color breaks that were also doubles. For instance, if we had breaks that corresponding to the values of 0.0 - 1.0, and colors to match those breaks, we now are able to render a tile that has values 0.0 - 1.0 with those breaks.

ColorBreaks changes from being a `case class ColorBreaks(limits: Array[Int], colors: Array[Int])` to a trait, with `IntColorBreaks` and `DoubleColorBreaks` implementations. This is an API change.