### PR TITLE
Upgrade to JTS version 1.14.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val logging       = "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
   val scalatest     = "org.scalatest"       %%  "scalatest"      % "2.2.0"
   val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.11.1"
-  val jts           = "com.vividsolutions"  %  "jts"             % "1.13"
+  val jts           = "com.vividsolutions"  %  "jts-core"        % "1.14.0"
 
   val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"    % Version.monocle
   val monocleMacro  = "com.github.julien-truffaut" %% "monocle-macro"   % Version.monocle

--- a/vector/src/main/scala/geotrellis/vector/Feature.scala
+++ b/vector/src/main/scala/geotrellis/vector/Feature.scala
@@ -16,9 +16,6 @@
 
 package geotrellis.vector
 
-import com.vividsolutions.jts.{geom => jts}
-import spray.json._
-
 case class Feature[+G <: Geometry, D](geom: G, data: D) {
   def mapGeom[T <: Geometry](f: G => T): Feature[T, D] =
     Feature(f(geom), data)


### PR DESCRIPTION
No compile problems or test failures after upgrading.  I looked over the release notes and did a quick review of geotrellis-vector and didn't see anything that needed to be updated.  I'm going to look into how the new LineDissolver in JTS compares with the LineDissolve operation in geotrellis, if the JTS version seems clearly superior it might make sense to include that change in this PR.