### PR TITLE
Allow extents in GeometryCollections; Style GeoJson

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffTestUtils.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffTestUtils.scala
@@ -50,8 +50,9 @@ trait GeoTiffTestUtils extends Matchers {
   import GeoTiffTestUtils._
 
   def geoTiffPath(name: String): String = {
-    initializeTestFiles()
-    s"$testDirPath/$name"
+    val path = s"$testDirPath/$name"
+    GeoTiffTestUtils.initializeTestFiles(!new File(path).exists)
+    path
   }
 
   def baseDataPath = "raster-test/data"
@@ -59,8 +60,6 @@ trait GeoTiffTestUtils extends Matchers {
   val Epsilon = 1e-9
 
   var writtenFiles = Vector[String]()
-
-  def initializeTestFiles(): Unit = GeoTiffTestUtils.initializeTestFiles(false)
 
   protected def addToPurge(path: String) = synchronized {
     writtenFiles = writtenFiles :+ path

--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -16,10 +16,10 @@ libraryDependencies ++= Seq(
   scalazStream,
   scalatest % "test")
 
-fork := true
-parallelExecution in Test := false
+fork := false
+
 javaOptions ++= List(
-  "-Xmx8G",
+  "-Xmx2G",
   "-XX:MaxPermSize=384m",
   s"-Djava.library.path=${Environment.javaGdalDir}",
   "-Dsun.io.serialization.extendedDebugInfo=true")

--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   scalazStream,
   scalatest % "test")
 
-fork := false
+fork in Test := false
 
 javaOptions ++= List(
   "-Xmx2G",

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/package.scala
@@ -49,6 +49,9 @@ package object hadoop {
     /** Creates a Configuration with all files in a directory (recursively searched)*/
     def withInputDirectory(path: Path): Configuration = {
       val allFiles = HdfsUtils.listFiles(path, config)
+      if(allFiles.isEmpty) {
+        sys.error(s"$path contains no files.")
+      }
       HdfsUtils.putFilesInConf(allFiles.mkString(","), config)
     }
 

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
@@ -12,7 +12,7 @@ import DefaultJsonProtocol._
 import org.apache.spark._
 import java.io.PrintWriter
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.{ObjectMetadata, AmazonS3Exception}
 import scala.io.Source
 import java.io.ByteArrayInputStream
 
@@ -39,27 +39,35 @@ class S3AttributeStore(bucket: String, rootPath: String) extends AttributeStore[
   def attributePrefix(attributeName: String): String =
     path(rootPath, "_attributes", s"${attributeName}__")
 
-  private def readKey[T: Format](key: String): Option[(LayerId, T)] = {
+  private def readKey[T: Format](key: String): (LayerId, T) = {
     val is = s3Client.getObject(bucket, key).getObjectContent
-    val json = Source.fromInputStream(is)(Charset.forName("UTF-8")).mkString
-    is.close()
-    Some(json.parseJson.convertTo[(LayerId, T)])
-    // TODO: Make this crash to find out when None should be returned
+    val json =
+      try {
+        Source.fromInputStream(is)(Charset.forName("UTF-8")).mkString
+      } finally {
+        is.close()
+      }
+
+    json.parseJson.convertTo[(LayerId, T)]
   }
   
   def read[T: Format](layerId: LayerId, attributeName: String): T =
-    readKey[T](attributePath(layerId, attributeName)) match {
-      case Some((id, value)) => value
-      case None => throw new AttributeNotFoundError(attributeName, layerId)
+    try {
+      readKey[T](attributePath(layerId, attributeName))._2
+    } catch {
+      case e: AmazonS3Exception =>
+        throw new AttributeNotFoundError(attributeName, layerId).initCause(e)
     }
 
   def readAll[T: Format](attributeName: String): Map[LayerId, T] =
     s3Client
       .listObjectsIterator(bucket, attributePrefix(attributeName))
-      .map{ os =>       
-        readKey[T](os.getKey) match {
-          case Some(tup) => tup
-          case None => throw new CatalogError(s"Unable to list $attributeName attributes from $bucket/${os.getKey}") 
+      .map{ os =>
+        try {
+          readKey[T](os.getKey)
+        } catch {
+          case e: AmazonS3Exception =>
+            throw new CatalogError(s"Unable to list $attributeName attributes from $bucket/${os.getKey}").initCause(e)
         }
       }
       .toMap
@@ -72,9 +80,8 @@ class S3AttributeStore(bucket: String, rootPath: String) extends AttributeStore[
     //AmazonServiceException possible
   }
 
-  def layerExists(layerId: LayerId): Boolean = {
-    s3Client.listObjectsIterator(bucket, AttributeStore.Fields.metaData, 1).nonEmpty
-  }
+  def layerExists(layerId: LayerId): Boolean =
+    s3Client.listObjectsIterator(bucket, attributePath(layerId, AttributeStore.Fields.metaData), 1).nonEmpty
 
   def delete(layerId: LayerId, path: String): Unit = {
     if(!layerExists(layerId)) throw new LayerNotFoundError(layerId)
@@ -85,8 +92,10 @@ class S3AttributeStore(bucket: String, rootPath: String) extends AttributeStore[
     if(!layerExists(layerId)) throw new LayerNotFoundError(layerId)
     s3Client
       .listObjectsIterator(bucket, path(rootPath, "_attributes"))
-      .collect { case os if os.getKey.contains(s"__${layerId.name}__${layerId.zoom}.json") =>
-        s3Client.deleteObject(bucket, os.getKey)
+      .foreach { os =>
+        if(os.getKey.contains(s"__${layerId.name}__${layerId.zoom}.json")) {
+          s3Client.deleteObject(bucket, os.getKey)
+        }
       }
   }
 

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3Client.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3Client.scala
@@ -81,7 +81,7 @@ trait S3Client extends LazyLogging {
       def getNextPage: Boolean =  {
         val nextRequest = request.withMarker(listing.getNextMarker)
         listing = listObjects(nextRequest)
-        listing.getObjectSummaries.asScala.iterator        
+        listing.getObjectSummaries.asScala.iterator
         iter.hasNext
       }
 

--- a/spark/src/main/scala/geotrellis/spark/utils/SparkUtils.scala
+++ b/spark/src/main/scala/geotrellis/spark/utils/SparkUtils.scala
@@ -45,11 +45,6 @@ object SparkUtils extends Logging {
    * It's not clear if this way of driving spark will continue to be support, perhaps for debugging
    */
   def createLocalSparkContext(sparkMaster: String, appName: String, sparkConf: SparkConf = createSparkConf) = {
-    val sparkHome = scala.util.Properties.envOrNone("SPARK_HOME") match {
-      case Some(value) => value
-      case None        => throw new Error("Oops, SPARK_HOME is not defined")
-    }
-
     sparkConf
       .setMaster(sparkMaster)
       .setAppName(appName)

--- a/spark/src/test/scala/geotrellis/spark/OnlyIfCanRunSpark.scala
+++ b/spark/src/test/scala/geotrellis/spark/OnlyIfCanRunSpark.scala
@@ -23,11 +23,11 @@ import org.scalatest.BeforeAndAfterAll
 import scala.util._
 
 object OnlyIfCanRunSpark {
-  lazy val _sc = Try{
+  lazy val _sc = {
     System.setProperty("spark.driver.port", "0")
     System.setProperty("spark.hostPort", "0")
 
-    val sparkContext = SparkUtils.createLocalSparkContext("local[8]", "Test Context", new SparkConf())
+    val sparkContext = SparkUtils.createLocalSparkContext("local", "Test Context", new SparkConf())
 
     System.clearProperty("spark.driver.port")
     System.clearProperty("spark.hostPort")
@@ -39,14 +39,11 @@ object OnlyIfCanRunSpark {
 trait OnlyIfCanRunSpark extends FunSpec with BeforeAndAfterAll {
   import OnlyIfCanRunSpark._
 
-  implicit def sc: SparkContext = _sc.get
+  implicit def sc: SparkContext = _sc
 
-  def canRunSpark: Boolean = _sc.isSuccess
+  def canRunSpark: Boolean = true
 
   def ifCanRunSpark(f: => Unit): Unit = {    
-     _sc match {
-      case Success(sc) => f
-      case Failure(error) => ignore(error.getMessage) {}
-    }    
+    f
   }  
 }

--- a/spark/src/test/scala/geotrellis/spark/OpAsserter.scala
+++ b/spark/src/test/scala/geotrellis/spark/OpAsserter.scala
@@ -16,27 +16,18 @@ trait OpAsserter extends FunSpec
     with TestEnvironment
     with RasterMatchers  {
 
-  val basePath = {
-    val workingDir = 
-    localFS
-      .getWorkingDirectory
-      .toString
-      .substring(5)
-    s"${workingDir}/src/test/resources/"
-  }
-
-  def testArg(sc: SparkContext,
-    path: String,
-    layoutCols: Int = 4,
-    layoutRows: Int = 3)
-    (
-      rasterOp: (Tile, RasterExtent) => Tile,
-      sparkOp: RasterRDD[SpatialKey] => RasterRDD[SpatialKey],
-      asserter: (Tile, Tile) => Unit = tilesEqual
-    ) = {
-    val tile = ArgReader.read(basePath + path)
-    testTile(sc, tile, layoutCols, layoutRows)(rasterOp, sparkOp, asserter)
-  }
+  // def testArg(sc: SparkContext,
+  //   path: String,
+  //   layoutCols: Int = 4,
+  //   layoutRows: Int = 3)
+  //   (
+  //     rasterOp: (Tile, RasterExtent) => Tile,
+  //     sparkOp: RasterRDD[SpatialKey] => RasterRDD[SpatialKey],
+  //     asserter: (Tile, Tile) => Unit = tilesEqual
+  //   ) = {
+  //   val tile = ArgReader.read(basePath + path)
+  //   testTile(sc, tile, layoutCols, layoutRows)(rasterOp, sparkOp, asserter)
+  // }
 
   def testGeoTiff(sc: SparkContext,
     path: String,
@@ -47,7 +38,7 @@ trait OpAsserter extends FunSpec
       sparkOp: RasterRDD[SpatialKey] => RasterRDD[SpatialKey],
       asserter: (Tile, Tile) => Unit = tilesEqual
     ) = {
-    val tile = SingleBandGeoTiff(basePath + path).tile
+    val tile = SingleBandGeoTiff(new File(inputHomeLocalPath, path).getPath).tile
     testTile(sc, tile, layoutCols, layoutRows)(rasterOp, sparkOp, asserter)
   }
 

--- a/spark/src/test/scala/geotrellis/spark/OpAsserter.scala
+++ b/spark/src/test/scala/geotrellis/spark/OpAsserter.scala
@@ -16,19 +16,6 @@ trait OpAsserter extends FunSpec
     with TestEnvironment
     with RasterMatchers  {
 
-  // def testArg(sc: SparkContext,
-  //   path: String,
-  //   layoutCols: Int = 4,
-  //   layoutRows: Int = 3)
-  //   (
-  //     rasterOp: (Tile, RasterExtent) => Tile,
-  //     sparkOp: RasterRDD[SpatialKey] => RasterRDD[SpatialKey],
-  //     asserter: (Tile, Tile) => Unit = tilesEqual
-  //   ) = {
-  //   val tile = ArgReader.read(basePath + path)
-  //   testTile(sc, tile, layoutCols, layoutRows)(rasterOp, sparkOp, asserter)
-  // }
-
   def testGeoTiff(sc: SparkContext,
     path: String,
     layoutCols: Int = 4,

--- a/spark/src/test/scala/geotrellis/spark/RDDQuerySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RDDQuerySpec.scala
@@ -10,73 +10,71 @@ import geotrellis.spark.testfiles._
 import org.scalatest._
 
 class RDDQuerySpec extends FunSpec
-  with TestEnvironment with TestFiles  with Matchers with OnlyIfCanRunSpark {
+  with TestEnvironment with TestFiles  with Matchers with TestSparkContext {
 
-  ifCanRunSpark {
-    describe("RasterQuerySpec") {
-      val md = RasterMetaData(
-        TypeFloat,
-        LayoutDefinition(LatLng.worldExtent, TileLayout(8, 8, 3, 4)),
-        Extent(-135.00000125, -89.99999, 134.99999125, 67.49999249999999),
-        LatLng
-        )
+  describe("RasterQuerySpec") {
+    val md = RasterMetaData(
+      TypeFloat,
+      LayoutDefinition(LatLng.worldExtent, TileLayout(8, 8, 3, 4)),
+      Extent(-135.00000125, -89.99999, 134.99999125, 67.49999249999999),
+      LatLng
+    )
 
-      val keyBounds = KeyBounds(SpatialKey(1, 1), SpatialKey(6, 7))
+    val keyBounds = KeyBounds(SpatialKey(1, 1), SpatialKey(6, 7))
 
-      it("should be better then Java serialization") {
-        val query = new RDDQuery[SpatialKey, RasterMetaData].where(Intersects(GridBounds(2, 2, 2, 2)))
-        val outKeyBounds = query(md, keyBounds)
-        info(outKeyBounds.toString)
-      }
-
-      it("should throw on intersecting regions") {
-        val query = new RDDQuery[SpatialKey, RasterMetaData]
-          .where(Intersects(GridBounds(2, 2, 2, 2)) or Intersects(GridBounds(2, 2, 2, 2)))
-
-        intercept[RuntimeException] {
-          query(md, keyBounds)
-        }
-      }
-
+    it("should be better then Java serialization") {
+      val query = new RDDQuery[SpatialKey, RasterMetaData].where(Intersects(GridBounds(2, 2, 2, 2)))
+      val outKeyBounds = query(md, keyBounds)
+      info(outKeyBounds.toString)
     }
 
-    describe("RDDQuery KeyBounds generation") {
-      def spatialKeyBoundsKeys(kb: KeyBounds[SpatialKey]) = {
-        for {
-          row <- kb.minKey.row to kb.maxKey.row
-          col <- kb.minKey.col to kb.maxKey.col
-        } yield SpatialKey(col, row)
+    it("should throw on intersecting regions") {
+      val query = new RDDQuery[SpatialKey, RasterMetaData]
+        .where(Intersects(GridBounds(2, 2, 2, 2)) or Intersects(GridBounds(2, 2, 2, 2)))
+
+      intercept[RuntimeException] {
+        query(md, keyBounds)
       }
-
-
-      val md = AllOnesTestFile.metaData
-      val kb = KeyBounds[SpatialKey](SpatialKey(0, 0), SpatialKey(6, 7))
-
-      it("should generate KeyBounds for single region") {
-        val bounds1 = GridBounds(1, 1, 3, 2)
-        val query = new RDDQuery[SpatialKey, RasterMetaData].where(Intersects(bounds1))
-        val expected = for ((x, y) <- bounds1.coords) yield SpatialKey(x, y)
-
-        val found = query(md, kb).flatMap(spatialKeyBoundsKeys)
-        info(s"missing: ${(expected diff found).toList}")
-        info(s"unwanted: ${(found diff expected).toList}")
-
-        found should contain theSameElementsAs expected
-      }
-
-      it("should generate KeyBounds for two regions") {
-        val bounds1 = GridBounds(1, 1, 3, 3)
-        val bounds2 = GridBounds(4, 5, 6, 6)
-        val query = new RDDQuery[SpatialKey, RasterMetaData].where(Intersects(bounds1) or Intersects(bounds2))
-        val expected = for ((x, y) <- bounds1.coords ++ bounds2.coords) yield SpatialKey(x, y)
-
-        val found = query(md, kb).flatMap(spatialKeyBoundsKeys)
-        info(s"missing: ${(expected diff found).toList}")
-        info(s"unwanted: ${(found diff expected).toList}")
-
-        found should contain theSameElementsAs expected
-      }
-      // TODO: it would be nice to test SpaceTime too, but since time doesn't have a resolution we can not iterate
     }
+
+  }
+
+  describe("RDDQuery KeyBounds generation") {
+    def spatialKeyBoundsKeys(kb: KeyBounds[SpatialKey]) = {
+      for {
+        row <- kb.minKey.row to kb.maxKey.row
+        col <- kb.minKey.col to kb.maxKey.col
+      } yield SpatialKey(col, row)
+    }
+
+
+    val md = AllOnesTestFile.metaData
+    val kb = KeyBounds[SpatialKey](SpatialKey(0, 0), SpatialKey(6, 7))
+
+    it("should generate KeyBounds for single region") {
+      val bounds1 = GridBounds(1, 1, 3, 2)
+      val query = new RDDQuery[SpatialKey, RasterMetaData].where(Intersects(bounds1))
+      val expected = for ((x, y) <- bounds1.coords) yield SpatialKey(x, y)
+
+      val found = query(md, kb).flatMap(spatialKeyBoundsKeys)
+      info(s"missing: ${(expected diff found).toList}")
+      info(s"unwanted: ${(found diff expected).toList}")
+
+      found should contain theSameElementsAs expected
+    }
+
+    it("should generate KeyBounds for two regions") {
+      val bounds1 = GridBounds(1, 1, 3, 3)
+      val bounds2 = GridBounds(4, 5, 6, 6)
+      val query = new RDDQuery[SpatialKey, RasterMetaData].where(Intersects(bounds1) or Intersects(bounds2))
+      val expected = for ((x, y) <- bounds1.coords ++ bounds2.coords) yield SpatialKey(x, y)
+
+      val found = query(md, kb).flatMap(spatialKeyBoundsKeys)
+      info(s"missing: ${(expected diff found).toList}")
+      info(s"unwanted: ${(found diff expected).toList}")
+
+      found should contain theSameElementsAs expected
+    }
+    // TODO: it would be nice to test SpaceTime too, but since time doesn't have a resolution we can not iterate
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/RasterRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterRDDSpec.scala
@@ -10,56 +10,53 @@ class RasterRDDSpec extends FunSpec
     with TestFiles
     with RasterRDDMatchers
     with RasterRDDBuilders
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("RasterRDD") {
-    ifCanRunSpark {
+    it("should find integer min/max of AllOnesTestFile") {
+      val ones: RasterRDD[SpatialKey] = AllOnesTestFile
+      val (min, max) = ones.minMax
 
-      it("should find integer min/max of AllOnesTestFile") {
-        val ones: RasterRDD[SpatialKey] = AllOnesTestFile
-        val (min, max) = ones.minMax
-
-        min should be (1)
-        max should be (1)
-      }
-
-      it ("should find integer min/max of example") {
-        val arr: Array[Int] =
-          Array(1, 1, 2, 2,
-                3, 3, 4, 4,
-
-                -1, -1, -2, -2,
-                -3, -3, -4, -4)
-
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val (min, max) = rdd.minMax
-
-        min should be (-4)
-        max should be (4)
-      }
-
-      it ("should find double min/max of example") {
-        val arr: Array[Double] =
-          Array(1, 1, 2, 2,
-                3, 3, 4.1, 4.1,
-
-                -1, -1, -2, -2,
-                -3, -3, -4.1, -4.1)
-
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val (min, max) = rdd.minMaxDouble
-
-        min should be (-4.1)
-        max should be (4.1)
-      }
-
+      min should be (1)
+      max should be (1)
     }
+
+    it ("should find integer min/max of example") {
+      val arr: Array[Int] =
+        Array(1, 1, 2, 2,
+          3, 3, 4, 4,
+
+          -1, -1, -2, -2,
+          -3, -3, -4, -4)
+
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createRasterRDD(sc, tile, tileLayout)
+
+      val (min, max) = rdd.minMax
+
+      min should be (-4)
+      max should be (4)
+    }
+
+    it ("should find double min/max of example") {
+      val arr: Array[Double] =
+        Array(1, 1, 2, 2,
+          3, 3, 4.1, 4.1,
+
+          -1, -1, -2, -2,
+          -3, -3, -4.1, -4.1)
+
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createRasterRDD(sc, tile, tileLayout)
+
+      val (min, max) = rdd.minMaxDouble
+
+      min should be (-4.1)
+      max should be (4.1)
+    }
+
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/TestEnvironment.scala
+++ b/spark/src/test/scala/geotrellis/spark/TestEnvironment.scala
@@ -21,16 +21,27 @@ import geotrellis.spark.utils.SparkUtils
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.FileUtil
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.conf.Configuration
 import org.scalatest._
 import org.scalatest.BeforeAndAfterAll
 
 import java.io.File
 
+object TestEnvironment {
+  def getLocalFS(conf: Configuration): FileSystem = new Path(System.getProperty("java.io.tmpdir")).getFileSystem(conf)
+
+  def inputHome: Path = {
+    val conf = SparkUtils.hadoopConfiguration
+    val localFS = getLocalFS(conf)
+    new Path(localFS.getWorkingDirectory, "spark/src/test/resources/")
+  }
+}
+
 /*
  * These set of traits handle the creation and deletion of test directories on the local fs and hdfs,
  * It uses commons-io in at least one case (recursive directory deletion)
  */
-trait TestEnvironment extends BeforeAndAfterAll {self: Suite =>
+trait TestEnvironment extends BeforeAndAfterAll { self: Suite =>
   // get the name of the class which mixes in this trait
   val name = this.getClass.getName
 
@@ -38,11 +49,12 @@ trait TestEnvironment extends BeforeAndAfterAll {self: Suite =>
   val conf = SparkUtils.hadoopConfiguration
 
   // cache the local file system, no tests should have to call getFileSystem
-  val localFS = getLocalFS
+  val localFS = TestEnvironment.getLocalFS(conf)
 
   // e.g., root directory on local file system for source data (e.g., tiffs)
   // localFS.getWorkingDirectory is for e.g., /home/jdoe/git/geotrellis
-  val inputHome = new Path(localFS.getWorkingDirectory, "src/test/resources/")
+  val inputHome = TestEnvironment.inputHome
+  val inputHomeLocalPath = inputHome.toUri.getPath
 
   // test directory paths on local and hdfs 
   // outputHomeLocal - root directory of all tests on the local file system (e.g., file:///tmp/testFiles)

--- a/spark/src/test/scala/geotrellis/spark/TestSparkContext.scala
+++ b/spark/src/test/scala/geotrellis/spark/TestSparkContext.scala
@@ -22,8 +22,8 @@ import org.scalatest._
 import org.scalatest.BeforeAndAfterAll
 import scala.util._
 
-object OnlyIfCanRunSpark {
-  lazy val _sc = {
+object TestSparkContext {
+  lazy val _sc = this.synchronized {
     System.setProperty("spark.driver.port", "0")
     System.setProperty("spark.hostPort", "0")
 
@@ -36,14 +36,6 @@ object OnlyIfCanRunSpark {
   }
 }
 
-trait OnlyIfCanRunSpark extends FunSpec with BeforeAndAfterAll {
-  import OnlyIfCanRunSpark._
-
-  implicit def sc: SparkContext = _sc
-
-  def canRunSpark: Boolean = true
-
-  def ifCanRunSpark(f: => Unit): Unit = {    
-    f
-  }  
+trait TestSparkContext extends FunSpec with BeforeAndAfterAll {
+  implicit def sc: SparkContext = TestSparkContext._sc
 }

--- a/spark/src/test/scala/geotrellis/spark/ingest/IngestSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/ingest/IngestSpec.scala
@@ -23,57 +23,55 @@ import org.scalatest._
 class IngestSpec extends FunSpec
   with Matchers
   with TestEnvironment
-  with OnlyIfCanRunSpark
+  with TestSparkContext
   with OnlyIfGdalInstalled
 {
 
   describe("Ingest") {
-    ifCanRunSpark {
-      it("should ingest GeoTiff"){
-        val source = sc.hadoopGeoTiffRDD(new Path(inputHome, "all-ones.tif"))
-        Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme(LatLng, 512)){ (rdd, zoom) =>
-          zoom should be (10)
-          rdd.count should be (8)
+    it("should ingest GeoTiff"){
+      val source = sc.hadoopGeoTiffRDD(new Path(inputHome, "all-ones.tif"))
+      Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme(LatLng, 512)){ (rdd, zoom) =>
+        zoom should be (10)
+        rdd.count should be (8)
+      }
+    }
+
+    ifGdalInstalled {
+      val expectedKeys = List(
+        SpaceTimeKey(SpatialKey(1,1),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(2,0),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(2,1),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(0,0),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(2,1),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(2,1),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(0,1),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(0,1),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(0,1),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(1,0),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(1,0),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(0,0),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(1,0),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(1,1),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(1,1),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(2,0),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(2,0),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
+        SpaceTimeKey(SpatialKey(0,0),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z")))
+      )
+
+      it("should ingest time-band NetCDF") {
+        val source = sc.netCdfRDD(new Path(inputHome, "ipcc-access1-tasmin.nc"))
+        Ingest[NetCdfBand, SpaceTimeKey](source, LatLng, ZoomedLayoutScheme(LatLng, 512)){ (rdd, level) =>
+          val ingestKeys = rdd.keys.collect()
+          ingestKeys should contain theSameElementsAs expectedKeys
         }
       }
 
-      ifGdalInstalled {
-        val expectedKeys = List(
-          SpaceTimeKey(SpatialKey(1,1),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(2,0),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(2,1),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(0,0),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(2,1),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(2,1),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(0,1),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(0,1),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(0,1),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(1,0),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(1,0),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(0,0),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(1,0),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(1,1),TemporalKey(DateTime.parse("2006-01-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(1,1),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(2,0),TemporalKey(DateTime.parse("2006-02-15T00:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(2,0),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z"))),
-          SpaceTimeKey(SpatialKey(0,0),TemporalKey(DateTime.parse("2006-03-16T12:00:00.000Z")))
-        )
-
-        it("should ingest time-band NetCDF") {
-          val source = sc.netCdfRDD(new Path(inputHome, "ipcc-access1-tasmin.nc"))
-          Ingest[NetCdfBand, SpaceTimeKey](source, LatLng, ZoomedLayoutScheme(LatLng, 512)){ (rdd, level) =>
-            val ingestKeys = rdd.keys.collect()
-            ingestKeys should contain theSameElementsAs expectedKeys
-          }
-        }
-
-        it("should ingest time-band NetCDF in stages"){
-          val source = sc.netCdfRDD(new Path(inputHome, "ipcc-access1-tasmin.nc"))
-          val (zoom, rmd) = source.collectMetaData(LatLng, ZoomedLayoutScheme(LatLng, 512))
-          val tiled = source.tile[SpaceTimeKey](rmd)
-          val ingestKeys = tiled.keys.collect()
-          ingestKeys should contain theSameElementsAs expectedKeys
-        }
+      it("should ingest time-band NetCDF in stages"){
+        val source = sc.netCdfRDD(new Path(inputHome, "ipcc-access1-tasmin.nc"))
+        val (zoom, rmd) = source.collectMetaData(LatLng, ZoomedLayoutScheme(LatLng, 512))
+        val tiled = source.tile[SpaceTimeKey](rmd)
+        val ingestKeys = tiled.keys.collect()
+        ingestKeys should contain theSameElementsAs expectedKeys
       }
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/ingest/TilerSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/ingest/TilerSpec.scala
@@ -16,58 +16,56 @@ import org.apache.spark.SparkContext._
 class TilerSpec extends FunSpec
   with Matchers
   with TestEnvironment
-  with OnlyIfCanRunSpark
+  with TestSparkContext
 {
 
   describe("Tiler") {
-    ifCanRunSpark { 
-      it("should tile overlapping rasters"){
-        def createTile(value: Int): Tile =
-          ArrayTile(Array.ofDim[Int](4 * 5).fill(value), 4, 5)
+    it("should tile overlapping rasters"){
+      def createTile(value: Int): Tile =
+        ArrayTile(Array.ofDim[Int](4 * 5).fill(value), 4, 5)
 
-        val extents = 
-          List(
-            Extent(20.0, 75.0, 100.0, 175.0),
-            Extent(60.0, 25.0, 140.0, 125.0)
-          )
-
-        val (tile1, extent1) = (createTile(1), extents(0))
-        val (tile2, extent2) = (createTile(2), extents(1))
-
-        val totalExtent = Extent(0.0, 0.0, 160.0, 200.0)
-
-        val tileLayout = TileLayout(4, 4, 4, 5)
-
-        val mapTransform = MapKeyTransform(totalExtent, tileLayout.layoutCols, tileLayout.layoutRows)
-
-        val rdd: RDD[(Int, Tile)] = sc.parallelize(Array( (1, tile1), (2, tile2) ))
-        val tiled =
-          Tiler.cutTiles[Int, SpatialKey, Tile]( {i: Int => extents(i - 1)}, {(i: Int, key: SpatialKey) => key}, rdd, mapTransform, tile1.cellType, tileLayout)
-            .reduceByKey { case (tile1, tile2) => if(tile1.get(0,0) > tile2.get(0,0)) tile2.merge(tile1) else tile1.merge(tile2) }
-            .collect
-            .toMap
-
-        tiled.size should be (4*4 - 2) 
-
-        val n = NODATA
-        tiled( SpatialKey(1,2) ).toArray should be (
-          Array( 
-            1, 1, 2, 2,
-            1, 1, 2, 2,
-            1, 1, 2, 2,
-            n, n, 2, 2,
-            n, n, 2, 2)
+      val extents =
+        List(
+          Extent(20.0, 75.0, 100.0, 175.0),
+          Extent(60.0, 25.0, 140.0, 125.0)
         )
 
-        tiled( SpatialKey(1,1) ).toArray should be (
-          Array( 
-            1, 1, 1, 1,
-            1, 1, 1, 1,
-            1, 1, 2, 2,
-            1, 1, 2, 2,
-            1, 1, 2, 2)
-        )
-      }
+      val (tile1, extent1) = (createTile(1), extents(0))
+      val (tile2, extent2) = (createTile(2), extents(1))
+
+      val totalExtent = Extent(0.0, 0.0, 160.0, 200.0)
+
+      val tileLayout = TileLayout(4, 4, 4, 5)
+
+      val mapTransform = MapKeyTransform(totalExtent, tileLayout.layoutCols, tileLayout.layoutRows)
+
+      val rdd: RDD[(Int, Tile)] = sc.parallelize(Array( (1, tile1), (2, tile2) ))
+      val tiled =
+        Tiler.cutTiles[Int, SpatialKey, Tile]( {i: Int => extents(i - 1)}, {(i: Int, key: SpatialKey) => key}, rdd, mapTransform, tile1.cellType, tileLayout)
+          .reduceByKey { case (tile1, tile2) => if(tile1.get(0,0) > tile2.get(0,0)) tile2.merge(tile1) else tile1.merge(tile2) }
+          .collect
+          .toMap
+
+      tiled.size should be (4*4 - 2)
+
+      val n = NODATA
+      tiled( SpatialKey(1,2) ).toArray should be (
+        Array(
+          1, 1, 2, 2,
+          1, 1, 2, 2,
+          1, 1, 2, 2,
+          n, n, 2, 2,
+          n, n, 2, 2)
+      )
+
+      tiled( SpatialKey(1,1) ).toArray should be (
+        Array(
+          1, 1, 1, 1,
+          1, 1, 1, 1,
+          1, 1, 2, 2,
+          1, 1, 2, 2,
+          1, 1, 2, 2)
+      )
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/AllOnesTestTileTests.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/AllOnesTestTileTests.scala
@@ -1,55 +1,52 @@
 package geotrellis.spark.io
 
 import geotrellis.raster.{GridBounds, Tile}
-import geotrellis.spark.{OnlyIfCanRunSpark, SpatialKey}
+import geotrellis.spark.{TestSparkContext, SpatialKey}
 import geotrellis.vector.Extent
 
-trait AllOnesTestTileTests { self: PersistenceSpec[SpatialKey, Tile] with OnlyIfCanRunSpark =>
+trait AllOnesTestTileTests { self: PersistenceSpec[SpatialKey, Tile] with TestSparkContext =>
 
   val bounds1 = GridBounds(1,1,3,3)
   val bounds2 = GridBounds(4,5,6,6)
 
-  if (canRunSpark) {
+  it("filters past layout bounds") {
+    query.where(Intersects(GridBounds(6, 2, 7, 3))).toRDD.keys.collect() should
+    contain theSameElementsAs Array(SpatialKey(6, 3), SpatialKey(6, 2))
+  }
 
-    it("filters past layout bounds") {
-      query.where(Intersects(GridBounds(6, 2, 7, 3))).toRDD.keys.collect() should
-        contain theSameElementsAs Array(SpatialKey(6, 3), SpatialKey(6, 2))
-    }
+  it("query inside layer bounds") {
+    val actual = query.where(Intersects(bounds1)).toRDD.keys.collect()
+    val expected = for ((x, y) <- bounds1.coords) yield SpatialKey(x, y)
 
-    it("query inside layer bounds") {
-      val actual = query.where(Intersects(bounds1)).toRDD.keys.collect()
-      val expected = for ((x, y) <- bounds1.coords) yield SpatialKey(x, y)
+    if (expected.diff(actual).nonEmpty)
+      info(s"missing: ${(expected diff actual).toList}")
+    if (actual.diff(expected).nonEmpty)
+      info(s"unwanted: ${(actual diff expected).toList}")
 
-      if (expected.diff(actual).nonEmpty)
-        info(s"missing: ${(expected diff actual).toList}")
-      if (actual.diff(expected).nonEmpty)
-        info(s"unwanted: ${(actual diff expected).toList}")
+    actual should contain theSameElementsAs expected
+  }
 
-      actual should contain theSameElementsAs expected
-    }
+  it("query outside of layer bounds") {
+    query.where(Intersects(GridBounds(10, 10, 15, 15))).toRDD.collect() should be(empty)
+  }
 
-    it("query outside of layer bounds") {
-      query.where(Intersects(GridBounds(10, 10, 15, 15))).toRDD.collect() should be(empty)
-    }
+  it("disjoint query on space") {
+    val actual = query.where(Intersects(bounds1) or Intersects(bounds2)).toRDD.keys.collect()
+    val expected = for ((x, y) <- bounds1.coords ++ bounds2.coords) yield SpatialKey(x, y)
 
-    it("disjoint query on space") {
-      val actual = query.where(Intersects(bounds1) or Intersects(bounds2)).toRDD.keys.collect()
-      val expected = for ((x, y) <- bounds1.coords ++ bounds2.coords) yield SpatialKey(x, y)
+    if (expected.diff(actual).nonEmpty)
+      info(s"missing: ${(expected diff actual).toList}")
+    if (actual.diff(expected).nonEmpty)
+      info(s"unwanted: ${(actual diff expected).toList}")
 
-      if (expected.diff(actual).nonEmpty)
-        info(s"missing: ${(expected diff actual).toList}")
-      if (actual.diff(expected).nonEmpty)
-        info(s"unwanted: ${(actual diff expected).toList}")
+    actual should contain theSameElementsAs expected
+  }
 
-      actual should contain theSameElementsAs expected
-    }
-
-    it("should filter by extent") {
-      val extent = Extent(-10, -10, 10, 10) // this should intersect the four central tiles in 8x8 layout
-      query.where(Intersects(extent)).toRDD.keys.collect() should
-        contain theSameElementsAs {
-        for ((col, row) <- GridBounds(3, 3, 4, 4).coords) yield SpatialKey(col, row)
-      }
+  it("should filter by extent") {
+    val extent = Extent(-10, -10, 10, 10) // this should intersect the four central tiles in 8x8 layout
+    query.where(Intersects(extent)).toRDD.keys.collect() should
+    contain theSameElementsAs {
+      for ((col, row) <- GridBounds(3, 3, 4, 4).coords) yield SpatialKey(col, row)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/CoordinateSpaceTimeTests.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/CoordinateSpaceTimeTests.scala
@@ -2,10 +2,10 @@ package geotrellis.spark.io
 
 import com.github.nscala_time.time.Imports._
 import geotrellis.raster.{GridBounds, Tile}
-import geotrellis.spark.{OnlyIfCanRunSpark, SpaceTimeKey}
+import geotrellis.spark.{TestSparkContext, SpaceTimeKey}
 import org.joda.time.DateTime
 
-trait CoordinateSpaceTimeTests { self: PersistenceSpec[SpaceTimeKey, Tile] with OnlyIfCanRunSpark =>
+trait CoordinateSpaceTimeTests { self: PersistenceSpec[SpaceTimeKey, Tile] with TestSparkContext =>
   val dates = Vector( // all the dates in the layer
     new DateTime(2010,1,1,0,0,0, DateTimeZone.UTC),
     new DateTime(2011,1,1,0,0,0, DateTimeZone.UTC),
@@ -15,48 +15,46 @@ trait CoordinateSpaceTimeTests { self: PersistenceSpec[SpaceTimeKey, Tile] with 
   val bounds1 = GridBounds(1,1,3,3)
   val bounds2 = GridBounds(4,5,6,6)
 
-  if (canRunSpark) {
-    it("query outside of layer bounds") {
-      query.where(Intersects(GridBounds(10, 10, 15, 15))).toRDD.collect() should be(empty)
+  it("query outside of layer bounds") {
+    query.where(Intersects(GridBounds(10, 10, 15, 15))).toRDD.collect() should be(empty)
+  }
+
+  it("query disjunction on space") {
+    val actual = query.where(Intersects(bounds1) or Intersects(bounds2)).toRDD.keys.collect()
+
+    val expected = {
+      for {
+        (col, row) <- bounds1.coords ++ bounds2.coords
+        time <- dates
+      } yield SpaceTimeKey(col, row, time)
     }
 
-    it("query disjunction on space") {
-      val actual = query.where(Intersects(bounds1) or Intersects(bounds2)).toRDD.keys.collect()
+    if (expected.diff(actual).nonEmpty)
+      info(s"missing: ${(expected diff actual).toList}")
+    if (actual.diff(expected).nonEmpty)
+      info(s"unwanted: ${(actual diff expected).toList}")
 
-      val expected = {
-        for {
-          (col, row) <- bounds1.coords ++ bounds2.coords
-          time <- dates
-        } yield SpaceTimeKey(col, row, time)
+    actual should contain theSameElementsAs expected
+  }
+
+  it("query disjunction on space and time") {
+    val actual = query.where(Intersects(bounds1) or Intersects(bounds2))
+      .where(Between(dates(0), dates(1)) or Between(dates(3), dates(4))).toRDD.keys.collect()
+
+    val expected = {
+      for {
+        (col, row) <- bounds1.coords ++ bounds2.coords
+        time <- dates diff Seq(dates(2))
+      } yield {
+        SpaceTimeKey(col, row, time)
       }
-
-      if (expected.diff(actual).nonEmpty)
-        info(s"missing: ${(expected diff actual).toList}")
-      if (actual.diff(expected).nonEmpty)
-        info(s"unwanted: ${(actual diff expected).toList}")
-
-      actual should contain theSameElementsAs expected
     }
 
-    it("query disjunction on space and time") {
-      val actual = query.where(Intersects(bounds1) or Intersects(bounds2))
-        .where(Between(dates(0), dates(1)) or Between(dates(3), dates(4))).toRDD.keys.collect()
+    if (expected.diff(actual).nonEmpty)
+      info(s"missing: ${(expected diff actual).toList}")
+    if (actual.diff(expected).nonEmpty)
+      info(s"unwanted: ${(actual diff expected).toList}")
 
-      val expected = {
-        for {
-          (col, row) <- bounds1.coords ++ bounds2.coords
-          time <- dates diff Seq(dates(2))
-        } yield {
-          SpaceTimeKey(col, row, time)
-        }
-      }
-
-      if (expected.diff(actual).nonEmpty)
-        info(s"missing: ${(expected diff actual).toList}")
-      if (actual.diff(expected).nonEmpty)
-        info(s"unwanted: ${(actual diff expected).toList}")
-
-      actual should contain theSameElementsAs expected
-    }
+    actual should contain theSameElementsAs expected
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/LayerUpdateSpaceTimeTileTests.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/LayerUpdateSpaceTimeTileTests.scala
@@ -1,35 +1,33 @@
 package geotrellis.spark.io
 
 import geotrellis.raster.Tile
-import geotrellis.spark.{SpaceTimeKey, OnlyIfCanRunSpark, SpatialKey}
+import geotrellis.spark.{SpaceTimeKey, TestSparkContext, SpatialKey}
 
-trait LayerUpdateSpaceTimeTileTests { self: PersistenceSpec[SpaceTimeKey, Tile] with OnlyIfCanRunSpark =>
+trait LayerUpdateSpaceTimeTileTests { self: PersistenceSpec[SpaceTimeKey, Tile] with TestSparkContext =>
 
   def updater: TestUpdater
 
-  if (canRunSpark) {
-    it("should update a layer") {
-      updater.update(layerId, sample)
+  it("should update a layer") {
+    updater.update(layerId, sample)
+  }
+
+  it("should not update a layer (empty set)") {
+    intercept[LayerUpdateError] {
+      updater.update(layerId, sc.emptyRDD[(SpaceTimeKey, Tile)].asInstanceOf[Container])
     }
+  }
 
-    it("should not update a layer (empty set)") {
-      intercept[LayerUpdateError] {
-        updater.update(layerId, sc.emptyRDD[(SpaceTimeKey, Tile)].asInstanceOf[Container])
-      }
-    }
+  it("should not update a layer (keys out of bounds)") {
+    val (minKey, minTile) = sample.sortByKey().first()
+    val (maxKey, maxTile) = sample.sortByKey(false).first()
 
-    it("should not update a layer (keys out of bounds)") {
-      val (minKey, minTile) = sample.sortByKey().first()
-      val (maxKey, maxTile) = sample.sortByKey(false).first()
-
-      val update = sc.parallelize(
-        (minKey.updateSpatialComponent(SpatialKey(minKey.col - 1, minKey.row - 1)), minTile) ::
+    val update = sc.parallelize(
+      (minKey.updateSpatialComponent(SpatialKey(minKey.col - 1, minKey.row - 1)), minTile) ::
         (minKey.updateSpatialComponent(SpatialKey(maxKey.col + 1, maxKey.row + 1)), maxTile) :: Nil
-      ).asInstanceOf[Container]
+    ).asInstanceOf[Container]
 
-      intercept[LayerOutOfKeyBoundsError] {
-        updater.update(layerId, update)
-      }
+    intercept[LayerOutOfKeyBoundsError] {
+      updater.update(layerId, update)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest._
 import spray.json.JsonFormat
 import scala.reflect._
 
-abstract class PersistenceSpec[K: ClassTag, V: ClassTag] extends FunSpec with Matchers { self: OnlyIfCanRunSpark =>
+abstract class PersistenceSpec[K: ClassTag, V: ClassTag] extends FunSpec with Matchers { self: TestSparkContext =>
   type Container <: RDD[(K, V)]
   type TestReader = FilteringLayerReader[LayerId, K, Container]
   type TestWriter = Writer[LayerId, Container]
@@ -28,50 +28,47 @@ abstract class PersistenceSpec[K: ClassTag, V: ClassTag] extends FunSpec with Ma
   val deleteLayerId = LayerId("deleteSample-" + this.getClass.getName, 1) // second layer to avoid data race
   lazy val query = reader.query(layerId)
   
-  if (canRunSpark) {
-
-    it("should not find layer before write") {
-      intercept[LayerNotFoundError] {
-        reader.read(layerId)
-      }
+  it("should not find layer before write") {
+    intercept[LayerNotFoundError] {
+      reader.read(layerId)
     }
+  }
 
-    it("should not delete layer before write") {
-      intercept[LayerNotFoundError] {
-        deleter.delete(layerId)
-      }
+  it("should not delete layer before write") {
+    intercept[LayerNotFoundError] {
+      deleter.delete(layerId)
     }
+  }
 
-    it("should write a layer") {
-      writer.write(layerId, sample)
-      writer.write(deleteLayerId, sample)
-    }
+  it("should write a layer") {
+    writer.write(layerId, sample)
+    writer.write(deleteLayerId, sample)
+  }
 
-    it("should read a layer back") {
-      val actual = reader.read(layerId).keys.collect()
-      val expected = sample.keys.collect()
+  it("should read a layer back") {
+    val actual = reader.read(layerId).keys.collect()
+    val expected = sample.keys.collect()
 
-      if (expected.diff(actual).nonEmpty)
-        info(s"missing: ${(expected diff actual).toList}")
-      if (actual.diff(expected).nonEmpty)
-        info(s"unwanted: ${(actual diff expected).toList}")
+    if (expected.diff(actual).nonEmpty)
+      info(s"missing: ${(expected diff actual).toList}")
+    if (actual.diff(expected).nonEmpty)
+      info(s"unwanted: ${(actual diff expected).toList}")
 
-      actual should contain theSameElementsAs expected
-    }
+    actual should contain theSameElementsAs expected
+  }
 
-    it("should read a single value") {
-      val tileReader = tiles.read(layerId)
-      val key = sample.keys.first()
-      val readV: V = tileReader.read(key)
-      val expectedV: V = sample.filter(_._1 == key).values.first()
-      readV should be equals expectedV
-    }
+  it("should read a single value") {
+    val tileReader = tiles.read(layerId)
+    val key = sample.keys.first()
+    val readV: V = tileReader.read(key)
+    val expectedV: V = sample.filter(_._1 == key).values.first()
+    readV should be equals expectedV
+  }
 
-    it("should delete a layer") {
-      deleter.delete(deleteLayerId)
-      intercept[LayerNotFoundError] {
-        reader.read(deleteLayerId)
-      }
+  it("should delete a layer") {
+    deleter.delete(deleteLayerId)
+    intercept[LayerNotFoundError] {
+      reader.read(deleteLayerId)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
@@ -24,8 +24,8 @@ abstract class PersistenceSpec[K: ClassTag, V: ClassTag] extends FunSpec with Ma
   def deleter: TestDeleter
   def tiles: TestTileReader
 
-  val layerId = LayerId("sample", 1)
-  val deleteLayerId = LayerId("deleteSample", 1) // second layer to avoid data race
+  val layerId = LayerId("sample-" + this.getClass.getName, 1)
+  val deleteLayerId = LayerId("deleteSample-" + this.getClass.getName, 1) // second layer to avoid data race
   lazy val query = reader.query(layerId)
   
   if (canRunSpark) {

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStoreSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStoreSpec.scala
@@ -21,54 +21,51 @@ class AccumuloAttributeStoreSpec extends FunSpec
   with Matchers
   with TestFiles
   with TestEnvironment
-  with OnlyIfCanRunSpark {
+  with TestSparkContext {
 
   describe("Accumulo Attribute Store") {
-    ifCanRunSpark {
+    val accumulo = AccumuloInstance(
+      instanceName = "fake",
+      zookeeper = "localhost",
+      user = "root",
+      token = new PasswordToken("")
+    )
 
-      val accumulo = AccumuloInstance(
-        instanceName = "fake",
-        zookeeper = "localhost",
-        user = "root",
-        token = new PasswordToken("")
-      )
+    val attribStore = new AccumuloAttributeStore(accumulo.connector, "attributes")
+    val layerId = LayerId("test", 3)
 
-      val attribStore = new AccumuloAttributeStore(accumulo.connector, "attributes")
-      val layerId = LayerId("test", 3)
+    it("should save and pull out a histogram") {
+      val histo = DecreasingTestFile.histogram
 
-      it("should save and pull out a histogram") {
-        val histo = DecreasingTestFile.histogram
+      attribStore.write(layerId, "histogram", histo)
 
-        attribStore.write(layerId, "histogram", histo)
+      val loaded = attribStore.read[Histogram](layerId, "histogram")
+      loaded.getMean should be (histo.getMean)
+    }
 
-        val loaded = attribStore.read[Histogram](layerId, "histogram")
-        loaded.getMean should be (histo.getMean)
+    it("should save and load a random RootJsonReadable object") {
+      case class Foo(x: Int, y: String)
+
+      implicit object FooFormat extends RootJsonFormat[Foo] {
+        def write(obj: Foo): JsObject =
+          JsObject(
+            "the_first_field" -> JsNumber(obj.x),
+            "the_second_field" -> JsString(obj.y)
+          )
+
+        def read(json: JsValue): Foo =
+          json.asJsObject.getFields("the_first_field", "the_second_field") match {
+            case Seq(JsNumber(x), JsString(y)) =>
+              Foo(x.toInt, y)
+            case _ =>
+              throw new DeserializationException(s"JSON reading failed.")
+          }
       }
 
-      it("should save and load a random RootJsonReadable object") {
-        case class Foo(x: Int, y: String)
+      val foo = Foo(1, "thing")
 
-        implicit object FooFormat extends RootJsonFormat[Foo] {
-          def write(obj: Foo): JsObject =
-            JsObject(
-              "the_first_field" -> JsNumber(obj.x),
-              "the_second_field" -> JsString(obj.y)
-            )
-
-          def read(json: JsValue): Foo =
-            json.asJsObject.getFields("the_first_field", "the_second_field") match {
-              case Seq(JsNumber(x), JsString(y)) =>
-                Foo(x.toInt, y)
-              case _ =>
-                throw new DeserializationException(s"JSON reading failed.")
-            }
-        }
-
-        val foo = Foo(1, "thing")
-
-        attribStore.write(layerId, "foo", foo)
-        attribStore.read[Foo](layerId, "foo") should be (foo)
-      }
+      attribStore.write(layerId, "foo", foo)
+      attribStore.read[Foo](layerId, "foo") should be (foo)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeAlternativeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeAlternativeSpec.scala
@@ -10,7 +10,7 @@ import geotrellis.spark.io.avro.codecs._
 
 class AccumuloSpaceTimeAlternativeSpec
   extends PersistenceSpec[SpaceTimeKey, Tile]
-          with OnlyIfCanRunSpark
+          with TestSparkContext
           with TestEnvironment with TestFiles
           with CoordinateSpaceTimeTests
           with LayerUpdateSpaceTimeTileTests {

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeSpec.scala
@@ -11,7 +11,7 @@ import org.joda.time.DateTime
 
 abstract class AccumuloSpaceTimeSpec
   extends PersistenceSpec[SpaceTimeKey, Tile]
-          with OnlyIfCanRunSpark
+          with TestSparkContext
           with TestEnvironment with TestFiles
           with CoordinateSpaceTimeTests
           with LayerUpdateSpaceTimeTileTests {

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpatialSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpatialSpec.scala
@@ -9,7 +9,7 @@ import geotrellis.spark._
 
 abstract class AccumuloSpatialSpec
   extends PersistenceSpec[SpatialKey, Tile]
-          with OnlyIfCanRunSpark
+          with TestSparkContext
           with TestEnvironment with TestFiles
           with AllOnesTestTileTests {
   type Container = RasterRDD[SpatialKey]

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopIngestSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopIngestSpec.scala
@@ -21,7 +21,7 @@ class HadoopIngestSpec
   ifCanRunSpark {
     it("should allow filtering files in hadoopGeoTiffRDD") {
       val tilesDir = new Path(localFS.getWorkingDirectory,
-        "../raster-test/data/one-month-tiles/")
+        "raster-test/data/one-month-tiles/")
       val source = sc.hadoopGeoTiffRDD(tilesDir)
 
       // Raises exception if the bogus file isn't properly filtered out
@@ -30,7 +30,7 @@ class HadoopIngestSpec
 
     it("should allow overriding tiff file extensions in hadoopGeoTiffRDD") {
       val tilesDir = new Path(localFS.getWorkingDirectory,
-        "../raster-test/data/one-month-tiles-tiff/")
+        "raster-test/data/one-month-tiles-tiff/")
       val source = sc.hadoopGeoTiffRDD(tilesDir, ".tiff")
 
       // Raises exception if the ".tiff" extension override isn't provided

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopIngestSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopIngestSpec.scala
@@ -14,27 +14,26 @@ class HadoopIngestSpec
     with Matchers
     with RasterRDDMatchers
     with TestEnvironment with TestFiles
-    with OnlyIfCanRunSpark{
+    with TestSparkContext{
 
   val layoutScheme = ZoomedLayoutScheme(LatLng, 512)
 
-  ifCanRunSpark {
-    it("should allow filtering files in hadoopGeoTiffRDD") {
-      val tilesDir = new Path(localFS.getWorkingDirectory,
-        "raster-test/data/one-month-tiles/")
-      val source = sc.hadoopGeoTiffRDD(tilesDir)
+  it("should allow filtering files in hadoopGeoTiffRDD") {
+    val tilesDir = new Path(localFS.getWorkingDirectory,
+      "raster-test/data/one-month-tiles/")
+    val source = sc.hadoopGeoTiffRDD(tilesDir)
 
-      // Raises exception if the bogus file isn't properly filtered out
-      Ingest[ProjectedExtent, SpatialKey](source, LatLng, layoutScheme){ (rdd, level) => {} }
-    }
+    // Raises exception if the bogus file isn't properly filtered out
+    Ingest[ProjectedExtent, SpatialKey](source, LatLng, layoutScheme){ (rdd, level) => {} }
+  }
 
-    it("should allow overriding tiff file extensions in hadoopGeoTiffRDD") {
-      val tilesDir = new Path(localFS.getWorkingDirectory,
-        "raster-test/data/one-month-tiles-tiff/")
-      val source = sc.hadoopGeoTiffRDD(tilesDir, ".tiff")
+  it("should allow overriding tiff file extensions in hadoopGeoTiffRDD") {
+    val tilesDir = new Path(localFS.getWorkingDirectory,
+      "raster-test/data/one-month-tiles-tiff/")
+    val source = sc.hadoopGeoTiffRDD(tilesDir, ".tiff")
 
-      // Raises exception if the ".tiff" extension override isn't provided
-      Ingest[ProjectedExtent, SpatialKey](source, LatLng, layoutScheme){ (rdd, level) => {} }
-    }
+    // Raises exception if the ".tiff" extension override isn't provided
+    Ingest[ProjectedExtent, SpatialKey](source, LatLng, layoutScheme){ (rdd, level) => {} }
   }
 }
+

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopSpaceTimeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopSpaceTimeSpec.scala
@@ -10,7 +10,7 @@ import org.joda.time.DateTime
 
 abstract class HadoopSpaceTimeSpec
   extends PersistenceSpec[SpaceTimeKey, Tile]
-          with OnlyIfCanRunSpark
+          with TestSparkContext
           with TestEnvironment with TestFiles
           with CoordinateSpaceTimeTests {
   type Container = RasterRDD[SpaceTimeKey]

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopSpatialSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopSpatialSpec.scala
@@ -8,7 +8,7 @@ import geotrellis.spark._
 
 abstract class HadoopSpatialSpec
   extends PersistenceSpec[SpatialKey, Tile]
-          with OnlyIfCanRunSpark
+          with TestSparkContext
           with TestEnvironment with TestFiles
           with AllOnesTestTileTests {
   type Container = RasterRDD[SpatialKey]

--- a/spark/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
@@ -9,31 +9,30 @@ import geotrellis.spark.io.hadoop._
 import geotrellis.spark.ingest._
 import org.scalatest._
 
-class GeoTiffS3InputFormatSpec extends FunSpec with OnlyIfCanRunSpark with Matchers {
+class GeoTiffS3InputFormatSpec extends FunSpec with TestSparkContext with Matchers {
   
   describe("GeoTiff S3 InputFormat") {      
     val url = "s3n://geotrellis-test/nlcd-geotiff"      
-    ifCanRunSpark {  
-      it("should read GeoTiffs from S3") {
-        val job = sc.newJob("geotiff-ingest")        
-        S3InputFormat.setUrl(job, url)
-        S3InputFormat.setAnonymous(job)
-        
-        val source = sc.newAPIHadoopRDD(job.getConfiguration,
-          classOf[GeoTiffS3InputFormat],
-          classOf[ProjectedExtent],
-          classOf[Tile])
-        source.map(x=>x).cache      
-        val sourceCount = source.count
-        sourceCount should not be (0)
-        info(s"Source RDD count: ${sourceCount}")
-        
-        Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme(LatLng)){ (rdd, level) =>
-          val rddCount = rdd.count
-          rddCount should not be (0)
-          info(s"Tiled RDD count: ${rddCount}")        
-        }        
-      }
+
+    it("should read GeoTiffs from S3") {
+      val job = sc.newJob("geotiff-ingest")        
+      S3InputFormat.setUrl(job, url)
+      S3InputFormat.setAnonymous(job)
+
+      val source = sc.newAPIHadoopRDD(job.getConfiguration,
+        classOf[GeoTiffS3InputFormat],
+        classOf[ProjectedExtent],
+        classOf[Tile])
+      source.map(x=>x).cache      
+      val sourceCount = source.count
+      sourceCount should not be (0)
+      info(s"Source RDD count: ${sourceCount}")
+
+      Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme(LatLng)){ (rdd, level) =>
+        val rddCount = rdd.count
+        rddCount should not be (0)
+        info(s"Tiled RDD count: ${rddCount}")        
+      }        
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/s3/MockS3Client.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/MockS3Client.scala
@@ -215,4 +215,3 @@ object MockS3Client{
     }
   }
 }
-

--- a/spark/src/test/scala/geotrellis/spark/io/s3/S3SpaceTimeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/S3SpaceTimeSpec.scala
@@ -30,7 +30,7 @@ abstract class S3SpaceTimeSpec
   }
   lazy val reader = new S3LayerReader[SpaceTimeKey, Tile, RasterRDD[SpaceTimeKey]](attributeStore, rddReader, None)
   lazy val updater = new S3LayerUpdater[SpaceTimeKey, Tile, RasterRDD[SpaceTimeKey]](attributeStore, rddWriter, true)
-  lazy val deleter = new S3LayerDeleter(attributeStore)
+  lazy val deleter = new S3LayerDeleter(attributeStore) { override val getS3Client = () => new MockS3Client() }
   lazy val tiles = new S3TileReader[SpaceTimeKey, Tile](attributeStore) {
     override val s3Client = new MockS3Client
   }

--- a/spark/src/test/scala/geotrellis/spark/io/s3/S3SpaceTimeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/S3SpaceTimeSpec.scala
@@ -11,7 +11,7 @@ import org.joda.time.DateTime
 
 abstract class S3SpaceTimeSpec
   extends PersistenceSpec[SpaceTimeKey, Tile]
-          with OnlyIfCanRunSpark
+          with TestSparkContext
           with TestEnvironment with TestFiles
           with CoordinateSpaceTimeTests
           with LayerUpdateSpaceTimeTileTests {

--- a/spark/src/test/scala/geotrellis/spark/io/s3/S3SpatialSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/S3SpatialSpec.scala
@@ -11,7 +11,7 @@ import geotrellis.spark._
 
 abstract class S3SpatialSpec
   extends PersistenceSpec[SpatialKey, Tile]
-          with OnlyIfCanRunSpark
+          with TestSparkContext
           with TestEnvironment with TestFiles
           with AllOnesTestTileTests {
   type Container = RasterRDD[SpatialKey]

--- a/spark/src/test/scala/geotrellis/spark/io/s3/S3SpatialSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/S3SpatialSpec.scala
@@ -18,6 +18,7 @@ abstract class S3SpatialSpec
   val bucket = "mock-bucket"
   val prefix = "catalog"
   override val layerId = LayerId("sample-" + name, 1) // avoid test collisions
+
   lazy val attributeStore = new S3AttributeStore(bucket, prefix) {
     override val s3Client = new MockS3Client()
   }
@@ -33,7 +34,7 @@ abstract class S3SpatialSpec
   }
   lazy val reader = new S3LayerReader[SpatialKey, Tile, RasterRDD[SpatialKey]](attributeStore, rddReader, None)
   lazy val updater = new S3LayerUpdater[SpatialKey, Tile, RasterRDD[SpatialKey]](attributeStore, rddWriter, true)
-  lazy val deleter = new S3LayerDeleter(attributeStore)
+  lazy val deleter = new S3LayerDeleter(attributeStore) { override val getS3Client = () => new MockS3Client() }
   lazy val tiles = new S3TileReader[SpatialKey, Tile](attributeStore) {
     override val s3Client = new MockS3Client()
   }

--- a/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
@@ -13,12 +13,12 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.task._
 import org.scalatest._
 
-class TemporalGeoTiffS3InputFormatSpec extends FunSpec with Matchers with OnlyIfCanRunSpark {
+class TemporalGeoTiffS3InputFormatSpec extends FunSpec with Matchers with TestEnvironment with OnlyIfCanRunSpark {
   val layoutScheme = ZoomedLayoutScheme(LatLng)
 
   describe("Temporal GeoTiff S3 InputFormat"){
     it("should read a custom tiff tag and format") {
-      val path = "src/test/resources/test-time-tag.tif"
+      val path = new java.io.File(inputHomeLocalPath, "test-time-tag.tif").getPath
 
       val format = new TemporalGeoTiffS3InputFormat
       val conf = new Configuration(false)

--- a/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
@@ -13,49 +13,45 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.task._
 import org.scalatest._
 
-class TemporalGeoTiffS3InputFormatSpec extends FunSpec with Matchers with TestEnvironment with OnlyIfCanRunSpark {
+class TemporalGeoTiffS3InputFormatSpec extends FunSpec with Matchers with TestEnvironment with TestSparkContext {
   val layoutScheme = ZoomedLayoutScheme(LatLng)
 
   describe("Temporal GeoTiff S3 InputFormat"){
-    it("should read a custom tiff tag and format") {
-      val path = new java.io.File(inputHomeLocalPath, "test-time-tag.tif").getPath
+    val path = new java.io.File(inputHomeLocalPath, "test-time-tag.tif").getPath
 
-      val format = new TemporalGeoTiffS3InputFormat
-      val conf = new Configuration(false)
-      conf.set(TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_TAG, "TIFFTAG_DATETIME")
-      conf.set(TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_FORMAT, "2015:03:25 18:01:04")
-      val context = new TaskAttemptContextImpl(conf, new TaskAttemptID())
-      val rr = format.createRecordReader(null, context)
-      val (key, tile) = rr.read("key", Filesystem.slurp(path))
-    }
+    val format = new TemporalGeoTiffS3InputFormat
+    val conf = new Configuration(false)
+    conf.set(TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_TAG, "TIFFTAG_DATETIME")
+    conf.set(TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_FORMAT, "2015:03:25 18:01:04")
+    val context = new TaskAttemptContextImpl(conf, new TaskAttemptID())
+    val rr = format.createRecordReader(null, context)
+    val (key, tile) = rr.read("key", Filesystem.slurp(path))
+  }
 
-    ifCanRunSpark {
-      it("should read GeoTiffs with ISO_TIME tag from S3") {
-        val url = "s3n://geotrellis-test/nex-geotiff/"
-        val job = sc.newJob("temporal-geotiff-ingest")        
-        S3InputFormat.setUrl(job, url)
-        S3InputFormat.setAnonymous(job)
+  it("should read GeoTiffs with ISO_TIME tag from S3") {
+    val url = "s3n://geotrellis-test/nex-geotiff/"
+    val job = sc.newJob("temporal-geotiff-ingest")        
+    S3InputFormat.setUrl(job, url)
+    S3InputFormat.setAnonymous(job)
 
-        val conf = job.getConfiguration
-        conf.set(TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_TAG, "ISO_TIME")
-        conf.set(TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_FORMAT, "yyyy-MM-dd'T'HH:mm:ss")
+    val conf = job.getConfiguration
+    conf.set(TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_TAG, "ISO_TIME")
+    conf.set(TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_FORMAT, "yyyy-MM-dd'T'HH:mm:ss")
 
-        val source = sc.newAPIHadoopRDD(job.getConfiguration,
-          classOf[TemporalGeoTiffS3InputFormat],
-          classOf[SpaceTimeInputKey],
-          classOf[Tile])
+    val source = sc.newAPIHadoopRDD(job.getConfiguration,
+      classOf[TemporalGeoTiffS3InputFormat],
+      classOf[SpaceTimeInputKey],
+      classOf[Tile])
 
-        source.cache
-        val sourceCount = source.count
-        sourceCount should not be (0)
-        info(s"Source RDD count: ${sourceCount}")
+    source.cache
+    val sourceCount = source.count
+    sourceCount should not be (0)
+    info(s"Source RDD count: ${sourceCount}")
 
-        Ingest[SpaceTimeInputKey, SpaceTimeKey](source, LatLng, layoutScheme){ (rdd, level) => 
-          val rddCount = rdd.count
-          rddCount should not be (0)
-          info(s"Tiled RDD count: ${rddCount}")
-        }
-      }
+    Ingest[SpaceTimeInputKey, SpaceTimeKey](source, LatLng, layoutScheme){ (rdd, level) => 
+      val rddCount = rdd.count
+      rddCount should not be (0)
+      info(s"Tiled RDD count: ${rddCount}")
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriterSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriterSpec.scala
@@ -18,29 +18,27 @@ class HadoopSlippyTileWriterSpec
     with TestEnvironment 
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("HadoopSlippyTileWriter") {
     val testPath = new File(outputLocalPath, "slippy-write-test").getPath
 
-    ifCanRunSpark {
-      it("can write slippy tiles") {
-        val mapTransform = ZoomedLayoutScheme(WebMercator).levelForZoom(TestFiles.ZOOM_LEVEL).layout.mapTransform
+    it("can write slippy tiles") {
+      val mapTransform = ZoomedLayoutScheme(WebMercator).levelForZoom(TestFiles.ZOOM_LEVEL).layout.mapTransform
 
-        val writer =
-          new HadoopSlippyTileWriter[Tile](testPath, "tif")({ (key, tile) =>
-            SingleBandGeoTiff(tile, mapTransform(key), WebMercator).toByteArray
-          })
+      val writer =
+        new HadoopSlippyTileWriter[Tile](testPath, "tif")({ (key, tile) =>
+          SingleBandGeoTiff(tile, mapTransform(key), WebMercator).toByteArray
+        })
 
-        writer.write(TestFiles.ZOOM_LEVEL, AllOnesTestFile)
+      writer.write(TestFiles.ZOOM_LEVEL, AllOnesTestFile)
 
-        val reader =
-          new FileSlippyTileReader[Tile](testPath)({ (key, bytes) =>
-            SingleBandGeoTiff(bytes).tile
-          })
+      val reader =
+        new FileSlippyTileReader[Tile](testPath)({ (key, bytes) =>
+          SingleBandGeoTiff(bytes).tile
+        })
 
-        rastersEqual(reader.read(TestFiles.ZOOM_LEVEL), AllOnesTestFile)
+      rastersEqual(reader.read(TestFiles.ZOOM_LEVEL), AllOnesTestFile)
 
-      }
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/elevation/AspectSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/elevation/AspectSpec.scala
@@ -9,23 +9,20 @@ import org.scalatest.FunSpec
 
 class AspectSpec extends FunSpec with TestEnvironment
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders
     with OpAsserter {
 
   describe("Aspect Elevation Spec") {
 
-    ifCanRunSpark {
+    it("should match gdal computed slope raster") {
+      val rasterOp = (tile: Tile, re: RasterExtent) => tile.aspect(re.cellSize)
+      val sparkOp = (rdd: RasterRDD[SpatialKey]) => rdd.aspect()
 
-      it("should match gdal computed slope raster") {
-        val rasterOp = (tile: Tile, re: RasterExtent) => tile.aspect(re.cellSize)
-        val sparkOp = (rdd: RasterRDD[SpatialKey]) => rdd.aspect()
+      val path = "aspect.tif"
 
-        val path = "aspect.tif"
-
-        testGeoTiff(sc, path)(rasterOp, sparkOp)
-      }
-
+      testGeoTiff(sc, path)(rasterOp, sparkOp)
     }
+
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/elevation/HillshadeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/elevation/HillshadeSpec.scala
@@ -13,22 +13,19 @@ import spire.syntax.cfor._
 
 class HillshadeSpec extends FunSpec with TestEnvironment
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders
     with OpAsserter {
 
   describe("Hillshade Elevation Spec") {
 
-    ifCanRunSpark {
+    it("should get the same result on elevation for spark op as single raster op") {
+      val rasterOp = (tile: Tile, re: RasterExtent) => tile.hillshade(re.cellSize)
+      val sparkOp = (rdd: RasterRDD[SpatialKey]) => rdd.hillshade()
 
-      it("should get the same result on elevation for spark op as single raster op") {
-        val rasterOp = (tile: Tile, re: RasterExtent) => tile.hillshade(re.cellSize)
-        val sparkOp = (rdd: RasterRDD[SpatialKey]) => rdd.hillshade()
+      val path = "aspect.tif"
 
-        val path = "aspect.tif"
-
-        testGeoTiff(sc, path)(rasterOp, sparkOp)
-      }
+      testGeoTiff(sc, path)(rasterOp, sparkOp)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/elevation/SlopeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/elevation/SlopeSpec.scala
@@ -9,23 +9,20 @@ import org.scalatest.FunSpec
 
 class SlopeSpec extends FunSpec with TestEnvironment
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders
     with OpAsserter {
 
   describe("Slope Elevation Spec") {
 
-    ifCanRunSpark {
+    it("should match gdal computed slope raster") {
+      val rasterOp = (tile: Tile, re: RasterExtent) => tile.slope(re.cellSize)
+      val sparkOp = (rdd: RasterRDD[SpatialKey]) => rdd.slope()
 
-      it("should match gdal computed slope raster") {
-        val rasterOp = (tile: Tile, re: RasterExtent) => tile.slope(re.cellSize)
-        val sparkOp = (rdd: RasterRDD[SpatialKey]) => rdd.slope()
+      val path = "aspect.tif"
 
-        val path = "aspect.tif"
-
-        testGeoTiff(sc, path)(rasterOp, sparkOp)
-      }
-
+      testGeoTiff(sc, path)(rasterOp, sparkOp)
     }
+
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/focal/MaxSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/focal/MaxSpec.scala
@@ -8,93 +8,90 @@ import org.scalatest.FunSpec
 
 class MaxSpec extends FunSpec with TestEnvironment
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders {
 
   describe("Max Focal Spec") {
 
-    ifCanRunSpark {
+    val nd = NODATA
 
-      val nd = NODATA
+    it("should square max for raster rdd") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,7, 1,   1, 1, 1,   1, 1, 1,
+          9, 1, 1,   2, 2, 2,   1, 3, 1,
 
-      it("should square max for raster rdd") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,7, 1,   1, 1, 1,   1, 1, 1,
-            9, 1, 1,   2, 2, 2,   1, 3, 1,
+          3, 8, 1,   3, 3, 3,   1, 1, 2,
+          2, 1, 7,   1, nd,1,   8, 1, 1
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            3, 8, 1,   3, 3, 3,   1, 1, 2,
-            2, 1, 7,   1, nd,1,   8, 1, 1
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalMax(Square(1)).stitch.tile.toArray
 
-        val res = rasterRDD.focalMax(Square(1)).stitch.tile.toArray
+      val expected = Array(
+        9, 9, 7,    2, 2, 2,    3, 3, 3,
+        9, 9, 8,    3, 3, 3,    3, 3, 3,
 
-        val expected = Array(
-          9, 9, 7,    2, 2, 2,    3, 3, 3,
-          9, 9, 8,    3, 3, 3,    3, 3, 3,
+        9, 9, 8,    7, 3, 8,    8, 8, 3,
+        8, 8, 8,    7, 3, 8,    8, 8, 2
+      )
 
-          9, 9, 8,    7, 3, 8,    8, 8, 3,
-          8, 8, 8,    7, 3, 8,    8, 8, 2
-        )
-
-        res should be(expected)
-      }
-
-      it("should square max with 5 x 5 neighborhood") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,7, 1,   1, 1, 1,   1, 1, 1,
-            9, 1, 1,   2, 2, 2,   1, 3, 1,
-
-            3, 8, 1,   3, 3, 3,   1, 1, 2,
-            2, 1, 7,   1, nd,1,   8, 1, 1
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
-
-        val res = rasterRDD.focalMax(Square(2)).stitch.tile.toArray
-
-        val expected = Array(
-          9, 9, 9,    8, 3, 3,    3, 3, 3,
-          9, 9, 9,    8, 8, 8,    8, 8, 8,
-
-          9, 9, 9,    8, 8, 8,    8, 8, 8,
-          9, 9, 9,    8, 8, 8,    8, 8, 8
-        )
-
-        res should be(expected)
-      }
-
-      it("should circle max for raster rdd") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,7, 1,   1, 1, 1,   1, 1, 1,
-            9, 1, 1,   2, 2, 2,   1, 3, 1,
-
-            3, 8, 1,   3, 3, 3,   1, 1, 2,
-            2, 1, 7,   1, nd,1,   8, 1, 1
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
-
-        val res = rasterRDD.focalMax(Circle(1)).stitch.tile.toArray
-
-        val expected = Array(
-          9, 7, 7,    2, 2, 2,    1, 3, 1,
-          9, 9, 2,    3, 3, 3,    3, 3, 3,
-
-          9, 8, 8,    3, 3, 3,    8, 3, 2,
-          3, 8, 7,    7, 3, 8,    8, 8, 2
-        )
-
-        res should be (expected)
-      }
-
+      res should be(expected)
     }
+
+    it("should square max with 5 x 5 neighborhood") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,7, 1,   1, 1, 1,   1, 1, 1,
+          9, 1, 1,   2, 2, 2,   1, 3, 1,
+
+          3, 8, 1,   3, 3, 3,   1, 1, 2,
+          2, 1, 7,   1, nd,1,   8, 1, 1
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
+
+      val res = rasterRDD.focalMax(Square(2)).stitch.tile.toArray
+
+      val expected = Array(
+        9, 9, 9,    8, 3, 3,    3, 3, 3,
+        9, 9, 9,    8, 8, 8,    8, 8, 8,
+
+        9, 9, 9,    8, 8, 8,    8, 8, 8,
+        9, 9, 9,    8, 8, 8,    8, 8, 8
+      )
+
+      res should be(expected)
+    }
+
+    it("should circle max for raster rdd") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,7, 1,   1, 1, 1,   1, 1, 1,
+          9, 1, 1,   2, 2, 2,   1, 3, 1,
+
+          3, 8, 1,   3, 3, 3,   1, 1, 2,
+          2, 1, 7,   1, nd,1,   8, 1, 1
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
+
+      val res = rasterRDD.focalMax(Circle(1)).stitch.tile.toArray
+
+      val expected = Array(
+        9, 7, 7,    2, 2, 2,    1, 3, 1,
+        9, 9, 2,    3, 3, 3,    3, 3, 3,
+
+        9, 8, 8,    3, 3, 3,    8, 3, 2,
+        3, 8, 7,    7, 3, 8,    8, 8, 2
+      )
+
+      res should be (expected)
+    }
+
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/focal/MeanSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/focal/MeanSpec.scala
@@ -10,67 +10,63 @@ import org.scalatest.FunSpec
 class MeanSpec extends FunSpec with TestEnvironment
     with RasterRDDMatchers
     with RasterMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with OpAsserter
     with RasterRDDBuilders {
 
   describe("Mean Focal Spec") {
+    val nd = NODATA
 
-    ifCanRunSpark {
+    it("should square mean for raster rdd") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,7, 1,   1, 3, 5,   9, 8, 2,
+          9, 1, 1,   2, 2, 2,   4, 3, 5,
 
-      val nd = NODATA
+          3, 8, 1,   3, 3, 3,   1, 2, 2,
+          2, 4, 7,   1,nd, 1,   8, 4, 3
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-      it("should square mean for raster rdd") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,7, 1,   1, 3, 5,   9, 8, 2,
-            9, 1, 1,   2, 2, 2,   4, 3, 5,
+      val res = rasterRDD.focalMean(Square(1)).stitch.tile.toArrayDouble
 
-            3, 8, 1,   3, 3, 3,   1, 2, 2,
-            2, 4, 7,   1,nd, 1,   8, 4, 3
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val expected = Array(
+        5.666, 3.8, 2.166,   1.666,   2.5, 4.166,    5.166, 5.166,   4.5,
+        5.6, 3.875, 2.777,   1.888, 2.666, 3.555,    4.111,   4.0, 3.666,
 
-        val res = rasterRDD.focalMean(Square(1)).stitch.tile.toArrayDouble
+        4.5,  4.0, 3.111,    2.5, 2.125,   3.0,      3.111, 3.555, 3.166,
+        4.25, 4.166, 4.0,    3.0,   2.2,   3.2,      3.166, 3.333,  2.75
+      )
 
-        val expected = Array(
-          5.666, 3.8, 2.166,   1.666,   2.5, 4.166,    5.166, 5.166,   4.5,
-          5.6, 3.875, 2.777,   1.888, 2.666, 3.555,    4.111,   4.0, 3.666,
+      arraysEqual(res, expected)
+    }
 
-          4.5,  4.0, 3.111,    2.5, 2.125,   3.0,      3.111, 3.555, 3.166,
-          4.25, 4.166, 4.0,    3.0,   2.2,   3.2,      3.166, 3.333,  2.75
-        )
+    it("should circle mean for raster rdd") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          5.666,  3.8, 2.166,  1.666,   2.5, 4.166,  5.166, 5.166,   4.5,
+          5.6, 3.875, 2.777,   1.888, 2.666, 3.555,  4.111,   4.0, 3.666,
 
-        arraysEqual(res, expected)
-      }
+          4.5,  4.0, 3.111,    2.5, 2.125,   3.0,    3.111, 3.555, 3.166,
+          4.25, 4.166, 4.0,    3.0,   2.2,   3.2,    3.166, 3.333,  2.75
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-      it("should circle mean for raster rdd") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            5.666,  3.8, 2.166,  1.666,   2.5, 4.166,  5.166, 5.166,   4.5,
-            5.6, 3.875, 2.777,   1.888, 2.666, 3.555,  4.111,   4.0, 3.666,
+      val res = rasterRDD.focalMean(Circle(1)).stitch.tile.toArrayDouble
 
-            4.5,  4.0, 3.111,    2.5, 2.125,   3.0,    3.111, 3.555, 3.166,
-            4.25, 4.166, 4.0,    3.0,   2.2,   3.2,    3.166, 3.333,  2.75
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val expected = Array(
+        5.022,3.876,2.602,    2.054, 2.749, 3.846,    4.652, 4.708, 4.444,
+        4.910, 4.01,2.763,    2.299, 2.546, 3.499,    3.988, 4.099, 3.833,
 
-        val res = rasterRDD.focalMean(Circle(1)).stitch.tile.toArrayDouble
+        4.587, 3.93,3.277,    2.524, 2.498, 2.998,    3.388, 3.433, 3.284,
+        4.305,4.104,3.569,    2.925, 2.631, 2.891,    3.202, 3.201, 3.083
+      )
 
-        val expected = Array(
-          5.022,3.876,2.602,    2.054, 2.749, 3.846,    4.652, 4.708, 4.444,
-          4.910, 4.01,2.763,    2.299, 2.546, 3.499,    3.988, 4.099, 3.833,
-
-          4.587, 3.93,3.277,    2.524, 2.498, 2.998,    3.388, 3.433, 3.284,
-          4.305,4.104,3.569,    2.925, 2.631, 2.891,    3.202, 3.201, 3.083
-        )
-
-        arraysEqual(res, expected)
-      }
+      arraysEqual(res, expected)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/focal/MedianSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/focal/MedianSpec.scala
@@ -9,42 +9,39 @@ import org.scalatest.FunSpec
 
 class MedianSpec extends FunSpec with TestEnvironment
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders {
 
   describe("Median Focal Spec") {
 
-    ifCanRunSpark {
+    val nd = NODATA
 
-      val nd = NODATA
+    it("should square median for raster rdd") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,7, 1,   1, 3, 5,   9, 8, 2,
+          9, 1, 1,   2, 2, 2,   4, 3, 5,
 
-      it("should square median for raster rdd") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,7, 1,   1, 3, 5,   9, 8, 2,
-            9, 1, 1,   2, 2, 2,   4, 3, 5,
+          3, 8, 1,   3, 3, 3,   1, 2, 2,
+          2, 4, 7,   1,nd, 1,   8, 4, 3
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            3, 8, 1,   3, 3, 3,   1, 2, 2,
-            2, 4, 7,   1,nd, 1,   8, 4, 3
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalMedian(Square(1)).stitch.tile.toArray
 
-        val res = rasterRDD.focalMedian(Square(1)).stitch.tile.toArray
+      val expected = Array(
+        7, 1, 1,    1, 2, 3,    4, 4, 4,
+        7, 2, 1,    2, 3, 3,    3, 3, 2,
 
-        val expected = Array(
-          7, 1, 1,    1, 2, 3,    4, 4, 4,
-          7, 2, 1,    2, 3, 3,    3, 3, 2,
+        3, 3, 2,    2, 2, 2,    3, 3, 3,
+        3, 3, 3,    3, 3, 3,    2, 2, 2
+      )
 
-          3, 3, 2,    2, 2, 2,    3, 3, 3,
-          3, 3, 3,    3, 3, 3,    2, 2, 2
-        )
-
-        res should be (expected)
-      }
-
+      res should be (expected)
     }
 
   }
+
 }

--- a/spark/src/test/scala/geotrellis/spark/op/focal/MinSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/focal/MinSpec.scala
@@ -8,120 +8,117 @@ import org.scalatest.FunSpec
 
 class MinSpec extends FunSpec with TestEnvironment
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders {
 
   describe("Min Focal Spec") {
 
-    ifCanRunSpark {
+    val nd = NODATA
 
-      val nd = NODATA
+    val NaN = Double.NaN
 
-      val NaN = Double.NaN
+    it("should square min for raster rdd") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,7, 1,   1, 3, 5,   9, 8, 2,
+          9, 1, 1,   2, 2, 2,   4, 3, 5,
 
-      it("should square min for raster rdd") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,7, 1,   1, 3, 5,   9, 8, 2,
-            9, 1, 1,   2, 2, 2,   4, 3, 5,
+          3, 8, 1,   3, 3, 3,   1, 2, 2,
+          2, 4, 7,   1,nd, 1,   8, 4, 3
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            3, 8, 1,   3, 3, 3,   1, 2, 2,
-            2, 4, 7,   1,nd, 1,   8, 4, 3
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalMin(Square(1)).stitch.tile.toArray
 
-        val res = rasterRDD.focalMin(Square(1)).stitch.tile.toArray
+      val expected = Array(
+        1, 1, 1,    1, 1, 2,    2, 2, 2,
+        1, 1, 1,    1, 1, 1,    1, 1, 2,
 
-        val expected = Array(
-          1, 1, 1,    1, 1, 2,    2, 2, 2,
-          1, 1, 1,    1, 1, 1,    1, 1, 2,
+        1, 1, 1,    1, 1, 1,    1, 1, 2,
+        2, 1, 1,    1, 1, 1,    1, 1, 2
+      )
 
-          1, 1, 1,    1, 1, 1,    1, 1, 2,
-          2, 1, 1,    1, 1, 1,    1, 1, 2
-        )
+      res should be(expected)
+    }
 
-        res should be(expected)
-      }
+    it("should square min for raster rdd with doubles") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          NaN, 7.1, 1.2,   1.4, 3.9, 5.1,   9.9, 8.1, 2.2,
+          9.4, 1.1, 1.5,   2.5, 2.2, 2.9,   4.0, 3.3, 5.1,
 
-      it("should square min for raster rdd with doubles") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            NaN, 7.1, 1.2,   1.4, 3.9, 5.1,   9.9, 8.1, 2.2,
-            9.4, 1.1, 1.5,   2.5, 2.2, 2.9,   4.0, 3.3, 5.1,
+          3.4, 8.2, 1.9,   3.8, 3.1, 3.0,   1.3, 2.1, 2.5,
+          2.5, 4.9, 7.1,   1.4, NaN, 1.1,   8.0, 4.8, 3.0
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            3.4, 8.2, 1.9,   3.8, 3.1, 3.0,   1.3, 2.1, 2.5,
-            2.5, 4.9, 7.1,   1.4, NaN, 1.1,   8.0, 4.8, 3.0
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalMin(Square(1)).stitch.tile.toArrayDouble
 
-        val res = rasterRDD.focalMin(Square(1)).stitch.tile.toArrayDouble
+      val expected = Array(
+        1.1, 1.1, 1.1,    1.2, 1.4, 2.2,    2.9, 2.2, 2.2,
+        1.1, 1.1, 1.1,    1.2, 1.4, 1.3,    1.3, 1.3, 2.1,
 
-        val expected = Array(
-          1.1, 1.1, 1.1,    1.2, 1.4, 2.2,    2.9, 2.2, 2.2,
-          1.1, 1.1, 1.1,    1.2, 1.4, 1.3,    1.3, 1.3, 2.1,
+        1.1, 1.1, 1.1,    1.4, 1.1, 1.1,    1.1, 1.3, 2.1,
+        2.5, 1.9, 1.4,    1.4, 1.1, 1.1,    1.1, 1.3, 2.1
+      )
 
-          1.1, 1.1, 1.1,    1.4, 1.1, 1.1,    1.1, 1.3, 2.1,
-          2.5, 1.9, 1.4,    1.4, 1.1, 1.1,    1.1, 1.3, 2.1
-        )
+      res should be(expected)
+    }
 
-        res should be(expected)
-      }
+    it("should square min with 5 x 5 neighborhood") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,7, 7,   7, 3, 5,   9, 8, 2,
+          9, 7, 7,   2, 2, 2,   4, 3, 5,
 
-      it("should square min with 5 x 5 neighborhood") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,7, 7,   7, 3, 5,   9, 8, 2,
-            9, 7, 7,   2, 2, 2,   4, 3, 5,
+          3, 8, 7,   3, 3, 3,   7, 4, 5,
+          9, 4, 7,   7,nd, 7,   8, 4, 3
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            3, 8, 7,   3, 3, 3,   7, 4, 5,
-            9, 4, 7,   7,nd, 7,   8, 4, 3
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalMin(Square(2)).stitch.tile.toArray
 
-        val res = rasterRDD.focalMin(Square(2)).stitch.tile.toArray
+      val expected = Array(
+        3, 2, 2,    2, 2, 2,    2, 2, 2,
+        3, 2, 2,    2, 2, 2,    2, 2, 2,
 
-        val expected = Array(
-          3, 2, 2,    2, 2, 2,    2, 2, 2,
-          3, 2, 2,    2, 2, 2,    2, 2, 2,
+        3, 2, 2,    2, 2, 2,    2, 2, 2,
+        3, 2, 2,    2, 2, 2,    2, 2, 3
+      )
 
-          3, 2, 2,    2, 2, 2,    2, 2, 2,
-          3, 2, 2,    2, 2, 2,    2, 2, 3
-        )
+      res should be(expected)
+    }
 
-        res should be(expected)
-      }
+    it("should circle min for raster rdd") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,7, 4,   5, 4, 2,   9,nd,nd,
+          9, 6, 2,   2, 2, 2,   5, 3,nd,
 
-      it("should circle min for raster rdd") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,7, 4,   5, 4, 2,   9,nd,nd,
-            9, 6, 2,   2, 2, 2,   5, 3,nd,
+          3, 8, 4,   3, 3, 3,   3, 9, 2,
+          2, 9, 7,   4,nd, 9,   8, 8, 4
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            3, 8, 4,   3, 3, 3,   3, 9, 2,
-            2, 9, 7,   4,nd, 9,   8, 8, 4
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalMin(Circle(1)).stitch.tile.toArray
 
-        val res = rasterRDD.focalMin(Circle(1)).stitch.tile.toArray
+      val expected = Array(
+        7, 4, 2,    2, 2, 2,    2, 3, nd,
+        3, 2, 2,    2, 2, 2,    2, 3, 2,
 
-        val expected = Array(
-          7, 4, 2,    2, 2, 2,    2, 3, nd,
-          3, 2, 2,    2, 2, 2,    2, 3, 2,
+        2, 3, 2,    2, 2, 2,    3, 2, 2,
+        2, 2, 4,    3, 3, 3,    3, 4, 2
+      )
 
-          2, 3, 2,    2, 2, 2,    3, 2, 2,
-          2, 2, 4,    3, 3, 3,    3, 4, 2
-        )
-
-        res should be (expected)
-      }
+      res should be (expected)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/focal/ModeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/focal/ModeSpec.scala
@@ -9,41 +9,38 @@ import org.scalatest.FunSpec
 
 class ModeSpec extends FunSpec with TestEnvironment
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders {
 
   describe("Mode Focal Spec") {
 
-    ifCanRunSpark {
+    val nd = NODATA
 
-      val nd = NODATA
+    it("should square mode for raster rdd") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,7, 1,   1, 3, 5,   9, 8, 2,
+          9, 1, 1,   2, 2, 2,   4, 3, 5,
 
-      it("should square mode for raster rdd") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,7, 1,   1, 3, 5,   9, 8, 2,
-            9, 1, 1,   2, 2, 2,   4, 3, 5,
+          3, 8, 1,   3, 3, 3,   1, 2, 2,
+          2, 4, 7,   1,nd, 1,   8, 4, 3
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            3, 8, 1,   3, 3, 3,   1, 2, 2,
-            2, 4, 7,   1,nd, 1,   8, 4, 3
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalMode(Square(1)).stitch.tile.toArray
 
-        val res = rasterRDD.focalMode(Square(1)).stitch.tile.toArray
+      val expected = Array(
+        nd, 1, 1,    1, 2, 2,   nd,nd,nd,
+        nd, 1, 1,    1, 3, 3,   nd, 2, 2,
 
-        val expected = Array(
-          nd, 1, 1,    1, 2, 2,   nd,nd,nd,
-          nd, 1, 1,    1, 3, 3,   nd, 2, 2,
+        nd, 1, 1,    1,nd,nd,   nd,nd,nd,
+        nd,nd, 1,   nd, 3,nd,    1, 2, 2
+      )
 
-          nd, 1, 1,    1,nd,nd,   nd,nd,nd,
-          nd,nd, 1,   nd, 3,nd,    1, 2, 2
-        )
-
-        res should be (expected)
-      }
-
+      res should be (expected)
     }
+
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/focal/SumSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/focal/SumSpec.scala
@@ -12,92 +12,89 @@ import org.scalatest._
 class SumSpec extends FunSpec
     with TestEnvironment
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders {
 
   describe("Sum Focal Spec") {
 
-    ifCanRunSpark {
+    val nd = NODATA
 
-      val nd = NODATA
+    it("should square sum r = 1 for raster rdd") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,1, 1,   1, 1, 1,   1, 1, 1,
+          1, 1, 1,   2, 2, 2,   1, 1, 1,
 
-      it("should square sum r = 1 for raster rdd") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,1, 1,   1, 1, 1,   1, 1, 1,
-            1, 1, 1,   2, 2, 2,   1, 1, 1,
+          1, 1, 1,   3, 3, 3,   1, 1, 1,
+          1, 1, 1,   1,nd, 1,   1, 1, 1
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            1, 1, 1,   3, 3, 3,   1, 1, 1,
-            1, 1, 1,   1,nd, 1,   1, 1, 1
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalSum(Square(1)).stitch.tile.toArray
 
-        val res = rasterRDD.focalSum(Square(1)).stitch.tile.toArray
+      val expected = Array(
+        3, 5, 7,    8, 9, 8,    7, 6, 4,
+        5, 8,12,   15,18,15,   12, 9, 6,
 
-        val expected = Array(
-          3, 5, 7,    8, 9, 8,    7, 6, 4,
-          5, 8,12,   15,18,15,   12, 9, 6,
+        6, 9,12,   14,17,14,   12, 9, 6,
+        4, 6, 8,    9,11, 9,    8, 6, 4
+      )
 
-          6, 9,12,   14,17,14,   12, 9, 6,
-          4, 6, 8,    9,11, 9,    8, 6, 4
-        )
+      res should be (expected)
+    }
 
-        res should be (expected)
-      }
+    it("should square sum with 5x5 neighborhood") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,1, 1,   1, 1, 1,   1, 1, 1,
+          1, 1, 1,   2, 2, 2,    1, 1, 1,
 
-      it("should square sum with 5x5 neighborhood") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,1, 1,   1, 1, 1,   1, 1, 1,
-            1, 1, 1,   2, 2, 2,    1, 1, 1,
+          1, 1, 1,   3, 3, 3,    1, 1, 1,
+          1, 1, 1,   1,nd, 1,    1, 1, 1
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            1, 1, 1,   3, 3, 3,    1, 1, 1,
-            1, 1, 1,   1,nd, 1,    1, 1, 1
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalSum(Square(2)).stitch.tile.toArray
 
-        val res = rasterRDD.focalSum(Square(2)).stitch.tile.toArray
+      val expected = Array(
+        8, 14, 20,   24,24,24,    21,15, 9,
+        11, 18, 24,  28,28,28,   25,19,12,
 
-        val expected = Array(
-          8, 14, 20,   24,24,24,    21,15, 9,
-          11, 18, 24,  28,28,28,   25,19,12,
+        11, 18, 24,  28,28,28,    25,19,12,
+        9, 15, 20,   23,23,23,    20,15, 9
+      )
 
-          11, 18, 24,  28,28,28,    25,19,12,
-          9, 15, 20,   23,23,23,    20,15, 9
-        )
+      res should be (expected)
+    }
 
-        res should be (expected)
-      }
+    it("should circle sum for raster source") {
+      val rasterRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          nd,1, 1,   1, 1, 1,   1, 1, 1,
+          1, 1, 1,   2, 2, 2,    1, 1, 1,
 
-      it("should circle sum for raster source") {
-        val rasterRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            nd,1, 1,   1, 1, 1,   1, 1, 1,
-            1, 1, 1,   2, 2, 2,    1, 1, 1,
+          1, 1, 1,   3, 3, 3,    1, 1, 1,
+          1, 1, 1,   1,nd, 1,    1, 1, 1
+        ), 9, 4),
+        TileLayout(3, 2, 3, 2)
+      )
 
-            1, 1, 1,   3, 3, 3,    1, 1, 1,
-            1, 1, 1,   1,nd, 1,    1, 1, 1
-          ), 9, 4),
-          TileLayout(3, 2, 3, 2)
-        )
+      val res = rasterRDD.focalSum(Circle(1)).stitch.tile.toArray
 
-        val res = rasterRDD.focalSum(Circle(1)).stitch.tile.toArray
+      val expected = Array(
+        2, 3, 4,    5, 5, 5,    4, 4, 3,
+        3, 5, 6,    9,10, 9,    6, 5, 4,
 
-        val expected = Array(
-          2, 3, 4,    5, 5, 5,    4, 4, 3,
-          3, 5, 6,    9,10, 9,    6, 5, 4,
+        4, 5, 7,   10,11,10,    7, 5, 4,
+        3, 4, 4,    5, 5, 5,    4, 4, 3
+      )
 
-          4, 5, 7,   10,11,10,    7, 5, 4,
-          3, 4, 4,    5, 5, 5,    4, 4, 3
-        )
-
-        res should be (expected)
-      }
+      res should be (expected)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/global/VerticalFlipSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/global/VerticalFlipSpec.scala
@@ -9,23 +9,19 @@ import org.scalatest.FunSpec
 
 class VerticalFlipSpec extends FunSpec with TestEnvironment
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders
     with OpAsserter {
 
   describe("VerticalFlip Global Spec") {
+    it("should perform as the non-distributed raster operation") {
+      val rasterOp = (tile: Tile, re: RasterExtent) => tile.verticalFlip
+      val sparkOp = (rdd: RasterRDD[SpatialKey]) => rdd.verticalFlip
 
-    ifCanRunSpark {
+      val path = "aspect.tif"
 
-      it("should perform as the non-distributed raster operation") {
-        val rasterOp = (tile: Tile, re: RasterExtent) => tile.verticalFlip
-        val sparkOp = (rdd: RasterRDD[SpatialKey]) => rdd.verticalFlip
-
-        val path = "aspect.tif"
-
-        testGeoTiff(sc, path)(rasterOp, sparkOp)
-      }
-
+      testGeoTiff(sc, path)(rasterOp, sparkOp)
     }
+
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/AddSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/AddSpec.scala
@@ -28,68 +28,66 @@ class AddSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Add Operation") {
-    ifCanRunSpark {
-      val ones = AllOnesTestFile
+    val ones = AllOnesTestFile
 
-      val onesST = AllOnesSpaceTime
+    val onesST = AllOnesSpaceTime
 
-      it("should add a constant to a raster") {
-        val twos = ones + 1
+    it("should add a constant to a raster") {
+      val twos = ones + 1
 
-        rasterShouldBe(twos, (2, 2))
-        rastersShouldHaveSameIdsAndTileCount(ones, twos)
-      }
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(ones, twos)
+    }
 
-      it("should add a constant to a spacetime raster") {
-        val twos = onesST + 1
+    it("should add a constant to a spacetime raster") {
+      val twos = onesST + 1
 
-        rasterShouldBe(twos, (2, 2))
-        rastersShouldHaveSameIdsAndTileCount(onesST, twos)
-      }
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(onesST, twos)
+    }
 
-      it("should add a raster to a constant") {
-        val twos = 1 +: ones
+    it("should add a raster to a constant") {
+      val twos = 1 +: ones
 
-        rasterShouldBe(twos, (2, 2))
-        rastersShouldHaveSameIdsAndTileCount(ones, twos)
-      }
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(ones, twos)
+    }
 
-      it("should add a spacetime raster to a constant") {
-        val twos = 1 +: onesST
+    it("should add a spacetime raster to a constant") {
+      val twos = 1 +: onesST
 
-        rasterShouldBe(twos, (2, 2))
-        rastersShouldHaveSameIdsAndTileCount(onesST, twos)
-      }
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(onesST, twos)
+    }
 
-      it("should add multiple rasters") {
-        val threes = ones + ones + ones
+    it("should add multiple rasters") {
+      val threes = ones + ones + ones
 
-        rasterShouldBe(threes, (3, 3))
-        rastersShouldHaveSameIdsAndTileCount(ones, threes)
-      }
+      rasterShouldBe(threes, (3, 3))
+      rastersShouldHaveSameIdsAndTileCount(ones, threes)
+    }
 
-      it("should add multiple spacetime rasters") {
-        val twos = onesST + onesST
+    it("should add multiple spacetime rasters") {
+      val twos = onesST + onesST
 
-        rasterShouldBe(twos, (2, 2))
-        rastersShouldHaveSameIdsAndTileCount(onesST, twos)
-      }
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(onesST, twos)
+    }
 
-      it("should add multiple rasters as a seq") {
-        val threes = ones + Array(ones, ones)
+    it("should add multiple rasters as a seq") {
+      val threes = ones + Array(ones, ones)
 
-        rasterShouldBe(threes, (3, 3))
-        rastersShouldHaveSameIdsAndTileCount(ones, threes)
-      }
+      rasterShouldBe(threes, (3, 3))
+      rastersShouldHaveSameIdsAndTileCount(ones, threes)
+    }
 
-      it("should add multiple spacetime rasters as a seq") {
-        val twos = onesST + Array(onesST)
+    it("should add multiple spacetime rasters as a seq") {
+      val twos = onesST + Array(onesST)
 
-        rasterShouldBe(twos, (2, 2))
-        rastersShouldHaveSameIdsAndTileCount(onesST, twos)
-      }
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(onesST, twos)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/AndSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/AndSpec.scala
@@ -27,65 +27,63 @@ class AndSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("And Operation") {
-    ifCanRunSpark {
-      val ones = AllOnesTestFile
-      val twos = AllTwosTestFile
-      val hundreds = AllHundredsTestFile
+    val ones = AllOnesTestFile
+    val twos = AllTwosTestFile
+    val hundreds = AllHundredsTestFile
 
-      val onesST = AllOnesSpaceTime
-      val twosST = AllTwosSpaceTime
-      val hundredsST = AllHundredsSpaceTime
+    val onesST = AllOnesSpaceTime
+    val twosST = AllTwosSpaceTime
+    val hundredsST = AllHundredsSpaceTime
 
-      it("should and a raster with a constant") {
-        val res = ones & 1
+    it("should and a raster with a constant") {
+      val res = ones & 1
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should and a spacetime raster with a constant") {
-        val res = onesST & 1
+    it("should and a spacetime raster with a constant") {
+      val res = onesST & 1
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(onesST, res)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(onesST, res)
+    }
 
-      it("should and a constant with a raster") {
-        val res = 1 &: ones
+    it("should and a constant with a raster") {
+      val res = 1 &: ones
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should and three different rasters") {
-        val res = ones & twos & hundreds
+    it("should and three different rasters") {
+      val res = ones & twos & hundreds
 
-        rasterShouldBe(res, (0, 0))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (0, 0))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should and a constant with a spacetime raster") {
-        val res = 1 &: onesST
+    it("should and a constant with a spacetime raster") {
+      val res = 1 &: onesST
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(onesST, res)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(onesST, res)
+    }
 
-      it("should and three different rasters as a seq") {
-        val res = ones & Seq(twos, hundreds)
+    it("should and three different rasters as a seq") {
+      val res = ones & Seq(twos, hundreds)
 
-        rasterShouldBe(res, (0, 0))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (0, 0))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should and three different spacetime rasters as a seq") {
-        val res = onesST & Seq(twosST, hundredsST)
+    it("should and three different spacetime rasters as a seq") {
+      val res = onesST & Seq(twosST, hundredsST)
 
-        rasterShouldBe(res, (0, 0))
-        rastersShouldHaveSameIdsAndTileCount(onesST, res)
-      }
+      rasterShouldBe(res, (0, 0))
+      rastersShouldHaveSameIdsAndTileCount(onesST, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/DivideSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/DivideSpec.scala
@@ -26,40 +26,38 @@ class DivideSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Divide Operation") {
-    ifCanRunSpark {
-      val twos = AllTwosTestFile
-      val hundreds = AllHundredsTestFile
+    val twos = AllTwosTestFile
+    val hundreds = AllHundredsTestFile
 
-      it("should divide raster values by a constant") {
-        val ones = twos / 2
+    it("should divide raster values by a constant") {
+      val ones = twos / 2
 
-        rasterShouldBe(ones, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(twos, ones)
-      }
+      rasterShouldBe(ones, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(twos, ones)
+    }
 
-      it("should divide from a constant, raster values") {
-        val ones = 2 /: twos
+    it("should divide from a constant, raster values") {
+      val ones = 2 /: twos
 
-        rasterShouldBe(ones, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(twos, ones)
-      }
+      rasterShouldBe(ones, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(twos, ones)
+    }
 
-      it("should divide multiple rasters") {
-        val res = hundreds / twos / twos
+    it("should divide multiple rasters") {
+      val res = hundreds / twos / twos
 
-        rasterShouldBe(res, (25, 25))
-        rastersShouldHaveSameIdsAndTileCount(hundreds, res)
-      }
+      rasterShouldBe(res, (25, 25))
+      rastersShouldHaveSameIdsAndTileCount(hundreds, res)
+    }
 
-      it("should divide multiple rasters as a seq") {
-        val res = hundreds / Seq(twos, twos)
+    it("should divide multiple rasters as a seq") {
+      val res = hundreds / Seq(twos, twos)
 
-        rasterShouldBe(res, (25, 25))
-        rastersShouldHaveSameIdsAndTileCount(hundreds, res)
-      }
+      rasterShouldBe(res, (25, 25))
+      rastersShouldHaveSameIdsAndTileCount(hundreds, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/EqualSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/EqualSpec.scala
@@ -26,43 +26,41 @@ class EqualSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Equal Operation") {
-    ifCanRunSpark {
-      val inc = IncreasingTestFile
-      val ones = AllOnesTestFile
+    val inc = IncreasingTestFile
+    val ones = AllOnesTestFile
 
-      it("should check equal between an integer and a raster") {
-        val res = inc.localEqual(1)
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) 1 else 0
-        )
+    it("should check equal between an integer and a raster") {
+      val res = inc.localEqual(1)
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check equal between an double and a raster") {
-        val res = inc.localEqual(1.0)
+    it("should check equal between an double and a raster") {
+      val res = inc.localEqual(1.0)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check equal between two rasters") {
-        val res = inc.localEqual(ones)
+    it("should check equal between two rasters") {
+      val res = inc.localEqual(ones)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/GreaterOrEqualSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/GreaterOrEqualSpec.scala
@@ -26,66 +26,64 @@ class GreaterOrEqualSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Greater Or Equal Operation") {
-    ifCanRunSpark {
-      val inc = IncreasingTestFile
-      val ones = AllOnesTestFile
+    val inc = IncreasingTestFile
+    val ones = AllOnesTestFile
 
-      it("should check greater or equal between an integer and a raster") {
-        val res = inc >= 1
+    it("should check greater or equal between an integer and a raster") {
+      val res = inc >= 1
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check greater or equal right associative between an integer and a raster") {
-        val res = 1 >=: inc
+    it("should check greater or equal right associative between an integer and a raster") {
+      val res = 1 >=: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check greater or equal between a double and a raster") {
-        val res = inc >= 1.0
+    it("should check greater or equal between a double and a raster") {
+      val res = inc >= 1.0
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check greater or equal right associative between a double and a raster") {
-        val res = 1.0 >=: inc
+    it("should check greater or equal right associative between a double and a raster") {
+      val res = 1.0 >=: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check greater or equal between two rasters") {
-        val res = inc >= ones
+    it("should check greater or equal between two rasters") {
+      val res = inc >= ones
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/GreaterSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/GreaterSpec.scala
@@ -26,65 +26,63 @@ class GreaterSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Greater Operation") {
-    ifCanRunSpark {
-      val inc = IncreasingTestFile
-      val ones = AllOnesTestFile
+    val inc = IncreasingTestFile
+    val ones = AllOnesTestFile
 
-      it("should check greater between an integer and a raster") {
-        val res = inc > 1
+    it("should check greater between an integer and a raster") {
+      val res = inc > 1
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check greater right associative between an integer and a raster") {
-        val res = 1 >>: inc
+    it("should check greater right associative between an integer and a raster") {
+      val res = 1 >>: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check greater between a double and a raster") {
-        val res = inc > 1.0
+    it("should check greater between a double and a raster") {
+      val res = inc > 1.0
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check greater right associative between a double and a raster") {
-        val res = 1.0 >>: inc
+    it("should check greater right associative between a double and a raster") {
+      val res = 1.0 >>: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check greater or equal between two rasters") {
-        val res = inc > ones
+    it("should check greater or equal between two rasters") {
+      val res = inc > ones
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
-        )
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
+      )
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/IfCellSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/IfCellSpec.scala
@@ -27,112 +27,110 @@ class IfCellSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("IfCell Operation") {
-    ifCanRunSpark {
-      val inc = IncreasingTestFile
-      val dec = DecreasingTestFile
+    val inc = IncreasingTestFile
+    val dec = DecreasingTestFile
 
-      val (cols: Int, rows: Int, tots: Int) = {
-        val tile = inc.stitch.tile
-        (tile.cols, tile.rows, tile.cols * tile.rows - 1)
-      }
+    val (cols: Int, rows: Int, tots: Int) = {
+      val tile = inc.stitch.tile
+      (tile.cols, tile.rows, tile.cols * tile.rows - 1)
+    }
 
-      it("should change values mod 2 to 1, testing integer method") {
-        val res = inc.localIf((a: Int) => a % 2 == 0, 1)
+    it("should change values mod 2 to 1, testing integer method") {
+      val res = inc.localIf((a: Int) => a % 2 == 0, 1)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else y * cols + x 
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else y * cols + x 
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(res, inc)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, inc)
+    }
 
-      it("should change values mod 2 to 1 else 0, testing integer method") {
-        val res = inc.localIf((a: Int) => a % 2 == 0, 1, 0)
+    it("should change values mod 2 to 1 else 0, testing integer method") {
+      val res = inc.localIf((a: Int) => a % 2 == 0, 1, 0)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(res, inc)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, inc)
+    }
 
-      it("should change values mod 2 to 1, testing double method") {
-        val res = inc.localIf((a: Double) => a % 2 == 0, 1)
+    it("should change values mod 2 to 1, testing double method") {
+      val res = inc.localIf((a: Double) => a % 2 == 0, 1)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else y * cols + x
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else y * cols + x
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(res, inc)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, inc)
+    }
 
-      it("should change values mod 2 to 1 else 0, testing double method") {
-        val res = inc.localIf((a: Double) => a % 2 == 0, 1, 0)
+    it("should change values mod 2 to 1 else 0, testing double method") {
+      val res = inc.localIf((a: Double) => a % 2 == 0, 1, 0)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(res, inc)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, inc)
+    }
 
-      it("should if 2 values in 2 rasters are math.abs(diff) <= 1 set to 0 integer method") {
-        val thres = tots / 2.0
+    it("should if 2 values in 2 rasters are math.abs(diff) <= 1 set to 0 integer method") {
+      val thres = tots / 2.0
 
-        val res = inc.localIf(dec, (a: Int, b: Int) => math.abs(a - b) <= 1, 0)
+      val res = inc.localIf(dec, (a: Int, b: Int) => math.abs(a - b) <= 1, 0)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (math.abs((y * cols + x) - thres) <= 1) 0 else y * cols + x
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (math.abs((y * cols + x) - thres) <= 1) 0 else y * cols + x
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(res, inc)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, inc)
+    }
 
-      it("should if 2 values in 2 rasters are math.abs(diff) <= 1 set to 0 else 1 integer method") {
-        val thres = tots / 2.0
+    it("should if 2 values in 2 rasters are math.abs(diff) <= 1 set to 0 else 1 integer method") {
+      val thres = tots / 2.0
 
-        val res = inc.localIf(dec, (a: Int, b: Int) => math.abs(a - b) <= 1, 0, 0)
+      val res = inc.localIf(dec, (a: Int, b: Int) => math.abs(a - b) <= 1, 0, 0)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (math.abs((y * cols + x) - thres) <= 1) 0 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (math.abs((y * cols + x) - thres) <= 1) 0 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(res, inc)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, inc)
+    }
 
-      it("should if 2 values in 2 rasters are math.abs(diff) <= 1 set to 0 double method") {
-        val thres = tots / 2.0
+    it("should if 2 values in 2 rasters are math.abs(diff) <= 1 set to 0 double method") {
+      val thres = tots / 2.0
 
-        val res = inc.localIf(dec, (a: Double, b: Double) => math.abs(a - b) <= 1, 0)
+      val res = inc.localIf(dec, (a: Double, b: Double) => math.abs(a - b) <= 1, 0)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (math.abs((y * cols + x) - thres) <= 1) 0 else y * cols + x
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (math.abs((y * cols + x) - thres) <= 1) 0 else y * cols + x
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(res, inc)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, inc)
+    }
 
-      it("should if 2 values in 2 rasters are math.abs(diff) <= 1 set to 0 else 1 double method") {
-        val thres = tots / 2.0
+    it("should if 2 values in 2 rasters are math.abs(diff) <= 1 set to 0 else 1 double method") {
+      val thres = tots / 2.0
 
-        val res = inc.localIf(dec, (a: Double, b: Double) => math.abs(a - b) <= 1, 0, 0)
+      val res = inc.localIf(dec, (a: Double, b: Double) => math.abs(a - b) <= 1, 0, 0)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (math.abs((y * cols + x) - thres) <= 1) 0 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (math.abs((y * cols + x) - thres) <= 1) 0 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(res, inc)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, inc)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/LessOrEqualSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/LessOrEqualSpec.scala
@@ -26,66 +26,64 @@ class LessOrEqualSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Less Or Equal Operation") {
-    ifCanRunSpark {
-      val inc = IncreasingTestFile
-      val ones = AllOnesTestFile
+    val inc = IncreasingTestFile
+    val ones = AllOnesTestFile
 
-      it("should check less or equal between an integer and a raster") {
-        val res = inc <= 1
+    it("should check less or equal between an integer and a raster") {
+      val res = inc <= 1
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check less or equal right associative between an integer and a raster") {
-        val res = 1 <=: inc
+    it("should check less or equal right associative between an integer and a raster") {
+      val res = 1 <=: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check less or equal between a double and a raster") {
-        val res = inc <= 1.0
+    it("should check less or equal between a double and a raster") {
+      val res = inc <= 1.0
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check less or equal right associative between a double and a raster") {
-        val res = 1.0 <=: inc
+    it("should check less or equal right associative between a double and a raster") {
+      val res = 1.0 <=: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check less or equal between two rasters") {
-        val res = inc <= ones
+    it("should check less or equal between two rasters") {
+      val res = inc <= ones
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/LessSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/LessSpec.scala
@@ -26,66 +26,64 @@ class LessSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Less Operation") {
-    ifCanRunSpark {
-      val inc = IncreasingTestFile
-      val ones = AllOnesTestFile
+    val inc = IncreasingTestFile
+    val ones = AllOnesTestFile
 
-      it("should check less between an integer and a raster") {
-        val res = inc < 1
+    it("should check less between an integer and a raster") {
+      val res = inc < 1
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check less right associative between an integer and a raster") {
-        val res = 1 <<: inc
+    it("should check less right associative between an integer and a raster") {
+      val res = 1 <<: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check less between a double and a raster") {
-        val res = inc < 1.0
+    it("should check less between a double and a raster") {
+      val res = inc < 1.0
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check less right associative between a double and a raster") {
-        val res = 1.0 <<: inc
+    it("should check less right associative between a double and a raster") {
+      val res = 1.0 <<: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x <= 1 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check less between two rasters") {
-        val res = inc < ones
+    it("should check less between two rasters") {
+      val res = inc < ones
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 0 && y == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/LocalMapSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/LocalMapSpec.scala
@@ -14,192 +14,189 @@ class LocalMapSpec extends FunSpec
     with TestFiles
     with RasterRDDMatchers
     with RasterRDDBuilders
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Local Map Operations") {
-    ifCanRunSpark {
+    it("should map an integer function over an integer raster rdd") {
+      val arr: Array[Int] =
+        Array(NODATA, 1, 1, 1,
+              1, 1, 1, 1,
 
-      it("should map an integer function over an integer raster rdd") {
-        val arr: Array[Int] =
-          Array(NODATA, 1, 1, 1,
-                1, 1, 1, 1,
+              1, 1, 1, 1,
+              1, 1, 1, NODATA)
 
-                1, 1, 1, 1,
-                1, 1, 1, NODATA)
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
 
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
+      val rdd = createRasterRDD(sc, tile, tileLayout)
 
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val result = rdd.localMap((z: Int) => if (isNoData(z)) 0 else z + 1)
-        rasterShouldBeInt(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) 0 else 2)
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
-      it("should map an integer function over an integer spacetime raster rdd") {
-        val arr: Array[Int] =
-          Array(NODATA, 1, 1, 1,
-                1, 1, 1, 1,
-
-                1, 1, 1, 1,
-                1, 1, 1, NODATA)
-
-        val tile = ArrayTile(arr, 4, 4)  // size should be 4
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createSpaceTimeRasterRDD(sc, Array((tile, new DateTime())), tileLayout)
-
-        val result = rdd.localMap((z: Int) => if (isNoData(z)) 42 else 42)  // All values are 4
-        rasterShouldBe(result, 42, 4)
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
-      it("should map an integer function over a double raster rdd") {
-        val arr: Array[Double] =
-          Array(Double.NaN, 1.5, 1.5, 1.5,
-                1.5, 1.5, 1.5, 1.5,
-
-                1.5, 1.5, 1.5, 1.5,
-                1.5, 1.5, 1.5, Double.NaN)
-
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val result = rdd.localMap((z: Int) => if (isNoData(z)) 0 else z + 1)
-        rasterShouldBe(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) 0.0 else 2.0)
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
-      it("should map an integer function over a double spacetime raster rdd") {
-        val arr: Array[Double] =
-          Array(NODATA, 1.3, 1.5, 1.5,
-                1.1, 1.5, 1.9, NODATA,
-
-                1.2, 1.2, NODATA, 1.2,
-                1.2, NODATA, 1.2, 1.5)
-
-        val tile = ArrayTile(arr, 4, 4)  // size should be 4
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createSpaceTimeRasterRDD(sc, Array((tile, new DateTime())), tileLayout)
-
-        val result = rdd.localMap((z: Int) => if (isNoData(z)) 1000 else z * 10)  // All values are 4
-        rasterShouldBe(result, minMax=(10, 1000))
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
-      it("should map a double function over an integer raster rdd") {
-        val arr: Array[Int] = 
-          Array(NODATA, 1, 1, 1, 
-                1, 1, 1, 1, 
-
-                1, 1, 1, 1,
-                1, 1, 1, NODATA)
-
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val result = rdd.localMapDouble((z: Double) => if (isNoData(z)) 0.0 else z + 1.0)
-        rasterShouldBeInt(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) 0 else 2)
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
-      it("should map a double function over a double raster rdd") {
-        val arr: Array[Double] = 
-          Array(Double.NaN, 1.5, 1.5, 1.5, 
-                1.5, 1.5, 1.5, 1.5, 
-
-                1.5, 1.5, 1.5, 1.5,
-                1.5, 1.5, 1.5, Double.NaN)
-
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val result = rdd.localMapDouble((z: Double) => if (isNoData(z)) 0.0 else z + 0.3)
-        rasterShouldBe(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) 0 else 1.8)
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
-      // TODO figure this out
-      it("should mapIfSet an integer function over an integer raster rdd") {
-        val arr: Array[Int] = 
-          Array(NODATA, 1, 1, 1, 
-                1, 1, 1, 1, 
-                
-                1, 1, 1, 1,
-                1, 1, 1, NODATA)
-
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val result = rdd.localMapIfSet((z: Int) => z + 1)
-        rasterShouldBeInt(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) NODATA else 2)
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
-      it("should mapIfSet a integer function over a double raster rdd") {
-        val arr: Array[Double] =
-          Array(Double.NaN, 1.5, 1.5, 1.5,
-                1.5, 1.5, 1.5, 1.5,
-
-                1.5, 1.5, 1.5, 1.5,
-                1.5, 1.5, 1.5, Double.NaN)
-
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val result = rdd.localMapIfSet((z: Int) => z + 1)
-        // for some reason this is being converted to a double raster tile
-        rasterShouldBe(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) Double.NaN else 2.0)
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
-      it("should mapIfSet an double function over an integer raster rdd") {
-        val arr: Array[Int] =
-          Array(NODATA, 1, 1, 1,
-                1, 1, 1, 1,
-
-                1, 1, 1, 1,
-                1, 1, 1, NODATA)
-
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val result = rdd.localMapIfSetDouble((z: Double) => z + 1.0)
-        rasterShouldBeInt(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) NODATA else 2)
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
-      it("should mapIfSet a double function over a double raster rdd") {
-        val arr: Array[Double] =
-          Array(Double.NaN, 1.5, 1.5, 1.5,
-                1.5, 1.5, 1.5, 1.5,
-
-                1.5, 1.5, 1.5, 1.5,
-                1.5, 1.5, 1.5, Double.NaN)
-
-        val tile = ArrayTile(arr, 4, 4)
-        val tileLayout = TileLayout(2, 2, 2, 2)
-
-        val rdd = createRasterRDD(sc, tile, tileLayout)
-
-        val result = rdd.localMapIfSetDouble((z: Double) => z + 0.3)
-        rasterShouldBe(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) Double.NaN else 1.8)
-        rastersShouldHaveSameIdsAndTileCount(rdd, result)
-      }
-
+      val result = rdd.localMap((z: Int) => if (isNoData(z)) 0 else z + 1)
+      rasterShouldBeInt(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) 0 else 2)
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
     }
+
+    it("should map an integer function over an integer spacetime raster rdd") {
+      val arr: Array[Int] =
+        Array(NODATA, 1, 1, 1,
+              1, 1, 1, 1,
+
+              1, 1, 1, 1,
+              1, 1, 1, NODATA)
+
+      val tile = ArrayTile(arr, 4, 4)  // size should be 4
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createSpaceTimeRasterRDD(sc, Array((tile, new DateTime())), tileLayout)
+
+      val result = rdd.localMap((z: Int) => if (isNoData(z)) 42 else 42)  // All values are 4
+      rasterShouldBe(result, 42, 4)
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
+    }
+
+    it("should map an integer function over a double raster rdd") {
+      val arr: Array[Double] =
+        Array(Double.NaN, 1.5, 1.5, 1.5,
+              1.5, 1.5, 1.5, 1.5,
+
+              1.5, 1.5, 1.5, 1.5,
+              1.5, 1.5, 1.5, Double.NaN)
+
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createRasterRDD(sc, tile, tileLayout)
+
+      val result = rdd.localMap((z: Int) => if (isNoData(z)) 0 else z + 1)
+      rasterShouldBe(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) 0.0 else 2.0)
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
+    }
+
+    it("should map an integer function over a double spacetime raster rdd") {
+      val arr: Array[Double] =
+        Array(NODATA, 1.3, 1.5, 1.5,
+              1.1, 1.5, 1.9, NODATA,
+
+              1.2, 1.2, NODATA, 1.2,
+              1.2, NODATA, 1.2, 1.5)
+
+      val tile = ArrayTile(arr, 4, 4)  // size should be 4
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createSpaceTimeRasterRDD(sc, Array((tile, new DateTime())), tileLayout)
+
+      val result = rdd.localMap((z: Int) => if (isNoData(z)) 1000 else z * 10)  // All values are 4
+      rasterShouldBe(result, minMax=(10, 1000))
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
+    }
+
+    it("should map a double function over an integer raster rdd") {
+      val arr: Array[Int] = 
+        Array(NODATA, 1, 1, 1, 
+              1, 1, 1, 1, 
+
+              1, 1, 1, 1,
+              1, 1, 1, NODATA)
+
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createRasterRDD(sc, tile, tileLayout)
+
+      val result = rdd.localMapDouble((z: Double) => if (isNoData(z)) 0.0 else z + 1.0)
+      rasterShouldBeInt(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) 0 else 2)
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
+    }
+
+    it("should map a double function over a double raster rdd") {
+      val arr: Array[Double] = 
+        Array(Double.NaN, 1.5, 1.5, 1.5, 
+              1.5, 1.5, 1.5, 1.5, 
+
+              1.5, 1.5, 1.5, 1.5,
+              1.5, 1.5, 1.5, Double.NaN)
+
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createRasterRDD(sc, tile, tileLayout)
+
+      val result = rdd.localMapDouble((z: Double) => if (isNoData(z)) 0.0 else z + 0.3)
+      rasterShouldBe(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) 0 else 1.8)
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
+    }
+
+    // TODO figure this out
+    it("should mapIfSet an integer function over an integer raster rdd") {
+      val arr: Array[Int] = 
+        Array(NODATA, 1, 1, 1, 
+              1, 1, 1, 1, 
+
+              1, 1, 1, 1,
+              1, 1, 1, NODATA)
+
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createRasterRDD(sc, tile, tileLayout)
+
+      val result = rdd.localMapIfSet((z: Int) => z + 1)
+      rasterShouldBeInt(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) NODATA else 2)
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
+    }
+
+    it("should mapIfSet a integer function over a double raster rdd") {
+      val arr: Array[Double] =
+        Array(Double.NaN, 1.5, 1.5, 1.5,
+              1.5, 1.5, 1.5, 1.5,
+
+              1.5, 1.5, 1.5, 1.5,
+              1.5, 1.5, 1.5, Double.NaN)
+
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createRasterRDD(sc, tile, tileLayout)
+
+      val result = rdd.localMapIfSet((z: Int) => z + 1)
+      // for some reason this is being converted to a double raster tile
+      rasterShouldBe(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) Double.NaN else 2.0)
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
+    }
+
+    it("should mapIfSet an double function over an integer raster rdd") {
+      val arr: Array[Int] =
+        Array(NODATA, 1, 1, 1,
+              1, 1, 1, 1,
+
+              1, 1, 1, 1,
+              1, 1, 1, NODATA)
+
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createRasterRDD(sc, tile, tileLayout)
+
+      val result = rdd.localMapIfSetDouble((z: Double) => z + 1.0)
+      rasterShouldBeInt(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) NODATA else 2)
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
+    }
+
+    it("should mapIfSet a double function over a double raster rdd") {
+      val arr: Array[Double] =
+        Array(Double.NaN, 1.5, 1.5, 1.5,
+              1.5, 1.5, 1.5, 1.5,
+
+              1.5, 1.5, 1.5, 1.5,
+              1.5, 1.5, 1.5, Double.NaN)
+
+      val tile = ArrayTile(arr, 4, 4)
+      val tileLayout = TileLayout(2, 2, 2, 2)
+
+      val rdd = createRasterRDD(sc, tile, tileLayout)
+
+      val result = rdd.localMapIfSetDouble((z: Double) => z + 0.3)
+      rasterShouldBe(result, (x: Int, y: Int) => if ((x == 0 && y == 0) || (x == 3 && y == 3)) Double.NaN else 1.8)
+      rastersShouldHaveSameIdsAndTileCount(rdd, result)
+    }
+
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/LocalSeqSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/LocalSeqSpec.scala
@@ -27,141 +27,139 @@ class LocalSeqSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Local Seq Operations") {
-    ifCanRunSpark {
-      val ones = AllOnesTestFile
-      val twos = AllTwosTestFile
-      val hundreds = AllHundredsTestFile
-      val inc = IncreasingTestFile
-      val dec = DecreasingTestFile
+    val ones = AllOnesTestFile
+    val twos = AllTwosTestFile
+    val hundreds = AllHundredsTestFile
+    val inc = IncreasingTestFile
+    val dec = DecreasingTestFile
 
-      val (cols: Int, rows: Int) = {
-        val tile = ones.stitch.tile
-        (tile.cols, tile.rows)
-      }
+    val (cols: Int, rows: Int) = {
+      val tile = ones.stitch.tile
+      (tile.cols, tile.rows)
+    }
 
-      it("should test raster rdd seq with one element") {
-        val res = Seq(ones).localAdd
+    it("should test raster rdd seq with one element") {
+      val res = Seq(ones).localAdd
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should add rasters") {
-        val res = Seq(ones, hundreds, ones).localAdd
+    it("should add rasters") {
+      val res = Seq(ones, hundreds, ones).localAdd
 
-        rasterShouldBe(res, (102, 102))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (102, 102))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should get variety of rasters") {
-        val res = Seq(ones, hundreds, ones).localVariety
+    it("should get variety of rasters") {
+      val res = Seq(ones, hundreds, ones).localVariety
 
-        rasterShouldBe(res, (2, 2))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should get mean of rasters") {
-        val res = Seq(ones, hundreds, ones).localMean
+    it("should get mean of rasters") {
+      val res = Seq(ones, hundreds, ones).localMean
 
-        rasterShouldBe(res, (34, 34))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (34, 34))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should min three rasters as a seq") {
-        val res = Seq(inc, dec, hundreds).localMin
+    it("should min three rasters as a seq") {
+      val res = Seq(inc, dec, hundreds).localMin
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => {
-            val decV = cols * rows - (y * cols + x) - 1
-            val incV = y * cols + x
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => {
+          val decV = cols * rows - (y * cols + x) - 1
+          val incV = y * cols + x
 
-            math.min(math.min(decV, incV), 100)
-          }
-        )
+          math.min(math.min(decV, incV), 100)
+        }
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should min three rasters as a seq and take n:th smallest") {
-        val res = Seq(inc, dec, hundreds).localMinN(1)
+    it("should min three rasters as a seq and take n:th smallest") {
+      val res = Seq(inc, dec, hundreds).localMinN(1)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => {
-            val decV = cols * rows - (y * cols + x) - 1
-            val incV = y * cols + x
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => {
+          val decV = cols * rows - (y * cols + x) - 1
+          val incV = y * cols + x
 
-            val d = Array(decV, incV, 100).sorted
-            d(1)
-          }
-        )
+          val d = Array(decV, incV, 100).sorted
+          d(1)
+        }
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should max three rasters as a seq") {
-        val res = Seq(inc, dec, hundreds).localMax
+    it("should max three rasters as a seq") {
+      val res = Seq(inc, dec, hundreds).localMax
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => {
-            val decV = cols * rows - (y * cols + x) - 1
-            val incV = y * cols + x
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => {
+          val decV = cols * rows - (y * cols + x) - 1
+          val incV = y * cols + x
 
-            math.max(math.max(decV, incV), 100)
-          }
-        )
+          math.max(math.max(decV, incV), 100)
+        }
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should max three rasters as a seq and take n:th smallest") {
-        val res = Seq(inc, dec, hundreds).localMaxN(1)
+    it("should max three rasters as a seq and take n:th smallest") {
+      val res = Seq(inc, dec, hundreds).localMaxN(1)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => {
-            val decV = cols * rows - (y * cols + x) - 1
-            val incV = y * cols + x
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => {
+          val decV = cols * rows - (y * cols + x) - 1
+          val incV = y * cols + x
 
-            val d = Array(decV, incV, 100).sorted
-            d(1)
-          }
-        )
+          val d = Array(decV, incV, 100).sorted
+          d(1)
+        }
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should assign the minority of each raster") {
-        val res = Seq(ones, twos, twos, hundreds, hundreds).localMinority()
+    it("should assign the minority of each raster") {
+      val res = Seq(ones, twos, twos, hundreds, hundreds).localMinority()
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
+    }
 
-      it("should assign the nth minority of each raster") {
-        val res = Seq(ones, twos, twos, twos, hundreds, hundreds).localMinority(1)
+    it("should assign the nth minority of each raster") {
+      val res = Seq(ones, twos, twos, twos, hundreds, hundreds).localMinority(1)
 
-        rasterShouldBe(res, (100, 100))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (100, 100))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
+    }
 
-      it("should assign the majority of each raster") {
-        val res = Seq(ones, ones, ones, twos, twos, hundreds).localMajority()
+    it("should assign the majority of each raster") {
+      val res = Seq(ones, ones, ones, twos, twos, hundreds).localMajority()
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
+    }
 
-      it("should assign the nth majority of each raster") {
-        val res = Seq(ones, ones, ones, twos, twos, hundreds).localMajority(1)
+    it("should assign the nth majority of each raster") {
+      val res = Seq(ones, ones, ones, twos, twos, hundreds).localMajority(1)
 
-        rasterShouldBe(res, (2, 2))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/LocalSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/LocalSpec.scala
@@ -25,304 +25,302 @@ class LocalSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Local Operations") {
-    ifCanRunSpark {
-      val ones = AllOnesTestFile
-      val inc = IncreasingTestFile
-      val evo = EveryOtherUndefinedTestFile
-      val evo1Point01Else0Point99 =
-        EveryOther0Point99Else1Point01TestFile
-      val evo1Minus1 = EveryOther1ElseMinus1TestFile
+    val ones = AllOnesTestFile
+    val inc = IncreasingTestFile
+    val evo = EveryOtherUndefinedTestFile
+    val evo1Point01Else0Point99 =
+      EveryOther0Point99Else1Point01TestFile
+    val evo1Minus1 = EveryOther1ElseMinus1TestFile
 
-      val (cols: Int, rows: Int) = {
-        val tile = ones.stitch.tile
-        (tile.cols, tile.rows)
-      }
+    val (cols: Int, rows: Int) = {
+      val tile = ones.stitch.tile
+      (tile.cols, tile.rows)
+    }
 
-      it("should local mask two rasters") {
-        val res = ones.localMask(inc, 1, -1337)
+    it("should local mask two rasters") {
+      val res = ones.localMask(inc, 1, -1337)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) -1337 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) -1337 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should local inverse mask two rasters") {
-        val res = ones.localInverseMask(inc, 1, -1337)
+    it("should local inverse mask two rasters") {
+      val res = ones.localInverseMask(inc, 1, -1337)
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) 1 else -1337
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) 1 else -1337
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should set all undefined values to 0 and the rest to one") {
-        val res = evo.localDefined
+    it("should set all undefined values to 0 and the rest to one") {
+      val res = evo.localDefined
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo, res)
+    }
 
-      it("should set all defined values to 0 and the rest to one") {
-        val res = evo.localUndefined
+    it("should set all defined values to 0 and the rest to one") {
+      val res = evo.localUndefined
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else 0
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else 0
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo, res)
+    }
 
-      it("should square root all values in raster") {
-        val res = inc.localSqrt
+    it("should square root all values in raster") {
+      val res = inc.localSqrt
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.sqrt(y * cols + x),
-          1e-3
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.sqrt(y * cols + x),
+        1e-3
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should round all values in raster") {
-        val res = evo1Point01Else0Point99.localRound
+    it("should round all values in raster") {
+      val res = evo1Point01Else0Point99.localRound
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should log all values in raster") {
-        val res = inc.localLog
+    it("should log all values in raster") {
+      val res = inc.localLog
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.log(y * cols + x),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.log(y * cols + x),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should log base 10 all values in raster") {
-        val res = inc.localLog10
+    it("should log base 10 all values in raster") {
+      val res = inc.localLog10
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.log10(y * cols + x),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.log10(y * cols + x),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should floor all values in raster") {
-        val res = evo1Point01Else0Point99.localFloor
+    it("should floor all values in raster") {
+      val res = evo1Point01Else0Point99.localFloor
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should ceil all values in raster") {
-        val res = evo1Point01Else0Point99.localCeil
+    it("should ceil all values in raster") {
+      val res = evo1Point01Else0Point99.localCeil
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else 2
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if ((y * cols + x) % 2 == 0) 1 else 2
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should negate all values in raster") {
-        val res = inc.localNegate
+    it("should negate all values in raster") {
+      val res = inc.localNegate
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => (y * cols + x) * -1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => (y * cols + x) * -1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should negate with unary operator all values in raster") {
-        val res = -inc
+    it("should negate with unary operator all values in raster") {
+      val res = -inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => (y * cols + x) * -1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => (y * cols + x) * -1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should not all values in raster") {
-        val res = inc.localNot
+    it("should not all values in raster") {
+      val res = inc.localNot
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => ~(y * cols + x)
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => ~(y * cols + x)
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should abs all values in raster") {
-        val res = evo1Minus1.localAbs
+    it("should abs all values in raster") {
+      val res = evo1Minus1.localAbs
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Minus1, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Minus1, res)
+    }
 
-      it("should arc cos all values in raster") {
-        val res = evo1Point01Else0Point99.localAcos
+    it("should arc cos all values in raster") {
+      val res = evo1Point01Else0Point99.localAcos
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.acos(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.acos(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should arc sin all values in raster") {
-        val res = evo1Point01Else0Point99.localAsin
+    it("should arc sin all values in raster") {
+      val res = evo1Point01Else0Point99.localAsin
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.asin(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.asin(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should arc tangent 2 all values in raster") {
-        val res = evo1Point01Else0Point99.localAtan2(evo1Minus1)
+    it("should arc tangent 2 all values in raster") {
+      val res = evo1Point01Else0Point99.localAtan2(evo1Minus1)
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => {
-            val (xa, ya) = if ((y * cols + x) % 2 == 0)
-              (0.99, -1)
-            else
-              (1.01, 1)
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => {
+          val (xa, ya) = if ((y * cols + x) % 2 == 0)
+            (0.99, -1)
+          else
+            (1.01, 1)
 
-            math.atan2(xa, ya)
-          },
-          1e-4
-        )
+          math.atan2(xa, ya)
+        },
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should arc tan all values in raster") {
-        val res = evo1Point01Else0Point99.localAtan
+    it("should arc tan all values in raster") {
+      val res = evo1Point01Else0Point99.localAtan
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.atan(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.atan(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should cos all values in raster") {
-        val res = inc.localCos
+    it("should cos all values in raster") {
+      val res = inc.localCos
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.cos(y * cols + x),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.cos(y * cols + x),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should hyperbolic cos all values in raster") {
-        val res = evo1Point01Else0Point99.localCosh
+    it("should hyperbolic cos all values in raster") {
+      val res = evo1Point01Else0Point99.localCosh
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.cosh(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.cosh(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should sin all values in raster") {
-        val res = inc.localSin
+    it("should sin all values in raster") {
+      val res = inc.localSin
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.sin(y * cols + x),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.sin(y * cols + x),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should hyperbolic sin all values in raster") {
-        val res = evo1Point01Else0Point99.localSinh
+    it("should hyperbolic sin all values in raster") {
+      val res = evo1Point01Else0Point99.localSinh
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.sinh(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.sinh(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should tan all values in raster") {
-        val res = evo1Point01Else0Point99.localTan
+    it("should tan all values in raster") {
+      val res = evo1Point01Else0Point99.localTan
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.tan(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.tan(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
+    }
 
-      it("should hyperbolic tan all values in raster") {
-        val res = evo1Point01Else0Point99.localTanh
+    it("should hyperbolic tan all values in raster") {
+      val res = evo1Point01Else0Point99.localTanh
 
-        rasterShouldBeAbout(
-          res,
-          (x: Int, y: Int) => math.tanh(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
-          1e-4
-        )
+      rasterShouldBeAbout(
+        res,
+        (x: Int, y: Int) => math.tanh(if ((y * cols + x) % 2 == 0) 0.99 else 1.01),
+        1e-4
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(evo1Point01Else0Point99, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/MajoritySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/MajoritySpec.scala
@@ -28,41 +28,39 @@ class MajoritySpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Majority Operation") {
-    ifCanRunSpark {
-      val ones = AllOnesTestFile
-      val twos = AllTwosTestFile
-      val hundreds = AllHundredsTestFile
+    val ones = AllOnesTestFile
+    val twos = AllTwosTestFile
+    val hundreds = AllHundredsTestFile
 
-      it("should assign the majority of each raster, as a traversable") {
-        val res = ones.localMajority(List(twos, hundreds, hundreds))
+    it("should assign the majority of each raster, as a traversable") {
+      val res = ones.localMajority(List(twos, hundreds, hundreds))
 
-        rasterShouldBe(res, (100, 100))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (100, 100))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
+    }
 
-      it("should assign the majority of each raster, as a vararg") {
-        val res = ones.localMajority(twos, twos, hundreds)
+    it("should assign the majority of each raster, as a vararg") {
+      val res = ones.localMajority(twos, twos, hundreds)
 
-        rasterShouldBe(res, (2, 2))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
+    }
 
-      it("should assign the nth majority of each raster, as a traversable") {
-        val res = ones.localMajority(1, List(twos, hundreds, ones, twos, twos))
+    it("should assign the nth majority of each raster, as a traversable") {
+      val res = ones.localMajority(1, List(twos, hundreds, ones, twos, twos))
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
+    }
 
-      it("should assign the nth majority of each raster, as a vararg") {
-        val res = ones.localMajority(1, twos, hundreds, ones, twos, twos)
+    it("should assign the nth majority of each raster, as a vararg") {
+      val res = ones.localMajority(1, twos, hundreds, ones, twos, twos)
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/MaxSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/MaxSpec.scala
@@ -28,70 +28,68 @@ class MaxSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Max Operation") {
-    ifCanRunSpark {
-      val inc = IncreasingTestFile
-      val dec = DecreasingTestFile
-      val hundreds = AllHundredsTestFile
+    val inc = IncreasingTestFile
+    val dec = DecreasingTestFile
+    val hundreds = AllHundredsTestFile
 
-      val tots = 2342523;
+    val tots = 2342523;
 
-      it("should max a raster with an integer") {
-        val thresh = tots / 2
-        val res = inc.localMax(thresh)
+    it("should max a raster with an integer") {
+      val thresh = tots / 2
+      val res = inc.localMax(thresh)
 
-        rasterShouldBe(
-          res,
-          (tile: Tile, x: Int, y: Int) => math.max(y * tile.cols + x, thresh)
-        )
+      rasterShouldBe(
+        res,
+        (tile: Tile, x: Int, y: Int) => math.max(y * tile.cols + x, thresh)
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should max a raster with a double") {
-        val thresh = tots / 2.0
-        val res = inc.localMax(thresh)
+    it("should max a raster with a double") {
+      val thresh = tots / 2.0
+      val res = inc.localMax(thresh)
 
-        rasterShouldBe(
-          res,
-          (tile: Tile, x: Int, y: Int) => math.max(y * tile.cols + x, thresh)
-        )
+      rasterShouldBe(
+        res,
+        (tile: Tile, x: Int, y: Int) => math.max(y * tile.cols + x, thresh)
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should max two rasters") {
-        val res = inc.localMax(dec)
+    it("should max two rasters") {
+      val res = inc.localMax(dec)
 
-        rasterShouldBe(
-          res,
-          (tile: Tile, x: Int, y: Int) => {
-            val decV = tile.cols * tile.rows - (y * tile.cols + x) - 1
-            val incV = y * tile.cols + x
+      rasterShouldBe(
+        res,
+        (tile: Tile, x: Int, y: Int) => {
+          val decV = tile.cols * tile.rows - (y * tile.cols + x) - 1
+          val incV = y * tile.cols + x
 
-            math.max(decV, incV)
-          }
-        )
+          math.max(decV, incV)
+        }
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should max three rasters as a seq") {
-        val res = inc.localMax(Seq(dec, hundreds))
+    it("should max three rasters as a seq") {
+      val res = inc.localMax(Seq(dec, hundreds))
 
-        rasterShouldBe(
-          res,
-          (tile: Tile, x: Int, y: Int) => {
-            val decV = tile.cols * tile.rows - (y * tile.cols + x) - 1
-            val incV = y * tile.cols + x
+      rasterShouldBe(
+        res,
+        (tile: Tile, x: Int, y: Int) => {
+          val decV = tile.cols * tile.rows - (y * tile.cols + x) - 1
+          val incV = y * tile.cols + x
 
-            math.max(math.max(decV, incV), 100)
-          }
-        )
+          math.max(math.max(decV, incV), 100)
+        }
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/MinSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/MinSpec.scala
@@ -27,69 +27,67 @@ class MinSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Min Operation") {
-    ifCanRunSpark {
-      val inc = IncreasingTestFile
-      val dec = DecreasingTestFile
-      val hundreds = AllHundredsTestFile
+    val inc = IncreasingTestFile
+    val dec = DecreasingTestFile
+    val hundreds = AllHundredsTestFile
 
-      it("should min a raster with an integer") {
-        val thresh = 721.1
-        val res = inc.localMin(thresh)
-        rasterShouldBeAbout(
-          res,
-          (tile: Tile, x: Int, y: Int) => math.min(y * tile.cols + x, thresh),
-          1e-3
-        )
+    it("should min a raster with an integer") {
+      val thresh = 721.1
+      val res = inc.localMin(thresh)
+      rasterShouldBeAbout(
+        res,
+        (tile: Tile, x: Int, y: Int) => math.min(y * tile.cols + x, thresh),
+        1e-3
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should min a raster with a double") {
-        val thresh = 873.4
-        val res = inc.localMin(thresh)
+    it("should min a raster with a double") {
+      val thresh = 873.4
+      val res = inc.localMin(thresh)
 
-        rasterShouldBeAbout(
-          res,
-          (t: Tile, x: Int, y: Int) => math.min(y * t.cols + x, thresh),
-          1e-3
-        )
+      rasterShouldBeAbout(
+        res,
+        (t: Tile, x: Int, y: Int) => math.min(y * t.cols + x, thresh),
+        1e-3
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should min two rasters") {
-        val res = inc.localMin(dec)
+    it("should min two rasters") {
+      val res = inc.localMin(dec)
 
-        rasterShouldBe(
-          res,
-          (t: Tile, x: Int, y: Int) => {
-            val decV = t.cols * t.rows - (y * t.cols + x) - 1
-            val incV = y * t.cols + x
+      rasterShouldBe(
+        res,
+        (t: Tile, x: Int, y: Int) => {
+          val decV = t.cols * t.rows - (y * t.cols + x) - 1
+          val incV = y * t.cols + x
 
-            math.min(decV, incV)
-          }
-        )
+          math.min(decV, incV)
+        }
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should min three rasters as a seq") {
-        val res = inc.localMin(Seq(dec, hundreds))
+    it("should min three rasters as a seq") {
+      val res = inc.localMin(Seq(dec, hundreds))
 
-        rasterShouldBe(
-          res,
-          (t: Tile, x: Int, y: Int) => {
-            val decV = t.cols * t.rows - (y * t.cols + x) - 1
-            val incV = y * t.cols + x
+      rasterShouldBe(
+        res,
+        (t: Tile, x: Int, y: Int) => {
+          val decV = t.cols * t.rows - (y * t.cols + x) - 1
+          val incV = y * t.cols + x
 
-            math.min(math.min(decV, incV), 100)
-          }
-        )
+          math.min(math.min(decV, incV), 100)
+        }
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/MinoritySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/MinoritySpec.scala
@@ -27,41 +27,39 @@ class MinoritySpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Minority Operation") {
-    ifCanRunSpark {
-      val ones = AllOnesTestFile
-      val twos = AllTwosTestFile
-      val hundreds = AllHundredsTestFile
+    val ones = AllOnesTestFile
+    val twos = AllTwosTestFile
+    val hundreds = AllHundredsTestFile
 
-      it("should assign the minority of each raster, as a traversable") {
-        val res = ones.localMinority(List(twos, twos, twos, hundreds, hundreds))
+    it("should assign the minority of each raster, as a traversable") {
+      val res = ones.localMinority(List(twos, twos, twos, hundreds, hundreds))
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
+    }
 
-      it("should assign the minority of each raster, as a vararg") {
-        val res = ones.localMinority(twos, twos, hundreds, hundreds)
+    it("should assign the minority of each raster, as a vararg") {
+      val res = ones.localMinority(twos, twos, hundreds, hundreds)
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
+    }
 
-      it("should assign the nth minority of each raster, as a traversable") {
-        val res = ones.localMinority(1, List(twos, hundreds, ones, twos, twos))
+    it("should assign the nth minority of each raster, as a traversable") {
+      val res = ones.localMinority(1, List(twos, hundreds, ones, twos, twos))
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
+    }
 
-      it("should assign the nth minority of each raster, as a vararg") {
-        val res = ones.localMinority(1, twos, hundreds, ones, twos, twos)
+    it("should assign the nth minority of each raster, as a vararg") {
+      val res = ones.localMinority(1, twos, hundreds, ones, twos, twos)
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(res, ones)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(res, ones)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/MultiplySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/MultiplySpec.scala
@@ -25,39 +25,37 @@ class MultiplySpec extends FunSpec
                       with TestEnvironment
                       with TestFiles
                       with RasterRDDMatchers
-                      with OnlyIfCanRunSpark {
+                      with TestSparkContext {
 
   describe("Multiply Operation") {
-    ifCanRunSpark {
-      val twos = AllTwosTestFile
+    val twos = AllTwosTestFile
 
-      it("should multiply a constant by a raster") {
-        val fours = twos * 2
+    it("should multiply a constant by a raster") {
+      val fours = twos * 2
 
-        rasterShouldBe(fours, (4, 4))
-        rastersShouldHaveSameIdsAndTileCount(twos, fours)
-      }
+      rasterShouldBe(fours, (4, 4))
+      rastersShouldHaveSameIdsAndTileCount(twos, fours)
+    }
 
-      it("should multiply a raster by a constant") {
-        val fours = 2 *: twos
+    it("should multiply a raster by a constant") {
+      val fours = 2 *: twos
 
-        rasterShouldBe(fours, (4, 4))
-        rastersShouldHaveSameIdsAndTileCount(twos, fours)
-      }
+      rasterShouldBe(fours, (4, 4))
+      rastersShouldHaveSameIdsAndTileCount(twos, fours)
+    }
 
-      it("should multiply multiple rasters") {
-        val eights = twos * twos * twos
+    it("should multiply multiple rasters") {
+      val eights = twos * twos * twos
 
-        rasterShouldBe(eights, (8, 8))
-        rastersShouldHaveSameIdsAndTileCount(twos, eights)
-      }
+      rasterShouldBe(eights, (8, 8))
+      rastersShouldHaveSameIdsAndTileCount(twos, eights)
+    }
 
-      it("should multiply multiple rasters as a seq") {
-        val eights = twos * Seq(twos, twos)
+    it("should multiply multiple rasters as a seq") {
+      val eights = twos * Seq(twos, twos)
 
-        rasterShouldBe(eights, (8, 8))
-        rastersShouldHaveSameIdsAndTileCount(twos, eights)
-      }
+      rasterShouldBe(eights, (8, 8))
+      rastersShouldHaveSameIdsAndTileCount(twos, eights)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/OrSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/OrSpec.scala
@@ -27,40 +27,38 @@ class OrSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Or Operation") {
-    ifCanRunSpark {
-      val ones = AllOnesTestFile
-      val twos = AllTwosTestFile
-      val hundreds = AllHundredsTestFile
+    val ones = AllOnesTestFile
+    val twos = AllTwosTestFile
+    val hundreds = AllHundredsTestFile
 
-      it("should or a raster with a constant") {
-        val res = ones | 1
+    it("should or a raster with a constant") {
+      val res = ones | 1
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should or a constant with a raster") {
-        val res = 1 |: ones
+    it("should or a constant with a raster") {
+      val res = 1 |: ones
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should or three different rasters") {
-        val res = ones | twos | hundreds
+    it("should or three different rasters") {
+      val res = ones | twos | hundreds
 
-        rasterShouldBe(res, (103, 103))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (103, 103))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should or three different rasters as a seq") {
-        val res = ones | Seq(twos, hundreds)
+    it("should or three different rasters as a seq") {
+      val res = ones | Seq(twos, hundreds)
 
-        rasterShouldBe(res, (103, 103))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (103, 103))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/PowSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/PowSpec.scala
@@ -26,60 +26,58 @@ class PowSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Pow Operation") {
-    ifCanRunSpark {
-      val hundreds = AllHundredsTestFile
-      val twos = AllTwosTestFile
+    val hundreds = AllHundredsTestFile
+    val twos = AllTwosTestFile
 
-      it("should pow a raster with an integer") {
-        val res = twos ** 2
+    it("should pow a raster with an integer") {
+      val res = twos ** 2
 
-        rasterShouldBe(res, (4, 4))
+      rasterShouldBe(res, (4, 4))
 
-        rastersShouldHaveSameIdsAndTileCount(res, twos)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, twos)
+    }
 
-      it("should pow a integer with a raster") {
-        val res = 3 **: twos
+    it("should pow a integer with a raster") {
+      val res = 3 **: twos
 
-        rasterShouldBe(res, (9, 9))
+      rasterShouldBe(res, (9, 9))
 
-        rastersShouldHaveSameIdsAndTileCount(res, twos)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, twos)
+    }
 
-      it("should pow a raster with an double") {
-        val res = twos ** 1.5
+    it("should pow a raster with an double") {
+      val res = twos ** 1.5
 
-        rasterShouldBeAbout(res, (x: Int, y: Int) => math.pow(2, 1.5), 1e-6)
+      rasterShouldBeAbout(res, (x: Int, y: Int) => math.pow(2, 1.5), 1e-6)
 
-        rastersShouldHaveSameIdsAndTileCount(res, twos)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, twos)
+    }
 
-      it("should pow a double with a raster") {
-        val res = 1.5 **: twos
+    it("should pow a double with a raster") {
+      val res = 1.5 **: twos
 
-        rasterShouldBeAbout(res, (x: Int, y: Int) => math.pow(1.5, 2), 1e-10)
+      rasterShouldBeAbout(res, (x: Int, y: Int) => math.pow(1.5, 2), 1e-10)
 
-        rastersShouldHaveSameIdsAndTileCount(res, twos)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, twos)
+    }
 
 
-      it("should pow two rasters") {
-        val res = hundreds ** twos
+    it("should pow two rasters") {
+      val res = hundreds ** twos
 
-        rasterShouldBe(res, (1e4.toInt, 1e4.toInt))
+      rasterShouldBe(res, (1e4.toInt, 1e4.toInt))
 
-        rastersShouldHaveSameIdsAndTileCount(res, hundreds)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, hundreds)
+    }
 
-      it("should pow three rasters as a seq") {
-        val res = hundreds ** Seq(twos, twos)
+    it("should pow three rasters as a seq") {
+      val res = hundreds ** Seq(twos, twos)
 
-        rasterShouldBe(res, (1e8.toInt, 1e8.toInt))
+      rasterShouldBe(res, (1e8.toInt, 1e8.toInt))
 
-        rastersShouldHaveSameIdsAndTileCount(res, hundreds)
-      }
+      rastersShouldHaveSameIdsAndTileCount(res, hundreds)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/SubtractSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/SubtractSpec.scala
@@ -25,41 +25,39 @@ class SubtractSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Subtract Operation") {
-    ifCanRunSpark {
-      val ones = AllOnesTestFile
-      val twos = AllTwosTestFile
-      val hundreds = AllHundredsTestFile
+    val ones = AllOnesTestFile
+    val twos = AllTwosTestFile
+    val hundreds = AllHundredsTestFile
 
-      it("should subtract a constant from a raster") {
-        val res = twos - 1
+    it("should subtract a constant from a raster") {
+      val res = twos - 1
 
-        rasterShouldBe(res, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(twos, res)
-      }
+      rasterShouldBe(res, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(twos, res)
+    }
 
-      it("should subtract from a constant, raster values") {
-        val res = 3 -: twos
+    it("should subtract from a constant, raster values") {
+      val res = 3 -: twos
 
-        rasterShouldBe(ones, (1, 1))
-        rastersShouldHaveSameIdsAndTileCount(twos, res)
-      }
+      rasterShouldBe(ones, (1, 1))
+      rastersShouldHaveSameIdsAndTileCount(twos, res)
+    }
 
-      it("should subtract multiple rasters") {
-        val res = hundreds - twos - ones
+    it("should subtract multiple rasters") {
+      val res = hundreds - twos - ones
 
-        rasterShouldBe(res, (97, 97))
-        rastersShouldHaveSameIdsAndTileCount(hundreds, res)
-      }
+      rasterShouldBe(res, (97, 97))
+      rastersShouldHaveSameIdsAndTileCount(hundreds, res)
+    }
 
-      it("should subtract multiple rasters as a seq") {
-        val res = hundreds - Seq(twos, ones)
+    it("should subtract multiple rasters as a seq") {
+      val res = hundreds - Seq(twos, ones)
 
-        rasterShouldBe(res, (97, 97))
-        rastersShouldHaveSameIdsAndTileCount(hundreds, res)
-      }
+      rasterShouldBe(res, (97, 97))
+      rastersShouldHaveSameIdsAndTileCount(hundreds, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/UnequalSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/UnequalSpec.scala
@@ -26,169 +26,167 @@ class UnequalSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("UnEqual Operation") {
-    ifCanRunSpark {
-      val inc = IncreasingTestFile
-      val ones = AllOnesTestFile
+    val inc = IncreasingTestFile
+    val ones = AllOnesTestFile
 
-      val onesST = AllOnesSpaceTime
-      val twosST = AllTwosSpaceTime
+    val onesST = AllOnesSpaceTime
+    val twosST = AllTwosSpaceTime
 
-      it("should check unEqual between an integer and a raster") {
-        val res = inc !== 1
+    it("should check unEqual between an integer and a raster") {
+      val res = inc !== 1
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check unEqual between an integer and a spacetime raster") {
-        val res1 = onesST !== 1
+    it("should check unEqual between an integer and a spacetime raster") {
+      val res1 = onesST !== 1
 
-        rasterShouldBe(
-          res1,
-          0,
-          210
-        )
+      rasterShouldBe(
+        res1,
+        0,
+        210
+      )
 
-        val res2 = twosST !== 1
-        rasterShouldBe(
-          res2,
-          1,
-          210
-        )
+      val res2 = twosST !== 1
+      rasterShouldBe(
+        res2,
+        1,
+        210
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(onesST, res1)
-        rastersShouldHaveSameIdsAndTileCount(onesST, res2)
-      }
+      rastersShouldHaveSameIdsAndTileCount(onesST, res1)
+      rastersShouldHaveSameIdsAndTileCount(onesST, res2)
+    }
 
-      it("should check unEqual between a double and a raster") {
-        val res = inc !== 1.0
+    it("should check unEqual between a double and a raster") {
+      val res = inc !== 1.0
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check unEqual between an double and a spacetime raster") {
-        val res1 = onesST !== 1.0
+    it("should check unEqual between an double and a spacetime raster") {
+      val res1 = onesST !== 1.0
 
-        rasterShouldBe(
-          res1,
-          0,
-          210
-        )
+      rasterShouldBe(
+        res1,
+        0,
+        210
+      )
 
-        val res2 = twosST !== 1
-        rasterShouldBe(
-          res2,
-          1,
-          210
-        )
+      val res2 = twosST !== 1
+      rasterShouldBe(
+        res2,
+        1,
+        210
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(onesST, res1)
-        rastersShouldHaveSameIdsAndTileCount(onesST, res2)
-      }
+      rastersShouldHaveSameIdsAndTileCount(onesST, res1)
+      rastersShouldHaveSameIdsAndTileCount(onesST, res2)
+    }
 
-      it("should check unEqual between a raster and an integer") {
-        val res = 1 !==: inc
+    it("should check unEqual between a raster and an integer") {
+      val res = 1 !==: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check unEqual between an spacetime raster and an integer") {
-        val res1 = 1 !==: onesST
+    it("should check unEqual between an spacetime raster and an integer") {
+      val res1 = 1 !==: onesST
 
-        rasterShouldBe(
-          res1,
-          0,
-          210
-        )
+      rasterShouldBe(
+        res1,
+        0,
+        210
+      )
 
-        val res2 = twosST !== 1
-        rasterShouldBe(
-          res2,
-          1,
-          210
-        )
+      val res2 = twosST !== 1
+      rasterShouldBe(
+        res2,
+        1,
+        210
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(onesST, res1)
-        rastersShouldHaveSameIdsAndTileCount(onesST, res2)
-      }
+      rastersShouldHaveSameIdsAndTileCount(onesST, res1)
+      rastersShouldHaveSameIdsAndTileCount(onesST, res2)
+    }
 
-      it("should check unEqual between a raster and a double") {
-        val res = 1.0 !==: inc
+    it("should check unEqual between a raster and a double") {
+      val res = 1.0 !==: inc
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check unEqual between a spacetime raster and a double") {
-        val res1 = 1.0 !==: onesST
+    it("should check unEqual between a spacetime raster and a double") {
+      val res1 = 1.0 !==: onesST
 
-        rasterShouldBe(
-          res1,
-          0,
-          210
-        )
+      rasterShouldBe(
+        res1,
+        0,
+        210
+      )
 
-        val res2 = twosST !== 1
-        rasterShouldBe(
-          res2,
-          1,
-          210
-        )
+      val res2 = twosST !== 1
+      rasterShouldBe(
+        res2,
+        1,
+        210
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(onesST, res1)
-        rastersShouldHaveSameIdsAndTileCount(onesST, res2)
-      }
+      rastersShouldHaveSameIdsAndTileCount(onesST, res1)
+      rastersShouldHaveSameIdsAndTileCount(onesST, res2)
+    }
 
-      it("should check unEqual between two rasters") {
-        val res = inc !== ones
+    it("should check unEqual between two rasters") {
+      val res = inc !== ones
 
-        rasterShouldBe(
-          res,
-          (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
-        )
+      rasterShouldBe(
+        res,
+        (x: Int, y: Int) => if (x == 1 && y == 0) 0 else 1
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(inc, res)
-      }
+      rastersShouldHaveSameIdsAndTileCount(inc, res)
+    }
 
-      it("should check unEqual between two spacetime rasters") {
-        val res1 = onesST !== onesST
+    it("should check unEqual between two spacetime rasters") {
+      val res1 = onesST !== onesST
 
-        rasterShouldBe(
-          res1,
-          0,
-          210
-        )
+      rasterShouldBe(
+        res1,
+        0,
+        210
+      )
 
-        val res2 = onesST !== twosST
-        rasterShouldBe(
-          res2,
-          1,
-          210
-        )
+      val res2 = onesST !== twosST
+      rasterShouldBe(
+        res2,
+        1,
+        210
+      )
 
-        rastersShouldHaveSameIdsAndTileCount(onesST, res1)
-        rastersShouldHaveSameIdsAndTileCount(onesST, res2)
-      }
+      rastersShouldHaveSameIdsAndTileCount(onesST, res1)
+      rastersShouldHaveSameIdsAndTileCount(onesST, res2)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/XorSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/XorSpec.scala
@@ -27,72 +27,70 @@ class XorSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
   describe("Xor Operation") {
-    ifCanRunSpark {
-      val ones = AllOnesTestFile
-      val twos = AllTwosTestFile
-      val hundreds = AllHundredsTestFile
+    val ones = AllOnesTestFile
+    val twos = AllTwosTestFile
+    val hundreds = AllHundredsTestFile
 
-      val onesST = AllOnesSpaceTime
-      val twosST = AllTwosSpaceTime
-      val hundredsST = AllHundredsSpaceTime
+    val onesST = AllOnesSpaceTime
+    val twosST = AllTwosSpaceTime
+    val hundredsST = AllHundredsSpaceTime
 
-      it("should xor a raster with a constant") {
-        val res = ones ^ 1
+    it("should xor a raster with a constant") {
+      val res = ones ^ 1
 
-        rasterShouldBe(res, (0, 0))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (0, 0))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should xor a spacetime raster with a constant") {
-        val res = onesST ^ 1
+    it("should xor a spacetime raster with a constant") {
+      val res = onesST ^ 1
 
-        rasterShouldBe(res, (0, 0))
-        rastersShouldHaveSameIdsAndTileCount(onesST, res)
-      }
+      rasterShouldBe(res, (0, 0))
+      rastersShouldHaveSameIdsAndTileCount(onesST, res)
+    }
 
-      it("should xor a constant with a raster") {
-        val res = 2 ^: ones
+    it("should xor a constant with a raster") {
+      val res = 2 ^: ones
 
-        rasterShouldBe(res, (3, 3))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (3, 3))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should xor a constant with a spacetime raster") {
-        val res = 2 ^: onesST
+    it("should xor a constant with a spacetime raster") {
+      val res = 2 ^: onesST
 
-        rasterShouldBe(res, (3, 3))
-        rastersShouldHaveSameIdsAndTileCount(onesST, res)
-      }
+      rasterShouldBe(res, (3, 3))
+      rastersShouldHaveSameIdsAndTileCount(onesST, res)
+    }
 
-      it("should xor three different rasters") {
-        val res = ones ^ twos ^ hundreds
+    it("should xor three different rasters") {
+      val res = ones ^ twos ^ hundreds
 
-        rasterShouldBe(res, (103, 103))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (103, 103))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should xor three different spacetime rasters") {
-        val res = onesST ^ twosST ^ hundredsST
+    it("should xor three different spacetime rasters") {
+      val res = onesST ^ twosST ^ hundredsST
 
-        rasterShouldBe(res, (103, 103))
-        rastersShouldHaveSameIdsAndTileCount(onesST, res)
-      }
+      rasterShouldBe(res, (103, 103))
+      rastersShouldHaveSameIdsAndTileCount(onesST, res)
+    }
 
-      it("should xor three different rasters as a seq") {
-        val res = ones ^ Seq(twos, hundreds)
+    it("should xor three different rasters as a seq") {
+      val res = ones ^ Seq(twos, hundreds)
 
-        rasterShouldBe(res, (103, 103))
-        rastersShouldHaveSameIdsAndTileCount(ones, res)
-      }
+      rasterShouldBe(res, (103, 103))
+      rastersShouldHaveSameIdsAndTileCount(ones, res)
+    }
 
-      it("should xor three different spacetime rasters as a seq") {
-        val res = onesST ^ Seq(twosST, hundredsST)
+    it("should xor three different spacetime rasters as a seq") {
+      val res = onesST ^ Seq(twosST, hundredsST)
 
-        rasterShouldBe(res, (103, 103))
-        rastersShouldHaveSameIdsAndTileCount(onesST, res)
-      }
+      rasterShouldBe(res, (103, 103))
+      rastersShouldHaveSameIdsAndTileCount(onesST, res)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/local/spatial/LocalSpatialSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/spatial/LocalSpatialSpec.scala
@@ -29,92 +29,89 @@ class LocalSpatialSpec extends FunSpec
                                with TestFiles
                                with RasterRDDMatchers
                                with RasterRDDBuilders
-                               with OnlyIfCanRunSpark {
+                               with TestSparkContext {
 
   describe("Local Operations") {
-    ifCanRunSpark {
+    val rdd = AllOnesTestFile
+    val tile = rdd.stitch.tile
+    val worldExt = rdd.metaData.extent
+    val height = worldExt.height.toInt
+    val width = worldExt.width.toInt
 
-      val rdd = AllOnesTestFile
-      val tile = rdd.stitch.tile
-      val worldExt = rdd.metaData.extent
-      val height = worldExt.height.toInt
-      val width = worldExt.width.toInt
+    def inMirror(bound: Int): Int = inRange(-bound to bound)
+    def inRange(bounds: Range): Int = Random.nextInt(bounds.max - bounds.min) + bounds.min
 
-      def inMirror(bound: Int): Int = inRange(-bound to bound)
-      def inRange(bounds: Range): Int = Random.nextInt(bounds.max - bounds.min) + bounds.min
+    def triangle(size: Int, dx: Int, dy: Int): Line =
+      Line(Seq[(Double, Double)]((0, 0), (size, 0), (size, size), (0, 0))
+           .map { case (x, y) => (x + dx, y + dy) })
 
-      def triangle(size: Int, dx: Int, dy: Int): Line =
-        Line(Seq[(Double, Double)]((0, 0), (size, 0), (size, size), (0, 0))
-             .map { case (x, y) => (x + dx, y + dy) })
+    def randomPolygons(number: Int = 50)(maxWidth: Int, maxHeight: Int): Seq[Polygon] = {
+      val max = Math.min(maxWidth, maxHeight)
+      val min = max / 10
+      for {
+        _ <- 1 to number
+        size = inRange(min to max)
+        placeLeft = Math.max(0, max - size)
+        dx = inMirror(placeLeft) - size / 2
+        dy = inMirror(placeLeft) - size / 2
+        border = triangle(size, dx, dy)
+        hole = triangle(size / 3, dx + size / 2, dy + size / 3)
+      } yield Polygon(border, hole)
+    }
 
-      def randomPolygons(number: Int = 50)(maxWidth: Int, maxHeight: Int): Seq[Polygon] = {
-        val max = Math.min(maxWidth, maxHeight)
-        val min = max / 10
-        for {
-          _ <- 1 to number
-          size = inRange(min to max)
-          placeLeft = Math.max(0, max - size)
-          dx = inMirror(placeLeft) - size / 2
-          dy = inMirror(placeLeft) - size / 2
-          border = triangle(size, dx, dy)
-          hole = triangle(size / 3, dx + size / 2, dy + size / 3)
-        } yield Polygon(border, hole)
+    it ("should be masked by random polygons") {
+      randomPolygons()(width, height) foreach { poly =>
+        val masked = rdd.mask(poly).stitch.tile
+        val expected = tile.mask(worldExt, poly)
+        masked.toArray() shouldEqual expected.toArray()
       }
+    }
 
-      it ("should be masked by random polygons") {
-        randomPolygons()(width, height) foreach { poly =>
-          val masked = rdd.mask(poly).stitch.tile
-          val expected = tile.mask(worldExt, poly)
-          masked.toArray() shouldEqual expected.toArray()
-        }
+    it ("should be masked by complex polygons") {
+      val cases = Seq(
+        Polygon(Line((-5, -16), (44, -16), (44, 33), (-5, -16)), Line((19, 0), (35, 0), (35, 16), (19, 0))),
+        Polygon(Line((-84, -41), (40, -41), (40, 83), (-84, -41)), Line((-22, 0), (19, 0), (19, 41), (-22, 0))),
+        Polygon(Line((-7, 0), (28, 0), (28, 35), (-7, 0)), Line((10, 11), (21, 11), (21, 22), (10, 11)))
+      )
+      cases foreach { poly =>
+        val masked = rdd.mask(poly).stitch.tile
+        val expected = tile.mask(worldExt, poly)
+        masked.toArray() shouldEqual expected.toArray()
       }
+    }
 
-      it ("should be masked by complex polygons") {
-        val cases = Seq(
-          Polygon(Line((-5, -16), (44, -16), (44, 33), (-5, -16)), Line((19, 0), (35, 0), (35, 16), (19, 0))),
-          Polygon(Line((-84, -41), (40, -41), (40, 83), (-84, -41)), Line((-22, 0), (19, 0), (19, 41), (-22, 0))),
-          Polygon(Line((-7, 0), (28, 0), (28, 35), (-7, 0)), Line((10, 11), (21, 11), (21, 22), (10, 11)))
-        )
-        cases foreach { poly =>
-          val masked = rdd.mask(poly).stitch.tile
-          val expected = tile.mask(worldExt, poly)
-          masked.toArray() shouldEqual expected.toArray()
-        }
+    it ("should be masked by random multipolygons") {
+      val polygons = randomPolygons()(width, height)
+      val multipolygons = polygons.zip(polygons.reverse).map { case (a, b) =>
+        MultiPolygon(a, b)
       }
-
-      it ("should be masked by random multipolygons") {
-        val polygons = randomPolygons()(width, height)
-        val multipolygons = polygons.zip(polygons.reverse).map { case (a, b) =>
-          MultiPolygon(a, b)
-        }
-        multipolygons foreach { multipoly =>
-          val masked = rdd.mask(multipoly).stitch.tile
-          val expected = tile.mask(worldExt, multipoly)
-          masked.toArray() shouldEqual expected.toArray()
-        }
+      multipolygons foreach { multipoly =>
+        val masked = rdd.mask(multipoly).stitch.tile
+        val expected = tile.mask(worldExt, multipoly)
+        masked.toArray() shouldEqual expected.toArray()
       }
+    }
 
-      it ("should be masked by complex multipolygons") {
-        val cases = Seq(
-          MultiPolygon(Polygon(Line((29, 15), (110, 15), (110, 96), (29, 15)), Line((69, 42), (96, 42), (96, 69), (69, 42))),
-            Polygon(Line((-77, -78), (46, -78), (46, 45), (-77, -78)), Line((-16, -37), (25, -37), (25, 4), (-16, -37)))),
-          MultiPolygon(Polygon(Line((-41, -17), (0, -17), (0, 24), (-41, -17)), Line((-21, -4), (-8, -4), (-8, 9), (-21, -4))),
-            Polygon(Line((-83, -76), (-13, -76), (-13, -6), (-83, -76)), Line((-48, -53), (-25, -53), (-25, -30), (-48, -53))))
-        )
-        cases foreach { multipoly =>
-          val masked = rdd.mask(multipoly).stitch.tile
-          val expected = tile.mask(worldExt, multipoly)
-          masked.toArray() shouldEqual expected.toArray()
-        }
+    it ("should be masked by complex multipolygons") {
+      val cases = Seq(
+        MultiPolygon(Polygon(Line((29, 15), (110, 15), (110, 96), (29, 15)), Line((69, 42), (96, 42), (96, 69), (69, 42))),
+          Polygon(Line((-77, -78), (46, -78), (46, 45), (-77, -78)), Line((-16, -37), (25, -37), (25, 4), (-16, -37)))),
+        MultiPolygon(Polygon(Line((-41, -17), (0, -17), (0, 24), (-41, -17)), Line((-21, -4), (-8, -4), (-8, 9), (-21, -4))),
+          Polygon(Line((-83, -76), (-13, -76), (-13, -6), (-83, -76)), Line((-48, -53), (-25, -53), (-25, -30), (-48, -53))))
+      )
+      cases foreach { multipoly =>
+        val masked = rdd.mask(multipoly).stitch.tile
+        val expected = tile.mask(worldExt, multipoly)
+        masked.toArray() shouldEqual expected.toArray()
       }
+    }
 
-      it ("should be masked by random extents") {
-        val extents = randomPolygons()(width, height).map(_.envelope)
-        extents foreach { extent =>
-          val masked = rdd.mask(extent).stitch.tile
-          val expected = tile.mask(worldExt, extent)
-          masked.toArray() shouldEqual expected.toArray()
-        }
+    it ("should be masked by random extents") {
+      val extents = randomPolygons()(width, height).map(_.envelope)
+      extents foreach { extent =>
+        val masked = rdd.mask(extent).stitch.tile
+        val expected = tile.mask(worldExt, extent)
+        masked.toArray() shouldEqual expected.toArray()
       }
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/op/local/temporal/LocalTemporalRasterRDDMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/temporal/LocalTemporalRasterRDDMethodsSpec.scala
@@ -14,154 +14,150 @@ import org.scalatest.FunSpec
 class LocalTemporalSpec extends FunSpec with TestEnvironment
     with RasterRDDBuilders
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
-  ifCanRunSpark {
+  describe("Local Temporal Operations") {
 
-    describe("Local Temporal Operations") {
+    def createIncreasingTemporalRasterRDD(dates: Seq[DateTime], f: DateTime => Int = { dt => dt.getYear }) = {
+      val tileLayout = TileLayout(3, 3, 3, 3)
 
-      def createIncreasingTemporalRasterRDD(dates: Seq[DateTime], f: DateTime => Int = { dt => dt.getYear }) = {
-        val tileLayout = TileLayout(3, 3, 3, 3)
+      val datesZippedWithIndex = dates.zipWithIndex
 
-        val datesZippedWithIndex = dates.zipWithIndex
+      val rasterRDDs = for (dateTime <- dates) yield {
+        val idx = f(dateTime)
+        val rasterRDD = createRasterRDD(
+          sc,
+          ArrayTile((idx to (idx + 80)).toArray, 9, 9),
+          tileLayout
+        )
 
-        val rasterRDDs = for (dateTime <- dates) yield {
-          val idx = f(dateTime)
-          val rasterRDD = createRasterRDD(
-            sc,
-            ArrayTile((idx to (idx + 80)).toArray, 9, 9),
-            tileLayout
-          )
-
-          val metaData = rasterRDD.metaData
-          val rdd = rasterRDD.map { case(spatialKey, tile) =>
-            (SpaceTimeKey(spatialKey, TemporalKey(dateTime)), tile)
-          }
-
-          new RasterRDD(rdd, metaData)
-        }
-
-        val metaData = rasterRDDs.head.metaData
-        val combinedRDDs = rasterRDDs.map(_.rdd).reduce(_ ++ _)
-
-        new RasterRDD(combinedRDDs, metaData)
-      }
-
-      def groupRasterRDDToRastersByTemporalKey(rasterRDD: RasterRDD[SpaceTimeKey]): Map[DateTime, Tile] = {
         val metaData = rasterRDD.metaData
-        val gridBounds = metaData.mapTransform(metaData.extent)
-        val tileLayout = 
-          TileLayout(gridBounds.width, gridBounds.height, metaData.tileLayout.tileCols, metaData.tileLayout.tileRows)
+        val rdd = rasterRDD.map { case(spatialKey, tile) =>
+          (SpaceTimeKey(spatialKey, TemporalKey(dateTime)), tile)
+        }
 
-        rasterRDD
-          .groupBy { case (key, tile) =>
-            val SpaceTimeKey(_, _, time) = key
-            time
-           }
-          .collect
-          .sortWith { (x, y) => x._1.isBefore(y._1) }
-          .map { case (time, iter) =>
-            val tiles = 
-              iter
-                .toSeq
-                .sorted(Ordering.by[(SpaceTimeKey, Tile), (Int, Int)] { case (key, tile) =>
-                  val SpatialKey(col, row) = key.spatialComponent
-                  (row, col)
-                })
-                .map(_._2)
-
-            (time, CompositeTile(tiles.toSeq, tileLayout))
-           }
-          .toMap
+        new RasterRDD(rdd, metaData)
       }
 
-      it("should work with min for a 9 year period where the window is 3 years.") {
-        val dates = (1 until 10).map(i => new DateTime(i, 1, 1, 0, 0, 0, DateTimeZone.UTC))
-        val rasterRDD = createIncreasingTemporalRasterRDD(dates)
+      val metaData = rasterRDDs.head.metaData
+      val combinedRDDs = rasterRDDs.map(_.rdd).reduce(_ ++ _)
 
-        val start = new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC)
-        val end = new DateTime(9, 1, 1, 0, 0, 0, DateTimeZone.UTC)
-        val res = rasterRDD.minimum.per (3) ("years") from (start) to (end)
+      new RasterRDD(combinedRDDs, metaData)
+    }
 
-        val rasters = groupRasterRDDToRastersByTemporalKey(res)
+    def groupRasterRDDToRastersByTemporalKey(rasterRDD: RasterRDD[SpaceTimeKey]): Map[DateTime, Tile] = {
+      val metaData = rasterRDD.metaData
+      val gridBounds = metaData.mapTransform(metaData.extent)
+      val tileLayout = 
+        TileLayout(gridBounds.width, gridBounds.height, metaData.tileLayout.tileCols, metaData.tileLayout.tileRows)
 
-        rasters.size should be (3)
+      rasterRDD
+        .groupBy { case (key, tile) =>
+          val SpaceTimeKey(_, _, time) = key
+          time
+         }
+        .collect
+        .sortWith { (x, y) => x._1.isBefore(y._1) }
+        .map { case (time, iter) =>
+          val tiles = 
+            iter
+              .toSeq
+              .sorted(Ordering.by[(SpaceTimeKey, Tile), (Int, Int)] { case (key, tile) =>
+                val SpatialKey(col, row) = key.spatialComponent
+                (row, col)
+              })
+              .map(_._2)
 
-        // Years 1, 4 and 7 have the mins.
-        rasters.zip(List(1, 4, 7)).foreach { case((date, tile), idx) =>
-          date.getYear should be (idx)
-          val tileArray = tile.toArray
-          val correct = (idx to (idx + 80)).toArray
-          tileArray should be(correct)
-        }
+          (time, CompositeTile(tiles.toSeq, tileLayout))
+         }
+        .toMap
+    }
+
+    it("should work with min for a 9 year period where the window is 3 years.") {
+      val dates = (1 until 10).map(i => new DateTime(i, 1, 1, 0, 0, 0, DateTimeZone.UTC))
+      val rasterRDD = createIncreasingTemporalRasterRDD(dates)
+
+      val start = new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC)
+      val end = new DateTime(9, 1, 1, 0, 0, 0, DateTimeZone.UTC)
+      val res = rasterRDD.minimum.per (3) ("years") from (start) to (end)
+
+      val rasters = groupRasterRDDToRastersByTemporalKey(res)
+
+      rasters.size should be (3)
+
+      // Years 1, 4 and 7 have the mins.
+      rasters.zip(List(1, 4, 7)).foreach { case((date, tile), idx) =>
+        date.getYear should be (idx)
+        val tileArray = tile.toArray
+        val correct = (idx to (idx + 80)).toArray
+        tileArray should be(correct)
       }
+    }
 
-      it("should work with max for a 12 month period where the window is 5 months.") {
-        val dates = (1 to 12).map(i => new DateTime(1, i, 1, 0, 0, 0, DateTimeZone.UTC))
-        val rasterRDD = createIncreasingTemporalRasterRDD(dates, { date => date.getMonthOfYear })
+    it("should work with max for a 12 month period where the window is 5 months.") {
+      val dates = (1 to 12).map(i => new DateTime(1, i, 1, 0, 0, 0, DateTimeZone.UTC))
+      val rasterRDD = createIncreasingTemporalRasterRDD(dates, { date => date.getMonthOfYear })
 
-        val start = new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC)
-        val end = new DateTime(2, 1, 1, 0, 0, 0, DateTimeZone.UTC)
-        val periodStep = 5
-        val res = rasterRDD.maximum.per (periodStep) ("months") from (start) to (end)
+      val start = new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC)
+      val end = new DateTime(2, 1, 1, 0, 0, 0, DateTimeZone.UTC)
+      val periodStep = 5
+      val res = rasterRDD.maximum.per (periodStep) ("months") from (start) to (end)
 
-        val rasters = groupRasterRDDToRastersByTemporalKey(res)
+      val rasters = groupRasterRDDToRastersByTemporalKey(res)
 
-        rasters.size should be (3)
+      rasters.size should be (3)
 
-        // Months 5, 10 and 12 have the maxs.
+      // Months 5, 10 and 12 have the maxs.
 
-        rasters.zip(List(5, 10, 12)).foreach { case((date, tile), idx) =>
-          val tileArray = tile.toArray
-          val correct = (idx to (idx + 80)).toArray
-          tileArray should be(correct)
-        }
+      rasters.zip(List(5, 10, 12)).foreach { case((date, tile), idx) =>
+        val tileArray = tile.toArray
+        val correct = (idx to (idx + 80)).toArray
+        tileArray should be(correct)
       }
+    }
 
-      it("should work with mean for a 25 days period where the window is 7 days.") {
-        val dates = (1 to 25).map(i => new DateTime(1, 1, i, 0, 0, 0, DateTimeZone.UTC))
-        val rasterRDD = createIncreasingTemporalRasterRDD(dates, { date => date.getDayOfMonth })
+    it("should work with mean for a 25 days period where the window is 7 days.") {
+      val dates = (1 to 25).map(i => new DateTime(1, 1, i, 0, 0, 0, DateTimeZone.UTC))
+      val rasterRDD = createIncreasingTemporalRasterRDD(dates, { date => date.getDayOfMonth })
 
-        val start = new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC)
-        val end = new DateTime(2, 1, 1, 0, 0, 0, DateTimeZone.UTC)
-        val windowSize = 7
-        val res = rasterRDD.average.per (windowSize) ("days") from (start) to (end)
+      val start = new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC)
+      val end = new DateTime(2, 1, 1, 0, 0, 0, DateTimeZone.UTC)
+      val windowSize = 7
+      val res = rasterRDD.average.per (windowSize) ("days") from (start) to (end)
 
-        val rasters = groupRasterRDDToRastersByTemporalKey(res)
+      val rasters = groupRasterRDDToRastersByTemporalKey(res)
 
-        rasters.size should be (4)
+      rasters.size should be (4)
 
-        val firsts = (1 to 25) grouped 7 map { seq => seq.sum / seq.size }
-        for( ((time, tile), expected) <- rasters.zip(firsts.toSeq)) {
-          tile.getDouble(0, 0) should be (expected)
-        }
+      val firsts = (1 to 25) grouped 7 map { seq => seq.sum / seq.size }
+      for( ((time, tile), expected) <- rasters.zip(firsts.toSeq)) {
+        tile.getDouble(0, 0) should be (expected)
       }
+    }
 
-      it("should work with variance for a 12 hours period where the window is 3 hours.") {
-        val dates = (0 to 11).map(i => new DateTime(1, 1, 1, i, 0, 0, DateTimeZone.UTC))
-        val rasterRDD = createIncreasingTemporalRasterRDD(dates, { date => date.getHourOfDay })
+    it("should work with variance for a 12 hours period where the window is 3 hours.") {
+      val dates = (0 to 11).map(i => new DateTime(1, 1, 1, i, 0, 0, DateTimeZone.UTC))
+      val rasterRDD = createIncreasingTemporalRasterRDD(dates, { date => date.getHourOfDay })
 
-        val start = new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC)
-        val end = new DateTime(2, 1, 1, 0, 0, 0, DateTimeZone.UTC)
-        val windowSize = 3
-        val res = rasterRDD.variance.per (windowSize) ("hours") from (start) to (end)
+      val start = new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC)
+      val end = new DateTime(2, 1, 1, 0, 0, 0, DateTimeZone.UTC)
+      val windowSize = 3
+      val res = rasterRDD.variance.per (windowSize) ("hours") from (start) to (end)
 
-        val rasters = groupRasterRDDToRastersByTemporalKey(res)
+      val rasters = groupRasterRDDToRastersByTemporalKey(res)
 
-        rasters.size should be (4)
+      rasters.size should be (4)
 
-        val inputRasters = groupRasterRDDToRastersByTemporalKey(rasterRDD).values.toList
-        val expectedTiles = 
-          for(indicies <- (0 to 11).grouped(3)) yield {
-            Variance(indicies.map { inputRasters(_) })
-          }
-        expectedTiles.size should be (4)
-
-        rasters.zip(expectedTiles.toSeq) foreach { case ((_, tile), expected) =>
-          tile.toArrayDouble should be (expected.toArrayDouble)
+      val inputRasters = groupRasterRDDToRastersByTemporalKey(rasterRDD).values.toList
+      val expectedTiles = 
+        for(indicies <- (0 to 11).grouped(3)) yield {
+          Variance(indicies.map { inputRasters(_) })
         }
+      expectedTiles.size should be (4)
+
+      rasters.zip(expectedTiles.toSeq) foreach { case ((_, tile), expected) =>
+        tile.toArrayDouble should be (expected.toArrayDouble)
       }
     }
   }
-
 }

--- a/spark/src/test/scala/geotrellis/spark/op/stats/StatsRasterRDDMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/stats/StatsRasterRDDMethodsSpec.scala
@@ -16,35 +16,32 @@ class StatsRasterRDDMethodsSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders {
 
   describe("RDD Stats Method Operations") {
 
-    ifCanRunSpark {
+    it("gives correct class breaks for example raster histogram") {
+      val rdd = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          1, 1, 1,  1, 1, 1,  1, 1, 1,
+          1, 1, 1,  1, 1, 1,  1, 1, 1,
 
-      it("gives correct class breaks for example raster histogram") {
-        val rdd = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            1, 1, 1,  1, 1, 1,  1, 1, 1,
-            1, 1, 1,  1, 1, 1,  1, 1, 1,
+          2, 2, 2,  2, 2, 2,  2, 2, 2,
+          2, 2, 2,  2, 2, 2,  2, 2, 2,
 
-            2, 2, 2,  2, 2, 2,  2, 2, 2,
-            2, 2, 2,  2, 2, 2,  2, 2, 2,
+          3, 3, 3,  3, 3, 3,  3, 3, 3,
+          3, 3, 3,  3, 3, 3,  3, 3, 3,
 
-            3, 3, 3,  3, 3, 3,  3, 3, 3,
-            3, 3, 3,  3, 3, 3,  3, 3, 3,
+          4, 4, 4,  4, 4, 4,  4, 4, 4,
+          4, 4, 4,  4, 4, 4,  4, 4, 4), 9, 8),
+        TileLayout(3, 4, 3, 2)
+      )
 
-            4, 4, 4,  4, 4, 4,  4, 4, 4,
-            4, 4, 4,  4, 4, 4,  4, 4, 4), 9, 8),
-          TileLayout(3, 4, 3, 2)
-        )
+      val classBreaks = rdd.classBreaks(3)
 
-        val classBreaks = rdd.classBreaks(3)
-
-        classBreaks should be (Array(1, 3, 4))
-      }
+      classBreaks should be (Array(1, 3, 4))
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/HistogramSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/HistogramSpec.scala
@@ -17,81 +17,76 @@ class HistogramSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders {
 
   describe("Histogram Zonal Operation") {
+    it("gives correct histogram for example raster rdds") {
+      val rdd = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          1, 2, 2,  2, 3, 1,  6, 5, 1,
+          1, 2, 2,  2, 3, 6,  6, 5, 5,
 
-    ifCanRunSpark {
+          1, 3, 5,  3, 6, 6,  6, 5, 5,
+          3, 1, 5,  6, 6, 6,  6, 6, 2,
 
-      it("gives correct histogram for example raster rdds") {
-        val rdd = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            1, 2, 2,  2, 3, 1,  6, 5, 1,
-            1, 2, 2,  2, 3, 6,  6, 5, 5,
+          7, 7, 5,  6, 1, 3,  3, 3, 2,
+          7, 7, 5,  5, 5, 4,  3, 4, 2,
 
-            1, 3, 5,  3, 6, 6,  6, 5, 5,
-            3, 1, 5,  6, 6, 6,  6, 6, 2,
+          7, 7, 5,  5, 5, 4,  3, 4, 2,
+          7, 2, 2,  5, 4, 4,  3, 4, 4), 9, 8),
+        TileLayout(3, 4, 3, 2)
+      )
 
-            7, 7, 5,  6, 1, 3,  3, 3, 2,
-            7, 7, 5,  5, 5, 4,  3, 4, 2,
+      val zonesRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          1, 1, 1,  4, 4, 4,  5, 6, 6,
+          1, 1, 1,  4, 4, 5,  5, 6, 6,
 
-            7, 7, 5,  5, 5, 4,  3, 4, 2,
-            7, 2, 2,  5, 4, 4,  3, 4, 4), 9, 8),
-          TileLayout(3, 4, 3, 2)
-        )
+          1, 1, 2,  4, 5, 5,  5, 6, 6,
+          1, 2, 2,  3, 3, 3,  3, 3, 3,
 
-        val zonesRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            1, 1, 1,  4, 4, 4,  5, 6, 6,
-            1, 1, 1,  4, 4, 5,  5, 6, 6,
+          2, 2, 2,  3, 3, 3,  3, 3, 3,
+          2, 2, 2,  7, 7, 7,  7, 8, 8,
 
-            1, 1, 2,  4, 5, 5,  5, 6, 6,
-            1, 2, 2,  3, 3, 3,  3, 3, 3,
+          2, 2, 2,  7, 7, 7,  7, 8, 8,
+          2, 2, 2,  7, 7, 7,  7, 8, 8), 9, 8),
+        TileLayout(3, 4, 3, 2)
+      )
 
-            2, 2, 2,  3, 3, 3,  3, 3, 3,
-            2, 2, 2,  7, 7, 7,  7, 8, 8,
+      val r = rdd.stitch.tile
+      val zones = zonesRDD.stitch.tile
+      val (cols, rows) = (r.cols, r.rows)
 
-            2, 2, 2,  7, 7, 7,  7, 8, 8,
-            2, 2, 2,  7, 7, 7,  7, 8, 8), 9, 8),
-          TileLayout(3, 4, 3, 2)
-        )
+      val zoneValues = mutable.Map[Int, mutable.ListBuffer[Int]]()
 
-        val r = rdd.stitch.tile
-        val zones = zonesRDD.stitch.tile
-        val (cols, rows) = (r.cols, r.rows)
-
-        val zoneValues = mutable.Map[Int, mutable.ListBuffer[Int]]()
-
-        for(row <- 0 until rows) {
-          for(col <- 0 until cols) {
-            val z = zones.get(col, row)
-            if(!zoneValues.contains(z)) zoneValues(z) = mutable.ListBuffer[Int]()
-            zoneValues(z) += r.get(col, row)
-          }
-        }
-
-        val expected =
-          zoneValues.toMap.mapValues { list =>
-            list.distinct
-              .map { v => (v, list.filter(_ == v).length) }
-              .toMap
-          }
-
-        val result: Map[Int, Histogram] = rdd.zonalHistogram(zonesRDD)
-
-        result.keys should be (expected.keys)
-
-        for(zone <- result.keys) {
-          val hist = result(zone)
-          for(v <- expected(zone).keys) {
-            hist.getItemCount(v) should be (expected(zone)(v))
-          }
+      for(row <- 0 until rows) {
+        for(col <- 0 until cols) {
+          val z = zones.get(col, row)
+          if(!zoneValues.contains(z)) zoneValues(z) = mutable.ListBuffer[Int]()
+          zoneValues(z) += r.get(col, row)
         }
       }
 
+      val expected =
+        zoneValues.toMap.mapValues { list =>
+          list.distinct
+            .map { v => (v, list.filter(_ == v).length) }
+            .toMap
+        }
+
+      val result: Map[Int, Histogram] = rdd.zonalHistogram(zonesRDD)
+
+      result.keys should be (expected.keys)
+
+      for(zone <- result.keys) {
+        val hist = result(zone)
+        for(v <- expected(zone).keys) {
+          hist.getItemCount(v) should be (expected(zone)(v))
+        }
+      }
     }
 
   }

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/PercentageSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/PercentageSpec.scala
@@ -19,64 +19,59 @@ class PercentageSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark
+    with TestSparkContext
     with RasterRDDBuilders {
 
   describe("Percentage Zonal Operation") {
+    it("gives correct percentage for example raster rdds") {
+      val rdd = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          1, 2, 2,  2, 3, 1,  6, 5, 1,
+          1, 2, 2,  2, 3, 6,  6, 5, 5,
 
-    ifCanRunSpark {
+          1, 3, 5,  3, 6, 6,  6, 5, 5,
+          3, 1, 5,  6, 6, 6,  6, 6, 2,
 
-      it("gives correct percentage for example raster rdds") {
-        val rdd = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            1, 2, 2,  2, 3, 1,  6, 5, 1,
-            1, 2, 2,  2, 3, 6,  6, 5, 5,
+          7, 7, 5,  6, 1, 3,  3, 3, 2,
+          7, 7, 5,  5, 5, 4,  3, 4, 2,
 
-            1, 3, 5,  3, 6, 6,  6, 5, 5,
-            3, 1, 5,  6, 6, 6,  6, 6, 2,
+          7, 7, 5,  5, 5, 4,  3, 4, 2,
+          7, 2, 2,  5, 4, 4,  3, 4, 4), 9, 8),
+        TileLayout(3, 4, 3, 2)
+      )
 
-            7, 7, 5,  6, 1, 3,  3, 3, 2,
-            7, 7, 5,  5, 5, 4,  3, 4, 2,
+      val zonesRDD = createRasterRDD(
+        sc,
+        ArrayTile(Array(
+          1, 1, 1,  4, 4, 4,  5, 6, 6,
+          1, 1, 1,  4, 4, 5,  5, 6, 6,
 
-            7, 7, 5,  5, 5, 4,  3, 4, 2,
-            7, 2, 2,  5, 4, 4,  3, 4, 4), 9, 8),
-          TileLayout(3, 4, 3, 2)
-        )
+          1, 1, 2,  4, 5, 5,  5, 6, 6,
+          1, 2, 2,  3, 3, 3,  3, 3, 3,
 
-        val zonesRDD = createRasterRDD(
-          sc,
-          ArrayTile(Array(
-            1, 1, 1,  4, 4, 4,  5, 6, 6,
-            1, 1, 1,  4, 4, 5,  5, 6, 6,
+          2, 2, 2,  3, 3, 3,  3, 3, 3,
+          2, 2, 2,  7, 7, 7,  7, 8, 8,
 
-            1, 1, 2,  4, 5, 5,  5, 6, 6,
-            1, 2, 2,  3, 3, 3,  3, 3, 3,
+          2, 2, 2,  7, 7, 7,  7, 8, 8,
+          2, 2, 2,  7, 7, 7,  7, 8, 8), 9, 8),
+        TileLayout(3, 4, 3, 2)
+      )
 
-            2, 2, 2,  3, 3, 3,  3, 3, 3,
-            2, 2, 2,  7, 7, 7,  7, 8, 8,
+      val actual = rdd.zonalPercentage(zonesRDD).stitch.tile
+      val expected = rdd.stitch.tile.zonalPercentage(zonesRDD.stitch.tile)
 
-            2, 2, 2,  7, 7, 7,  7, 8, 8,
-            2, 2, 2,  7, 7, 7,  7, 8, 8), 9, 8),
-          TileLayout(3, 4, 3, 2)
-        )
+      (actual.cols, actual.rows) should be (expected.cols, expected.rows)
 
-        val actual = rdd.zonalPercentage(zonesRDD).stitch.tile
-        val expected = rdd.stitch.tile.zonalPercentage(zonesRDD.stitch.tile)
+      val (cols, rows) = (actual.cols, actual.rows)
 
-        (actual.cols, actual.rows) should be (expected.cols, expected.rows)
-
-        val (cols, rows) = (actual.cols, actual.rows)
-
-        cfor(0)(_ < rows, _ + 1) { row =>
-          cfor(0)(_ < cols, _ + 1) { col =>
-            val actualValue = actual.getDouble(col, row)
-            val expectedValue = expected.getDouble(col, row)
-            actualValue should be (expectedValue)
-          }
+      cfor(0)(_ < rows, _ + 1) { row =>
+        cfor(0)(_ < cols, _ + 1) { col =>
+          val actualValue = actual.getDouble(col, row)
+          val expectedValue = expected.getDouble(col, row)
+          actualValue should be (expectedValue)
         }
       }
-
     }
 
   }

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/summary/FeatureRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/summary/FeatureRDDSpec.scala
@@ -12,29 +12,25 @@ import org.scalatest._
 
 class FeatureRDDSpec extends FunSpec
     with Matchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Zonal summary on an RDD of features") {
+    it("should compute the area of features under a zone") {
+      val lowerExtent = Extent(1, 1, 7, 3) // Partially intersects
+      val middleExtent = Extent(3, 3, 5, 4) // Contained
+      val upperExtent = Extent(1, 4, 7, 6) // Partially intersects
 
-    ifCanRunSpark {
-      it("should compute the area of features under a zone") {
-        val lowerExtent = Extent(1, 1, 7, 3) // Partially intersects
-        val middleExtent = Extent(3, 3, 5, 4) // Contained
-        val upperExtent = Extent(1, 4, 7, 6) // Partially intersects
+      val polygon = Polygon( (2, 2), (4, 6), (6, 2), (2, 2) )
 
-        val polygon = Polygon( (2, 2), (4, 6), (6, 2), (2, 2) )
+      val featureRdd = sc.parallelize(Array(lowerExtent, middleExtent, upperExtent).map { e => Feature(e, e.area) })
+      val result = featureRdd.zonalSummary(polygon, 0.0)(
+        ZonalSummaryHandler({ feature: Feature[Extent, Double] => feature.data })
+                           ({ (polygon, feature) => polygon.intersection(feature.geom).asMultiPolygon.map(_.area).getOrElse(0.0) })
+                           ({ (v1, v2) => v1 + v2 })
+      )
+      val expected = polygon.area - 0.5
 
-        val featureRdd = sc.parallelize(Array(lowerExtent, middleExtent, upperExtent).map { e => Feature(e, e.area) })
-        val result = featureRdd.zonalSummary(polygon, 0.0)(
-          ZonalSummaryHandler({ feature: Feature[Extent, Double] => feature.data })
-                             ({ (polygon, feature) => polygon.intersection(feature.geom).asMultiPolygon.map(_.area).getOrElse(0.0) })
-                             ({ (v1, v2) => v1 + v2 })
-        )
-        val expected = polygon.area - 0.5
-
-        result should be (expected)
-      }
+      result should be (expected)
     }
   }
-
 }

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/summary/HistogramSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/summary/HistogramSpec.scala
@@ -16,99 +16,94 @@ class HistogramSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Histogram Zonal Summary Operation") {
+    val modHundred = Mod10000TestFile
+    val ones = AllOnesTestFile
 
-    ifCanRunSpark {
+    val tileLayout = modHundred.metaData.tileLayout
+    val count = (modHundred.count * tileLayout.tileCols * tileLayout.tileRows).toInt
+    val totalExtent = modHundred.metaData.extent
 
-      val modHundred = Mod10000TestFile
-      val ones = AllOnesTestFile
+    it("should get correct histogram over whole raster extent") {
+      val histogram = modHundred.zonalHistogram(totalExtent.toPolygon)
 
-      val tileLayout = modHundred.metaData.tileLayout
-      val count = (modHundred.count * tileLayout.tileCols * tileLayout.tileRows).toInt
-      val totalExtent = modHundred.metaData.extent
+      var map = HashMap[Int, Int]()
 
-      it("should get correct histogram over whole raster extent") {
-        val histogram = modHundred.zonalHistogram(totalExtent.toPolygon)
-
-        var map = HashMap[Int, Int]()
-
-        for (i <- 0 until count) {
-          val key = i % 10000
-          val v = map.getOrElse(key, 0) + 1
-          map = map + (key -> v)
-        }
-
-        map.foreach { case (v, k) => histogram.getItemCount(v) should be (k) }
+      for (i <- 0 until count) {
+        val key = i % 10000
+        val v = map.getOrElse(key, 0) + 1
+        map = map + (key -> v)
       }
 
-      it("should get correct histogram over a quarter of the extent") {
-        val xd = totalExtent.xmax - totalExtent.xmin
-        val yd = totalExtent.ymax - totalExtent.ymin
+      map.foreach { case (v, k) => histogram.getItemCount(v) should be (k) }
+    }
 
-        val quarterExtent = Extent(
-          totalExtent.xmin,
-          totalExtent.ymin,
-          totalExtent.xmin + xd / 2,
-          totalExtent.ymin + yd / 2
-        )
+    it("should get correct histogram over a quarter of the extent") {
+      val xd = totalExtent.xmax - totalExtent.xmin
+      val yd = totalExtent.ymax - totalExtent.ymin
 
-        val histogram = ones.zonalHistogram(quarterExtent.toPolygon)
-        val expected = ones.stitch.tile.zonalHistogram(totalExtent, quarterExtent.toPolygon)
+      val quarterExtent = Extent(
+        totalExtent.xmin,
+        totalExtent.ymin,
+        totalExtent.xmin + xd / 2,
+        totalExtent.ymin + yd / 2
+      )
 
-        histogram.getMinMaxValues should be (expected.getMinMaxValues)
-        histogram.getItemCount(1) should be (expected.getItemCount(1))
-      }
+      val histogram = ones.zonalHistogram(quarterExtent.toPolygon)
+      val expected = ones.stitch.tile.zonalHistogram(totalExtent, quarterExtent.toPolygon)
 
-      it("should get correct histogram over half of the extent in diamond shape") {
-        val xd = totalExtent.xmax - totalExtent.xmin
-        val yd = totalExtent.ymax - totalExtent.ymin
+      histogram.getMinMaxValues should be (expected.getMinMaxValues)
+      histogram.getItemCount(1) should be (expected.getItemCount(1))
+    }
 
-
-        val p1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
-        val p2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
-        val p3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
-        val p4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
-
-        val poly = Polygon(Line(Array(p1, p2, p3, p4, p1)))
-
-        val histogram = ones.zonalHistogram(poly)
-        val expected = ones.stitch.tile.zonalHistogram(totalExtent, poly)
-
-        histogram.getMinMaxValues should be (expected.getMinMaxValues)
-        histogram.getItemCount(1) should be (expected.getItemCount(1))
-      }
-
-      it("should get correct histogram over polygon with hole") {
-        val delta = 0.0001 // A bit of a delta to avoid floating point errors.
-
-        val xd = totalExtent.width + delta
-        val yd = totalExtent.height + delta
+    it("should get correct histogram over half of the extent in diamond shape") {
+      val xd = totalExtent.xmax - totalExtent.xmin
+      val yd = totalExtent.ymax - totalExtent.ymin
 
 
-        val pe1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
-        val pe2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
-        val pe3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
-        val pe4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
+      val p1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
+      val p2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
+      val p3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
+      val p4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
 
-        val exterior = Line(Array(pe1, pe2, pe3, pe4, pe1))
+      val poly = Polygon(Line(Array(p1, p2, p3, p4, p1)))
 
-        val pi1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax - yd / 4)
-        val pi2 = Point(totalExtent.xmax - xd / 4, totalExtent.ymin + yd / 2)
-        val pi3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin + yd / 4)
-        val pi4 = Point(totalExtent.xmin + xd / 4, totalExtent.ymin + yd / 2)
+      val histogram = ones.zonalHistogram(poly)
+      val expected = ones.stitch.tile.zonalHistogram(totalExtent, poly)
 
-        val interior = Line(Array(pi1, pi2, pi3, pi4, pi1))
-        val poly = Polygon(exterior, interior)
+      histogram.getMinMaxValues should be (expected.getMinMaxValues)
+      histogram.getItemCount(1) should be (expected.getItemCount(1))
+    }
 
-        val histogram = ones.zonalHistogram(poly)
-        val expected = ones.stitch.tile.zonalHistogram(totalExtent, poly)
+    it("should get correct histogram over polygon with hole") {
+      val delta = 0.0001 // A bit of a delta to avoid floating point errors.
 
-        histogram.getMinMaxValues should be (expected.getMinMaxValues)
-        histogram.getItemCount(1) should be (expected.getItemCount(1))
-      }
+      val xd = totalExtent.width + delta
+      val yd = totalExtent.height + delta
+
+
+      val pe1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
+      val pe2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
+      val pe3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
+      val pe4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
+
+      val exterior = Line(Array(pe1, pe2, pe3, pe4, pe1))
+
+      val pi1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax - yd / 4)
+      val pi2 = Point(totalExtent.xmax - xd / 4, totalExtent.ymin + yd / 2)
+      val pi3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin + yd / 4)
+      val pi4 = Point(totalExtent.xmin + xd / 4, totalExtent.ymin + yd / 2)
+
+      val interior = Line(Array(pi1, pi2, pi3, pi4, pi1))
+      val poly = Polygon(exterior, interior)
+
+      val histogram = ones.zonalHistogram(poly)
+      val expected = ones.stitch.tile.zonalHistogram(totalExtent, poly)
+
+      histogram.getMinMaxValues should be (expected.getMinMaxValues)
+      histogram.getItemCount(1) should be (expected.getItemCount(1))
     }
   }
-
 }

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/summary/MaxDoubleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/summary/MaxDoubleSpec.scala
@@ -13,65 +13,60 @@ class MaxDoubleSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Max Double Zonal Summary Operation") {
+    val inc = IncreasingTestFile
 
-    ifCanRunSpark {
+    val tileLayout = inc.metaData.tileLayout
+    val count = (inc.count * tileLayout.tileCols * tileLayout.tileRows).toInt
+    val totalExtent = inc.metaData.extent
 
-      val inc = IncreasingTestFile
+    it("should get correct double max over whole raster extent") {
+      inc.zonalMaxDouble(totalExtent.toPolygon) should be(count - 1)
+    }
 
-      val tileLayout = inc.metaData.tileLayout
-      val count = (inc.count * tileLayout.tileCols * tileLayout.tileRows).toInt
-      val totalExtent = inc.metaData.extent
+    it("should get correct double max over a quarter of the extent") {
+      val xd = totalExtent.xmax - totalExtent.xmin
+      val yd = totalExtent.ymax - totalExtent.ymin
 
-      it("should get correct double max over whole raster extent") {
-        inc.zonalMaxDouble(totalExtent.toPolygon) should be(count - 1)
-      }
+      val quarterExtent = Extent(
+        totalExtent.xmin,
+        totalExtent.ymin,
+        totalExtent.xmin + xd / 2,
+        totalExtent.ymin + yd / 2
+      )
 
-      it("should get correct double max over a quarter of the extent") {
-        val xd = totalExtent.xmax - totalExtent.xmin
-        val yd = totalExtent.ymax - totalExtent.ymin
+      val result = inc.zonalMaxDouble(quarterExtent.toPolygon)
+      val expected = inc.stitch.tile.zonalMaxDouble(totalExtent, quarterExtent.toPolygon)
 
-        val quarterExtent = Extent(
-          totalExtent.xmin,
-          totalExtent.ymin,
-          totalExtent.xmin + xd / 2,
-          totalExtent.ymin + yd / 2
-        )
+      result should be (expected)
+    }
 
-        val result = inc.zonalMaxDouble(quarterExtent.toPolygon)
-        val expected = inc.stitch.tile.zonalMaxDouble(totalExtent, quarterExtent.toPolygon)
+    it("should get correct double max over a two triangle multipolygon") {
+      val xd = totalExtent.xmax - totalExtent.xmin / 4
+      val yd = totalExtent.ymax - totalExtent.ymin / 4
 
-        result should be (expected)
-      }
+      val tri1 = Polygon( 
+        (totalExtent.xmin + (xd / 2), totalExtent.ymax - (yd / 2)),
+        (totalExtent.xmin + (xd / 2) + xd, totalExtent.ymax - (yd / 2)),
+        (totalExtent.xmin + (xd / 2) + xd, totalExtent.ymax - (yd)),
+        (totalExtent.xmin + (xd / 2), totalExtent.ymax - (yd / 2))
+      )
 
-      it("should get correct double max over a two triangle multipolygon") {
-        val xd = totalExtent.xmax - totalExtent.xmin / 4
-        val yd = totalExtent.ymax - totalExtent.ymin / 4
+      val tri2 = Polygon( 
+        (totalExtent.xmax - (xd / 2), totalExtent.ymin + (yd / 2)),
+        (totalExtent.xmax - (xd / 2) - xd, totalExtent.ymin + (yd / 2)),
+        (totalExtent.xmax - (xd / 2) - xd, totalExtent.ymin + (yd)),
+        (totalExtent.xmax - (xd / 2), totalExtent.ymin + (yd / 2))
+      )
 
-        val tri1 = Polygon( 
-          (totalExtent.xmin + (xd / 2), totalExtent.ymax - (yd / 2)),
-          (totalExtent.xmin + (xd / 2) + xd, totalExtent.ymax - (yd / 2)),
-          (totalExtent.xmin + (xd / 2) + xd, totalExtent.ymax - (yd)),
-          (totalExtent.xmin + (xd / 2), totalExtent.ymax - (yd / 2))
-        )
+      val mp = MultiPolygon(tri1, tri2)
 
-        val tri2 = Polygon( 
-          (totalExtent.xmax - (xd / 2), totalExtent.ymin + (yd / 2)),
-          (totalExtent.xmax - (xd / 2) - xd, totalExtent.ymin + (yd / 2)),
-          (totalExtent.xmax - (xd / 2) - xd, totalExtent.ymin + (yd)),
-          (totalExtent.xmax - (xd / 2), totalExtent.ymin + (yd / 2))
-        )
+      val result = inc.zonalMaxDouble(mp)
+      val expected = inc.stitch.tile.zonalMaxDouble(totalExtent, mp)
 
-        val mp = MultiPolygon(tri1, tri2)
-
-        val result = inc.zonalMaxDouble(mp)
-        val expected = inc.stitch.tile.zonalMaxDouble(totalExtent, mp)
-
-        result should be (expected)
-      }
+      result should be (expected)
     }
   }
-
 }

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/summary/MaxSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/summary/MaxSpec.scala
@@ -13,39 +13,34 @@ class MaxSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Max Zonal Summary Operation") {
+    val inc = IncreasingTestFile
 
-    ifCanRunSpark {
+    val tileLayout = inc.metaData.tileLayout
+    val count = (inc.count * tileLayout.tileCols * tileLayout.tileRows).toInt
+    val totalExtent = inc.metaData.extent
 
-      val inc = IncreasingTestFile
+    it("should get correct max over whole raster extent") {
+      inc.zonalMax(totalExtent.toPolygon) should be(count - 1)
+    }
 
-      val tileLayout = inc.metaData.tileLayout
-      val count = (inc.count * tileLayout.tileCols * tileLayout.tileRows).toInt
-      val totalExtent = inc.metaData.extent
+    it("should get correct max over a quarter of the extent") {
+      val xd = totalExtent.xmax - totalExtent.xmin
+      val yd = totalExtent.ymax - totalExtent.ymin
 
-      it("should get correct max over whole raster extent") {
-        inc.zonalMax(totalExtent.toPolygon) should be(count - 1)
-      }
+      val quarterExtent = Extent(
+        totalExtent.xmin,
+        totalExtent.ymin,
+        totalExtent.xmin + xd / 2,
+        totalExtent.ymin + yd / 2
+      )
 
-      it("should get correct max over a quarter of the extent") {
-        val xd = totalExtent.xmax - totalExtent.xmin
-        val yd = totalExtent.ymax - totalExtent.ymin
+      val result = inc.zonalMax(quarterExtent.toPolygon)
+      val expected = inc.stitch.tile.zonalMax(totalExtent, quarterExtent.toPolygon)
 
-        val quarterExtent = Extent(
-          totalExtent.xmin,
-          totalExtent.ymin,
-          totalExtent.xmin + xd / 2,
-          totalExtent.ymin + yd / 2
-        )
-
-        val result = inc.zonalMax(quarterExtent.toPolygon)
-        val expected = inc.stitch.tile.zonalMax(totalExtent, quarterExtent.toPolygon)
-
-        result should be (expected)
-      }
+      result should be (expected)
     }
   }
-
 }

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/summary/MinSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/summary/MinSpec.scala
@@ -13,39 +13,34 @@ class MinSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Min Zonal Summary Operation") {
+    val inc = IncreasingTestFile
 
-    ifCanRunSpark {
+    val tileLayout = inc.metaData.tileLayout
+    val count = (inc.count * tileLayout.tileCols * tileLayout.tileRows).toInt
+    val totalExtent = inc.metaData.extent
 
-      val inc = IncreasingTestFile
+    it("should get correct min over whole raster extent") {
+      inc.zonalMin(totalExtent.toPolygon) should be(0)
+    }
 
-      val tileLayout = inc.metaData.tileLayout
-      val count = (inc.count * tileLayout.tileCols * tileLayout.tileRows).toInt
-      val totalExtent = inc.metaData.extent
+    it("should get correct min over a quarter of the extent") {
+      val xd = totalExtent.xmax - totalExtent.xmin
+      val yd = totalExtent.ymax - totalExtent.ymin
 
-      it("should get correct min over whole raster extent") {
-        inc.zonalMin(totalExtent.toPolygon) should be(0)
-      }
+      val quarterExtent = Extent(
+        totalExtent.xmin,
+        totalExtent.ymin,
+        totalExtent.xmin + xd / 2,
+        totalExtent.ymin + yd / 2
+      )
 
-      it("should get correct min over a quarter of the extent") {
-        val xd = totalExtent.xmax - totalExtent.xmin
-        val yd = totalExtent.ymax - totalExtent.ymin
+      val result = inc.zonalMin(quarterExtent.toPolygon)
+      val expected = inc.stitch.tile.zonalMin(totalExtent, quarterExtent.toPolygon)
 
-        val quarterExtent = Extent(
-          totalExtent.xmin,
-          totalExtent.ymin,
-          totalExtent.xmin + xd / 2,
-          totalExtent.ymin + yd / 2
-        )
-
-        val result = inc.zonalMin(quarterExtent.toPolygon)
-        val expected = inc.stitch.tile.zonalMin(totalExtent, quarterExtent.toPolygon)
-
-        result should be (expected)
-      }
+      result should be (expected)
     }
   }
-
 }

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/summary/SumDoubleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/summary/SumDoubleSpec.scala
@@ -13,85 +13,80 @@ class SumDoubleSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Sum Double Zonal Summary Operation") {
+    val ones = AllOnesTestFile
 
-    ifCanRunSpark {
+    val tileLayout = ones.metaData.tileLayout
+    val count = (ones.count * tileLayout.tileCols * tileLayout.tileRows).toInt
+    val totalExtent = ones.metaData.extent
 
-      val ones = AllOnesTestFile
+    it("should get correct double sum over whole raster extent") {
+      ones.zonalSumDouble(totalExtent.toPolygon) should be(count)
+    }
 
-      val tileLayout = ones.metaData.tileLayout
-      val count = (ones.count * tileLayout.tileCols * tileLayout.tileRows).toInt
-      val totalExtent = ones.metaData.extent
+    it("should get correct double sum over a quarter of the extent") {
+      val xd = totalExtent.xmax - totalExtent.xmin
+      val yd = totalExtent.ymax - totalExtent.ymin
 
-      it("should get correct double sum over whole raster extent") {
-        ones.zonalSumDouble(totalExtent.toPolygon) should be(count)
-      }
+      val quarterExtent = Extent(
+        totalExtent.xmin,
+        totalExtent.ymin,
+        totalExtent.xmin + xd / 2,
+        totalExtent.ymin + yd / 2
+      )
 
-      it("should get correct double sum over a quarter of the extent") {
-        val xd = totalExtent.xmax - totalExtent.xmin
-        val yd = totalExtent.ymax - totalExtent.ymin
+      val result = ones.zonalSumDouble(quarterExtent.toPolygon)
+      val expected = ones.stitch.tile.zonalSumDouble(totalExtent, quarterExtent.toPolygon)
 
-        val quarterExtent = Extent(
-          totalExtent.xmin,
-          totalExtent.ymin,
-          totalExtent.xmin + xd / 2,
-          totalExtent.ymin + yd / 2
-        )
+      result should be (expected)
+    }
 
-        val result = ones.zonalSumDouble(quarterExtent.toPolygon)
-        val expected = ones.stitch.tile.zonalSumDouble(totalExtent, quarterExtent.toPolygon)
-
-        result should be (expected)
-      }
-
-      it("should get correct double sum over half of the extent in diamond shape") {
-        val xd = totalExtent.xmax - totalExtent.xmin
-        val yd = totalExtent.ymax - totalExtent.ymin
+    it("should get correct double sum over half of the extent in diamond shape") {
+      val xd = totalExtent.xmax - totalExtent.xmin
+      val yd = totalExtent.ymax - totalExtent.ymin
 
 
-        val p1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
-        val p2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
-        val p3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
-        val p4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
+      val p1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
+      val p2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
+      val p3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
+      val p4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
 
-        val poly = Polygon(Line(Array(p1, p2, p3, p4, p1)))
+      val poly = Polygon(Line(Array(p1, p2, p3, p4, p1)))
 
-        val result = ones.zonalSumDouble(poly)
-        val expected = ones.stitch.tile.zonalSumDouble(totalExtent, poly)
+      val result = ones.zonalSumDouble(poly)
+      val expected = ones.stitch.tile.zonalSumDouble(totalExtent, poly)
 
-        result should be (expected)
-      }
+      result should be (expected)
+    }
 
-      it("should get correct double sum over polygon with hole") {
-        val delta = 0.0001 // A bit of a delta to avoid floating point errors.
+    it("should get correct double sum over polygon with hole") {
+      val delta = 0.0001 // A bit of a delta to avoid floating point errors.
 
-        val xd = totalExtent.width + delta
-        val yd = totalExtent.height + delta
+      val xd = totalExtent.width + delta
+      val yd = totalExtent.height + delta
 
-        val pe1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
-        val pe2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
-        val pe3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
-        val pe4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
+      val pe1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
+      val pe2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
+      val pe3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
+      val pe4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
 
-        val exterior = Line(Array(pe1, pe2, pe3, pe4, pe1))
+      val exterior = Line(Array(pe1, pe2, pe3, pe4, pe1))
 
-        val pi1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax - yd / 4)
-        val pi2 = Point(totalExtent.xmax - xd / 4, totalExtent.ymin + yd / 2)
-        val pi3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin + yd / 4)
-        val pi4 = Point(totalExtent.xmin + xd / 4, totalExtent.ymin + yd / 2)
+      val pi1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax - yd / 4)
+      val pi2 = Point(totalExtent.xmax - xd / 4, totalExtent.ymin + yd / 2)
+      val pi3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin + yd / 4)
+      val pi4 = Point(totalExtent.xmin + xd / 4, totalExtent.ymin + yd / 2)
 
-        val interior = Line(Array(pi1, pi2, pi3, pi4, pi1))
+      val interior = Line(Array(pi1, pi2, pi3, pi4, pi1))
 
-        val poly = Polygon(exterior, interior)
-        val result = ones.zonalSumDouble(poly)
-        val expected = ones.stitch.tile.zonalSumDouble(totalExtent, poly)
+      val poly = Polygon(exterior, interior)
+      val result = ones.zonalSumDouble(poly)
+      val expected = ones.stitch.tile.zonalSumDouble(totalExtent, poly)
 
-        result should be (expected)
+      result should be (expected)
 
-      }
     }
   }
-
 }

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/summary/SumSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/summary/SumSpec.scala
@@ -13,85 +13,80 @@ class SumSpec extends FunSpec
     with TestEnvironment
     with TestFiles
     with RasterRDDMatchers
-    with OnlyIfCanRunSpark {
+    with TestSparkContext {
 
   describe("Sum Zonal Summary Operation") {
+    val ones = AllOnesTestFile
 
-    ifCanRunSpark {
+    val tileLayout = ones.metaData.tileLayout
+    val count = (ones.count * tileLayout.tileCols * tileLayout.tileRows).toInt
+    val totalExtent = ones.metaData.extent
 
-      val ones = AllOnesTestFile
+    it("should get correct sum over whole raster extent") {
+      ones.zonalSum(totalExtent.toPolygon) should be(count)
+    }
 
-      val tileLayout = ones.metaData.tileLayout
-      val count = (ones.count * tileLayout.tileCols * tileLayout.tileRows).toInt
-      val totalExtent = ones.metaData.extent
+    it("should get correct sum over a quarter of the extent") {
+      val xd = totalExtent.xmax - totalExtent.xmin
+      val yd = totalExtent.ymax - totalExtent.ymin
 
-      it("should get correct sum over whole raster extent") {
-        ones.zonalSum(totalExtent.toPolygon) should be(count)
-      }
+      val poly = Extent(
+        totalExtent.xmin,
+        totalExtent.ymin,
+        totalExtent.xmin + xd / 2,
+        totalExtent.ymin + yd / 2
+      ).toPolygon
 
-      it("should get correct sum over a quarter of the extent") {
-        val xd = totalExtent.xmax - totalExtent.xmin
-        val yd = totalExtent.ymax - totalExtent.ymin
+      val result = ones.zonalSum(poly)
+      val expected = ones.stitch.tile.zonalSum(totalExtent, poly)
 
-        val poly = Extent(
-          totalExtent.xmin,
-          totalExtent.ymin,
-          totalExtent.xmin + xd / 2,
-          totalExtent.ymin + yd / 2
-        ).toPolygon
+      result should be (expected)
+    }
 
-        val result = ones.zonalSum(poly)
-        val expected = ones.stitch.tile.zonalSum(totalExtent, poly)
-
-        result should be (expected)
-      }
-
-      it("should get correct sum over half of the extent in diamond shape") {
-        val xd = totalExtent.xmax - totalExtent.xmin
-        val yd = totalExtent.ymax - totalExtent.ymin
+    it("should get correct sum over half of the extent in diamond shape") {
+      val xd = totalExtent.xmax - totalExtent.xmin
+      val yd = totalExtent.ymax - totalExtent.ymin
 
 
-        val p1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
-        val p2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
-        val p3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
-        val p4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
+      val p1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
+      val p2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
+      val p3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
+      val p4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
 
-        val poly = Polygon(Line(Array(p1, p2, p3, p4, p1)))
+      val poly = Polygon(Line(Array(p1, p2, p3, p4, p1)))
 
-        val result = ones.zonalSum(poly)
-        val expected = ones.stitch.tile.zonalSum(totalExtent, poly)
+      val result = ones.zonalSum(poly)
+      val expected = ones.stitch.tile.zonalSum(totalExtent, poly)
 
-        result should be (expected)
-      }
+      result should be (expected)
+    }
 
-      it("should get correct sum over polygon with hole") {
-        val delta = 0.0001 // A bit of a delta to avoid floating point errors.
+    it("should get correct sum over polygon with hole") {
+      val delta = 0.0001 // A bit of a delta to avoid floating point errors.
 
-        val xd = totalExtent.width + delta
-        val yd = totalExtent.height + delta
+      val xd = totalExtent.width + delta
+      val yd = totalExtent.height + delta
 
-        val pe1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
-        val pe2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
-        val pe3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
-        val pe4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
+      val pe1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax)
+      val pe2 = Point(totalExtent.xmax, totalExtent.ymin + yd / 2)
+      val pe3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin)
+      val pe4 = Point(totalExtent.xmin, totalExtent.ymin + yd / 2)
 
-        val exterior = Line(Array(pe1, pe2, pe3, pe4, pe1))
+      val exterior = Line(Array(pe1, pe2, pe3, pe4, pe1))
 
-        val pi1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax - yd / 4)
-        val pi2 = Point(totalExtent.xmax - xd / 4, totalExtent.ymin + yd / 2)
-        val pi3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin + yd / 4)
-        val pi4 = Point(totalExtent.xmin + xd / 4, totalExtent.ymin + yd / 2)
+      val pi1 = Point(totalExtent.xmin + xd / 2, totalExtent.ymax - yd / 4)
+      val pi2 = Point(totalExtent.xmax - xd / 4, totalExtent.ymin + yd / 2)
+      val pi3 = Point(totalExtent.xmin + xd / 2, totalExtent.ymin + yd / 4)
+      val pi4 = Point(totalExtent.xmin + xd / 4, totalExtent.ymin + yd / 2)
 
-        val interior = Line(Array(pi1, pi2, pi3, pi4, pi1))
+      val interior = Line(Array(pi1, pi2, pi3, pi4, pi1))
 
-        val poly = Polygon(exterior, interior)
+      val poly = Polygon(exterior, interior)
 
-        val result = ones.zonalSum(poly)
-        val expected = ones.stitch.tile.zonalSum(totalExtent, poly)
+      val result = ones.zonalSum(poly)
+      val expected = ones.stitch.tile.zonalSum(totalExtent, poly)
 
-        result should be (expected)
-      }
+      result should be (expected)
     }
   }
-
 }

--- a/spark/src/test/scala/geotrellis/spark/testfiles/GenerateTestFiles.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/GenerateTestFiles.scala
@@ -32,7 +32,7 @@ import org.apache.spark._
 import com.github.nscala_time.time.Imports._
 
 /** Use this command to create test files when there's a breaking change to the files (i.e. SpatialKeyWritable package move) */
-object GenerateTestFiles {
+object GenerateTestFiles extends Logging {
   def generate(catalogPath: Path)(implicit sc: SparkContext): Unit = {
     val cellType = TypeFloat
     val crs = LatLng
@@ -42,8 +42,11 @@ object GenerateTestFiles {
     val extent = mapTransform(gridBounds)
 
     val md = RasterMetaData(cellType, LayoutDefinition(crs.worldExtent, tileLayout), extent, crs)
+    logInfo(s"Generating spatial layers...")
     generateSpatial(HadoopLayerWriter[SpatialKey, Tile, RasterRDD](catalogPath, RowMajorKeyIndexMethod), md)
+    logInfo(s"Generating spatiotemporal layers...")
     generateSpaceTime(HadoopLayerWriter[SpaceTimeKey, Tile, RasterRDD](catalogPath, ZCurveKeyIndexMethod.byYear), md)
+    logInfo(s"Done generating test catalog.")
   }
 
   def generateSpatial(catalog: HadoopLayerWriter[SpatialKey, Tile, RasterRDD[SpatialKey]], md: RasterMetaData)(implicit sc: SparkContext): Unit = {

--- a/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
@@ -11,12 +11,11 @@ import geotrellis.spark.io.hadoop._
 object TestFiles extends Logging {
   val ZOOM_LEVEL = 8
 
-  def catalogPath(implicit sc: SparkContext): Path = {
-    val localFS = new Path(System.getProperty("java.io.tmpdir")).getFileSystem(sc.hadoopConfiguration)
-    new Path(localFS.getWorkingDirectory, "src/test/resources/test-catalog")
+  def catalogPath: Path = {
+    new Path(TestEnvironment.inputHome, "test-catalog")
   }
 
-  def init(implicit sc: SparkContext) = {
+  def init(implicit sc: SparkContext) = this.synchronized {
     val conf = sc.hadoopConfiguration
     val localFS = catalogPath.getFileSystem(sc.hadoopConfiguration)
     val needGenerate = !localFS.exists(catalogPath)

--- a/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
@@ -38,7 +38,7 @@ object TestFiles extends Logging {
 
 }
 
-trait TestFiles { self: OnlyIfCanRunSpark =>
+trait TestFiles { self: TestSparkContext =>
   def spatialTestFile(layerName: String): RasterRDD[SpatialKey] = {
     TestFiles.spatialReader.query(LayerId(layerName, TestFiles.ZOOM_LEVEL)).toRDD.cache
   }

--- a/spark/src/test/scala/geotrellis/spark/utils/KryoClosureSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/utils/KryoClosureSpec.scala
@@ -17,26 +17,23 @@ class KryoClosureSpec extends FunSpec
   with TestEnvironment
   with TestFiles
   with RasterRDDMatchers
-  with OnlyIfCanRunSpark
+  with TestSparkContext
 {
   val transformer = new OptimusPrime(7)
   val numbers = Array.fill(10)(10)
 
   describe("KryoClosure") {
-    ifCanRunSpark {
+    val rdd = sc.parallelize(numbers, 1)
 
-      val rdd = sc.parallelize(numbers, 1)
-
-      it("should be better then Java serialization") {
-        intercept[org.apache.spark.SparkException] {
-          rdd.map(transformer).collect
-        }
+    it("should be better then Java serialization") {
+      intercept[org.apache.spark.SparkException] {
+        rdd.map(transformer).collect
       }
+    }
 
-      it("should be totally awesome at serialization"){
-        val out = rdd.map(KryoClosure(transformer))
-        out.collect should be (Array.fill(10)(17))
-      }
+    it("should be totally awesome at serialization"){
+      val out = rdd.map(KryoClosure(transformer))
+      out.collect should be (Array.fill(10)(17))
     }
   }
 }

--- a/vector-test/src/test/scala/spec/geotrellis/vector/io/json/StyleSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/io/json/StyleSpec.scala
@@ -1,0 +1,29 @@
+package geotrellis.vector.io.json
+
+import org.scalatest._
+
+import geotrellis.vector._
+
+class StyleSpec extends FunSpec with Matchers {
+  describe("Styling geometries") {
+    it("should style the geometry from a user defines style and read it back in") {
+      val p = """{ "type": "Polygon", "coordinates": [ [ [-76.97021484375, 40.17887331434696], [-74.02587890625, 39.842286020743394],
+	           [-73.4326171875, 41.713930073371294], [-76.79443359375, 41.94314874732696], 
+                   [-76.97021484375, 40.17887331434696] ] ] }""".parseGeoJson[Polygon]
+
+
+      val geoJson =
+        Feature(p, Style(strokeColor = "#555555", strokeWidth = 2, fillColor = "#00aa22", fillOpacity = 0.5)).toGeoJson
+
+
+      val Feature(_, style) = geoJson.parseGeoJson[Feature[Polygon, Style]]
+      style.strokeColor should be (Some("#555555"))
+      style.strokeWidth should be (Some(2))
+      style.strokeOpacity should be (None)
+      style.fillColor should be (Some("#00aa22"))
+      style.fillOpacity should be (Some(0.5))
+
+      println(geoJson)
+    }
+  }
+}

--- a/vector-test/src/test/scala/spec/geotrellis/vector/io/json/StyleSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/io/json/StyleSpec.scala
@@ -13,12 +13,12 @@ class StyleSpec extends FunSpec with Matchers {
 
 
       val geoJson =
-        Feature(p, Style(strokeColor = "#555555", strokeWidth = 2, fillColor = "#00aa22", fillOpacity = 0.5)).toGeoJson
+        Feature(p, Style(strokeColor = "#555555", strokeWidth = "2", fillColor = "#00aa22", fillOpacity = 0.5)).toGeoJson
 
 
       val Feature(_, style) = geoJson.parseGeoJson[Feature[Polygon, Style]]
       style.strokeColor should be (Some("#555555"))
-      style.strokeWidth should be (Some(2))
+      style.strokeWidth should be (Some("2"))
       style.strokeOpacity should be (None)
       style.fillColor should be (Some("#00aa22"))
       style.fillOpacity should be (Some(0.5))

--- a/vector/src/main/scala/geotrellis/vector/Extent.scala
+++ b/vector/src/main/scala/geotrellis/vector/Extent.scala
@@ -43,15 +43,9 @@ object ProjectedExtent {
  */
 case class Extent(xmin: Double, ymin: Double, xmax: Double, ymax: Double) extends Geometry {
 
-  // Validation: Do not accept extents with no width or height, or with min values greater than max values.
-  if (xmin >= xmax) {
-    if (xmin == xmax) { throw ExtentRangeError(s"Invalid Extent: Extent has no width. xmin must not equal xmax (xmin=$xmin, xmax=$xmax)") }
-    throw ExtentRangeError(s"Invalid Extent: xmin must be less than xmax (xmin=$xmin, xmax=$xmax)")
-  }
-  if (ymin >= ymax) {
-    if (ymin == ymax) { throw ExtentRangeError(s"Invalid Extent: Extent has no heigh. ymin must not equal ymax (ymin=$ymin, ymax=$ymax)") }
-    throw ExtentRangeError(s"Invalid Extent: ymin must be less than ymax (ymin=$ymin, ymax=$ymax)")
-  }
+  // Validation: Do not accept extents min values greater than max values.
+  if (xmin > xmax) { throw ExtentRangeError(s"Invalid Extent: xmin must be less than xmax (xmin=$xmin, xmax=$xmax)")  }
+  if (ymin > ymax) { throw ExtentRangeError(s"Invalid Extent: ymin must be less than ymax (ymin=$ymin, ymax=$ymax)") }
 
   def jtsGeom =
     factory.createPolygon(

--- a/vector/src/main/scala/geotrellis/vector/Extent.scala
+++ b/vector/src/main/scala/geotrellis/vector/Extent.scala
@@ -43,7 +43,17 @@ object ProjectedExtent {
  */
 case class Extent(xmin: Double, ymin: Double, xmax: Double, ymax: Double) extends Geometry {
 
-  def jtsGeom = 
+  // Validation: Do not accept extents with no width or height, or with min values greater than max values.
+  if (xmin >= xmax) {
+    if (xmin == xmax) { throw ExtentRangeError(s"Invalid Extent: Extent has no width. xmin must not equal xmax (xmin=$xmin, xmax=$xmax)") }
+    throw ExtentRangeError(s"Invalid Extent: xmin must be less than xmax (xmin=$xmin, xmax=$xmax)")
+  }
+  if (ymin >= ymax) {
+    if (ymin == ymax) { throw ExtentRangeError(s"Invalid Extent: Extent has no heigh. ymin must not equal ymax (ymin=$ymin, ymax=$ymax)") }
+    throw ExtentRangeError(s"Invalid Extent: ymin must be less than ymax (ymin=$ymin, ymax=$ymax)")
+  }
+
+  def jtsGeom =
     factory.createPolygon(
       factory.createLinearRing(
         Array(
@@ -56,10 +66,6 @@ case class Extent(xmin: Double, ymin: Double, xmax: Double, ymax: Double) extend
       ),
       null
     )
-    
-
-  if (xmin > xmax) throw ExtentRangeError(s"x: $xmin to $xmax")
-  if (ymin > ymax) throw ExtentRangeError(s"y: $ymin to $ymax")
 
   override def isValid: Boolean = true
   override def centroid: PointOrNoResult = PointResult(center)

--- a/vector/src/main/scala/geotrellis/vector/GeometryCollectionBuilder.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeometryCollectionBuilder.scala
@@ -24,8 +24,10 @@ class GeometryCollectionBuilder {
     case l: Line => lines += l
     case ml: MultiLine => multiLines += ml
     case p: Polygon => polygons += p
+    case e: Extent => polygons += e.toPolygon
     case mp: MultiPolygon => multiPolygons += mp
     case gc: GeometryCollection => collections += gc
+    case _ => throw new MatchError(s"Unexpected geometry of type ${geom.getClass.getName}: $geom")
   }
   def +=(geom: Geometry) = add(geom)
 
@@ -35,16 +37,18 @@ class GeometryCollectionBuilder {
     addAll(geoms)
 
 
-  def add(geom: jts.Geometry) = geom match {
-    //implicit conversions are happening here
-    case p: jts.Point => points += p
-    case mp: jts.MultiPoint => multiPoints += mp
-    case l: jts.LineString => lines += l
-    case ml: jts.MultiLineString => multiLines += ml
-    case p: jts.Polygon => polygons += p
-    case mp: jts.MultiPolygon => multiPolygons += mp
-    case gc: jts.GeometryCollection => collections += gc
-  }
+  def add(geom: jts.Geometry) =
+    geom match {
+      //implicit conversions are happening here
+      case p: jts.Point => points += p
+      case mp: jts.MultiPoint => multiPoints += mp
+      case l: jts.LineString => lines += l
+      case ml: jts.MultiLineString => multiLines += ml
+      case p: jts.Polygon => polygons += p
+      case mp: jts.MultiPolygon => multiPolygons += mp
+      case gc: jts.GeometryCollection => collections += gc
+      case _ => throw new MatchError(s"Unexpected geometry of type ${geom.getClass.getName}: $geom")
+    }
   def +=(geom: jts.Geometry) = add(geom)
 
   def addAll(geoms: Traversable[jts.Geometry])(implicit d: DummyImplicit) =

--- a/vector/src/main/scala/geotrellis/vector/io/json/GeometryFormats.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/GeometryFormats.scala
@@ -96,6 +96,10 @@ trait GeometryFormats {
     )
   }
 
+  /** Extent gets it's own non-GeoJson JSON representation.
+    * If you're using the Extent as a geometry, however, it gets converted
+    * to a Polygon and written out in GeoJson as a Polygon
+    */
   implicit object ExtentFormat extends RootJsonFormat[Extent] {
     def write(extent: Extent) = 
       JsObject(
@@ -110,7 +114,7 @@ trait GeometryFormats {
         case Seq(JsNumber(xmin), JsNumber(ymin), JsNumber(xmax), JsNumber(ymax)) =>
           Extent(xmin.toDouble, ymin.toDouble, xmax.toDouble, ymax.toDouble)
         case _ =>
-          throw new DeserializationException("Extent [xmin,ymin,xmax,ymax] expected")
+          throw new DeserializationException(s"Extent [xmin,ymin,xmax,ymax] expected: $value")
       }
   }
 
@@ -185,15 +189,16 @@ trait GeometryFormats {
   }
 
   implicit object GeometryFormat extends RootJsonFormat[Geometry] {
-    def write(o: Geometry) = o match {
-      case o: Point => o.toJson
-      case o: Line => o.toJson
-      case o: Polygon => o.toJson
-      case o: MultiPolygon => o.toJson
-      case o: MultiPoint => o.toJson
-      case o: MultiLine => o.toJson
-      case o: GeometryCollection => o.toJson
-      case _ => throw new SerializationException("Unknown Geometry")
+    def write(geom: Geometry) = geom match {
+      case geom: Point => geom.toJson
+      case geom: Line => geom.toJson
+      case geom: Polygon => geom.toJson
+      case geom: Extent => geom.toPolygon.toJson
+      case geom: MultiPolygon => geom.toJson
+      case geom: MultiPoint => geom.toJson
+      case geom: MultiLine => geom.toJson
+      case geom: GeometryCollection => geom.toJson
+      case _ => throw new SerializationException("Unknown Geometry type ${geom.getClass.getName}: $geom")
     }
 
     def read(value: JsValue) = value.asJsObject.getFields("type") match {

--- a/vector/src/main/scala/geotrellis/vector/io/json/Style.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/Style.scala
@@ -1,0 +1,86 @@
+package geotrellis.vector.io.json
+
+import spray.json._
+import scala.collection.mutable
+
+case class Style(
+  strokeColor: Option[String],
+  strokeWidth: Option[Int],
+  strokeOpacity: Option[Double],
+  fillColor: Option[String],
+  fillOpacity: Option[Double] 
+)
+
+object Style {
+  def apply(
+  strokeColor: String = "",
+  strokeWidth: Int = Int.MinValue,
+  strokeOpacity: Double = Double.NaN,
+  fillColor: String = "",
+  fillOpacity: Double = Double.NaN
+  ): Style = 
+    Style(
+      if(strokeColor != "") Some(strokeColor) else None,
+      if(strokeWidth != Int.MinValue) Some(strokeWidth) else None,
+      if(!java.lang.Double.isNaN(strokeOpacity)) Some(strokeOpacity) else None,
+      if(fillColor != "") Some(fillColor) else None,
+      if(!java.lang.Double.isNaN(fillOpacity)) Some(fillOpacity) else None
+    )
+
+  implicit object StyleFormat extends RootJsonFormat[Style] {
+    def read(value: JsValue): Style =
+      value match {
+        case obj: JsObject =>
+          val fields = obj.fields
+          val strokeColor =
+            fields.get("stroke") match {
+              case Some(JsString(v)) => Some(v)
+              case None => None
+              case Some(v) => throw new DeserializationException(s"'stroke' property must be a string, got $v")
+            }
+
+          val strokeWidth =
+            fields.get("stroke-width") match {
+              case Some(JsNumber(v)) => Some(v.toInt)
+              case None => None
+              case Some(v) => throw new DeserializationException(s"'stroke-width' property must be a number, got $v")
+            }
+
+          val strokeOpacity =
+            fields.get("stroke-opacity") match {
+              case Some(JsString(v)) => Some(v.toDouble)
+              case None => None
+              case Some(v) => throw new DeserializationException(s"'stroke-opacity' property must be a string, got $v")
+            }
+
+          val fillColor =
+            fields.get("fill") match {
+              case Some(JsString(sc)) => Some(sc)
+              case None => None
+              case Some(v) => throw new DeserializationException(s"'fill' property must be a string, got $v")
+            }
+
+          val fillOpacity =
+            fields.get("fill-opacity") match {
+              case Some(JsNumber(v)) => Some(v.toDouble)
+              case None => None
+              case Some(v) => throw new DeserializationException(s"'fill-opacity' property must be a string, got $v")
+            }
+
+          Style(strokeColor, strokeWidth, strokeOpacity, fillColor, fillOpacity)
+        case _ =>
+          Style()
+      }
+
+    def write(style: Style): JsValue = {
+      val l = mutable.ListBuffer[(String, JsValue)]()
+      if(style.strokeColor.isDefined) l += ( ("stroke", JsString(style.strokeColor.get)) )
+      if(style.strokeWidth.isDefined) l += ( ("stroke-width", JsNumber(style.strokeWidth.get)) )
+      if(style.strokeOpacity.isDefined) l += ( ("stroke-opacity", JsNumber(style.strokeOpacity.get)) )
+      if(style.fillColor.isDefined) l += ( ("fill", JsString(style.fillColor.get)) )
+      if(style.fillOpacity.isDefined) l += ( ("fill-opacity", JsNumber(style.fillOpacity.get)) )
+
+      JsObject(l:_*)
+    }
+  }
+}

--- a/vector/src/main/scala/geotrellis/vector/io/json/Style.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/Style.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 
 case class Style(
   strokeColor: Option[String],
-  strokeWidth: Option[Int],
+  strokeWidth: Option[String],
   strokeOpacity: Option[Double],
   fillColor: Option[String],
   fillOpacity: Option[Double] 
@@ -13,15 +13,15 @@ case class Style(
 
 object Style {
   def apply(
-  strokeColor: String = "",
-  strokeWidth: Int = Int.MinValue,
-  strokeOpacity: Double = Double.NaN,
-  fillColor: String = "",
-  fillOpacity: Double = Double.NaN
+    strokeColor: String = "",
+    strokeWidth: String = "",
+    strokeOpacity: Double = Double.NaN,
+    fillColor: String = "",
+    fillOpacity: Double = Double.NaN
   ): Style = 
     Style(
       if(strokeColor != "") Some(strokeColor) else None,
-      if(strokeWidth != Int.MinValue) Some(strokeWidth) else None,
+      if(strokeWidth != "") Some(strokeWidth) else None,
       if(!java.lang.Double.isNaN(strokeOpacity)) Some(strokeOpacity) else None,
       if(fillColor != "") Some(fillColor) else None,
       if(!java.lang.Double.isNaN(fillOpacity)) Some(fillOpacity) else None
@@ -41,9 +41,9 @@ object Style {
 
           val strokeWidth =
             fields.get("stroke-width") match {
-              case Some(JsNumber(v)) => Some(v.toInt)
+              case Some(JsString(v)) => Some(v)
               case None => None
-              case Some(v) => throw new DeserializationException(s"'stroke-width' property must be a number, got $v")
+              case Some(v) => throw new DeserializationException(s"'stroke-width' property must be a string, got $v")
             }
 
           val strokeOpacity =
@@ -75,7 +75,7 @@ object Style {
     def write(style: Style): JsValue = {
       val l = mutable.ListBuffer[(String, JsValue)]()
       if(style.strokeColor.isDefined) l += ( ("stroke", JsString(style.strokeColor.get)) )
-      if(style.strokeWidth.isDefined) l += ( ("stroke-width", JsNumber(style.strokeWidth.get)) )
+      if(style.strokeWidth.isDefined) l += ( ("stroke-width", JsString(style.strokeWidth.get)) )
       if(style.strokeOpacity.isDefined) l += ( ("stroke-opacity", JsNumber(style.strokeOpacity.get)) )
       if(style.fillColor.isDefined) l += ( ("fill", JsString(style.fillColor.get)) )
       if(style.fillOpacity.isDefined) l += ( ("fill-opacity", JsNumber(style.fillOpacity.get)) )

--- a/vector/src/main/scala/geotrellis/vector/io/json/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/package.scala
@@ -10,31 +10,31 @@ import scala.util.{Try, Success, Failure}
 package object json extends GeoJsonSupport {
 
   implicit class GeometriesToGeoJson(val geoms: Traversable[Geometry]) extends AnyVal {
-    def toGeoJson: String = {
+    def toGeoJson(): String = {
       GeometryCollection(geoms).toJson.compactPrint
     }
   }
 
   implicit class ExtentsToGeoJson(val extent: Extent) extends AnyVal {
-    def toGeoJson: String = {
+    def toGeoJson(): String = {
       extent.toPolygon.toGeoJson
     }
   }
 
   implicit class FeaturesToGeoJson[G <: Geometry, D: JsonWriter](features: Traversable[Feature[G, D]]) {
-    def toGeoJson: String = {
+    def toGeoJson(): String = {
       JsonFeatureCollection(features).toJson.compactPrint
     }
   }
 
   implicit class RichGeometry(val geom: Geometry) extends AnyVal {
-    def toGeoJson: String = geom.toJson.compactPrint
+    def toGeoJson(): String = geom.toJson.compactPrint
 
     def withCrs(crs: CRS) = WithCrs(geom, crs)
   }
 
   implicit class RichFeature[G <: Geometry, D: JsonWriter](feature: Feature[G, D]) {
-    def toGeoJson: String = writeFeatureJson(feature).compactPrint
+    def toGeoJson(): String = writeFeatureJson(feature).compactPrint
 
     def withCrs(crs: CRS) = WithCrs(feature, crs)
   }
@@ -46,7 +46,7 @@ package object json extends GeoJsonSupport {
      * @tparam T type of geometry or feature expected in the json string to be parsed
      * @return The geometry or feature of type T
      */
-    def parseGeoJson[T: JsonReader] = s.parseJson.convertTo[T]
+    def parseGeoJson[T: JsonReader]() = s.parseJson.convertTo[T]
 
     /**
      * extractGeometries, extracts geometries from json string,
@@ -54,7 +54,7 @@ package object json extends GeoJsonSupport {
      * @tparam G type of geometry desired to extract
      * @return Seq[G] containing geometries
      */
-    def extractGeometries[G <: Geometry : JsonReader: TypeTag]: Seq[G] =
+    def extractGeometries[G <: Geometry : JsonReader: TypeTag](): Seq[G] =
       Try(s.parseJson.convertTo[G]) match {
         case Success(g) => Seq(g)
         case Failure(_: spray.json.DeserializationException) =>
@@ -80,7 +80,7 @@ package object json extends GeoJsonSupport {
      * @tparam F type of feature desired to extract
      * @return Seq[F] containing features
      */
-    def extractFeatures[F <: Feature[_, _]: JsonReader]: Seq[F] =
+    def extractFeatures[F <: Feature[_, _]: JsonReader](): Seq[F] =
       Try(s.parseJson.convertTo[F]) match {
         case Success(g) => Seq(g)
         case Failure(_: spray.json.DeserializationException) =>

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -26,6 +26,7 @@ package object vector extends SeqMethods {
   type PointFeature[D] = Feature[Point, D]
   type LineFeature[D] = Feature[Line, D]
   type PolygonFeature[D] = Feature[Polygon, D]
+  type ExtentFeature[D] = Feature[Extent, D]
   type MultiPointFeature[D] = Feature[MultiPoint, D]
   type MultiLineFeature[D] = Feature[MultiLine, D]
   type MultiPolygonFeature[D] = Feature[MultiPolygon, D]
@@ -81,21 +82,6 @@ package object vector extends SeqMethods {
     }).toSeq
   }
 
-  implicit def geometryCollectionToSeqGeometry(gc: jts.GeometryCollection): Seq[Geometry] = {
-    val len = gc.getNumGeometries
-    (for (i <- 0 until len) yield {
-      gc.getGeometryN(i) match {
-        case p: jts.Point => Seq[Geometry](Point(p))
-        case mp: jts.MultiPoint => multiPointToSeqPoint(mp)
-        case l: jts.LineString => Seq[Geometry](Line(l))
-        case ml: jts.MultiLineString => multiLineToSeqLine(ml)
-        case p: jts.Polygon => Seq[Geometry](Polygon(p))
-        case mp: jts.MultiPolygon => multiPolygonToSeqPolygon(mp)
-        case gc: jts.GeometryCollection => geometryCollectionToSeqGeometry(gc)
-      }
-    }).toSeq.flatten
-  }
-
   implicit def seqPointToMultiPoint(ps: Seq[Point]): MultiPoint = MultiPoint(ps)
   implicit def arrayPointToMultiPoint(ps: Array[Point]): MultiPoint = MultiPoint(ps)
 
@@ -105,29 +91,6 @@ package object vector extends SeqMethods {
   implicit def seqPolygonToMultiPolygon(ps: Seq[Polygon]): MultiPolygon = MultiPolygon(ps)
   implicit def arrayPolygonToMultiPolygon(ps: Array[Polygon]): MultiPolygon = MultiPolygon(ps)
 
-  implicit def seqGeometryToGeometryCollection(gs: Seq[Geometry]): GeometryCollection = {
-    val points = mutable.ListBuffer[Point]()
-    val lines = mutable.ListBuffer[Line]()
-    val polygons = mutable.ListBuffer[Polygon]()
-    val multiPoints = mutable.ListBuffer[MultiPoint]()
-    val multiLines = mutable.ListBuffer[MultiLine]()
-    val multiPolygons = mutable.ListBuffer[MultiPolygon]()
-    val geometryCollections = mutable.ListBuffer[GeometryCollection]()
-
-    for(g <- gs) {
-      g match {
-        case p: Point => points += p
-        case l: Line => lines += l
-        case p: Polygon => polygons += p
-        case mp: MultiPoint => multiPoints += mp
-        case ml: MultiLine => multiLines += ml
-        case mp: MultiPolygon => multiPolygons += mp
-        case gc: GeometryCollection => geometryCollections += gc
-        case _ => sys.error(s"Unknown Geometry type: $g")
-      }
-    }
-    GeometryCollection(points, lines, polygons,
-                       multiPoints, multiLines, multiPolygons,
-                       geometryCollections)
-  }
+  implicit def seqGeometryToGeometryCollection(gs: Seq[Geometry]): GeometryCollection =
+    GeometryCollection(gs)
 }


### PR DESCRIPTION
A recent change made `Extent` extend `Geometry`, and this PR fixes a resulting bug that was caused by not correctly modifying the `GeometryCollectionBuilder` logic to handle that change.

Also, added a `Style` object that makes it simple to style GeoJson geometries so that they can have colors and more in web viewers like geojson.io and gists, like this: https://gist.github.com/lossyrob/df261af1a9a02e088686 (Thanks to @nocrosstalk for that idea)