### PR TITLE
Fixes and changes to Reprojection

### DIFF
--- a/.sbtignore
+++ b/.sbtignore
@@ -1,0 +1,28 @@
+# sbt ignore regexps
+Starting sbt with output filtering enabled
+^\[info\][ ]+(Resolving|Loading|Done|Attempting|Formatting|Updating)[ ]
+^\[info\] Main Scala API documentation
+^\[info\].*published[ ]+.*(sources\.jar|javadoc\.jar|\.pom)$
+^\[info\].*published ivy to
+^\[warn\] Credentials file
+^\[info\] Wrote.*[.]pom
+^Missing bintray credentials
+^SLF4J
+Unable to load native-hadoop library
+This usage is deprecated
+Attempting to overwrite
+delivering ivy file to
+warnings? found$
+re[-]run with [-](unchecked|deprecation|feature) for details
+model contains[ ]
+[ ]delivering[ ]
+^Graphviz dot encountered an error when generating the diagram for:
+^These are usually spurious errors, but if you notice a persistant error on
+^a diagram, please use the -diagrams-debug flag and report a bug with the output
+^Graphviz will be restarted...
+^Diagrams will be disabled for this run because the graphviz dot tool
+^has malfunctioned too many times. These scaladoc flags may help:
+^Please note that graphviz package
+^[*]+$
+^-diagrams-
+^$

--- a/buildall.sh
+++ b/buildall.sh
@@ -17,3 +17,4 @@
 ./sbt -J-Xmx2G "project jetty" compile || { exit 1; } 
 ./sbt -J-Xmx2G "project admin" compile || { exit 1; } 
 ./sbt -J-Xmx2G "project vector-benchmark" compile || { exit 1; } 
+./sbt -J-Xmx2G "project testkit" compile || { exit 1; }

--- a/proj4/src/main/scala/geotrellis/proj4/CRS.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/CRS.scala
@@ -96,6 +96,10 @@ object CRS {
     def epsgCode: Option[Int] = getEPSGCode(toProj4String + " <>")
   }
 
+  /** Creates a [[CoordinateReferenceSystem]] (CRS) from an EPSG code. */
+  def fromEpsgCode(epsgCode: Int) =
+    fromName(s"EPSG:$epsgCode")
+
   private def readEPSGCodeFromFile(proj4String: String): Option[String] = {
     val stream = getClass.getResourceAsStream(s"${filePrefix}epsg")
     try {

--- a/raster-test/build.sbt
+++ b/raster-test/build.sbt
@@ -10,5 +10,3 @@ libraryDependencies ++= Seq(
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
 parallelExecution := false
 fork in test := false
-javaOptions in run += "-Xmx2G"
-scalacOptions in compile += "-optimize"

--- a/raster-test/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
@@ -1,0 +1,93 @@
+package geotrellis.raster.reproject
+
+import geotrellis.raster._
+import geotrellis.raster.resample._
+import geotrellis.raster.mosaic._
+import geotrellis.vector._
+import geotrellis.vector.reproject._
+import geotrellis.vector.io.json._
+import geotrellis.engine._
+import geotrellis.testkit._
+import geotrellis.testkit.vector._
+import geotrellis.proj4._
+import geotrellis.raster.io.geotiff._
+import geotrellis.raster.io.geotiff.reader._
+
+import org.scalatest._
+import spire.syntax.cfor._
+
+class ReprojectRasterExtentSpec extends FunSpec
+    with TileBuilders
+    with GeoTiffTestUtils
+    with TestEngine {
+  describe("ReprojectRasterExtent") {
+
+    def formatExtent(name: String, re: RasterExtent) = {
+      val e = re.extent
+      val es = f"Extent(${e.xmin}%1.5f, ${e.ymin}%1.5f, ${e.xmax}%1.5f, ${e.ymax}%1.5f)"
+      f"$name: $es ${re.cellwidth}%1.5f, ${re.cellheight}%1.5f  (${re.cols} x ${re.rows})"
+    }
+
+    it("should (approximately) match a GDAL for EPSG:4326 to EPSG:3857") {
+      val sourceGt = SingleBandGeoTiff.compressed("raster-test/data/reproject/nlcd_tile_wsg84.tif")
+      val sourceRaster = sourceGt.raster
+
+      val rea @ RasterExtent(actualExtent, actualCellWidth, actualCellHeight, actualCols, actualRows) = 
+        ReprojectRasterExtent(sourceRaster.rasterExtent, sourceGt.crs, WebMercator)
+
+      val ree @ RasterExtent(expectedExtent, expectedCellWidth, expectedCellHeight, expectedCols, expectedRows) = 
+        SingleBandGeoTiff("raster-test/data/reproject/nlcd_tile_webmercator-nearestneighbor.tif").raster.rasterExtent
+
+      // println(formatExtent("GTA", rea))
+      // println(formatExtent("EXP", ree))
+
+      actualExtent.toPolygon should matchGeom (expectedExtent.toPolygon, 1.0)
+      actualCols should be (expectedCols +- 1)
+      actualRows should be (expectedRows +- 1)
+    }
+
+    it("should be in approximation to GDAL EPSG:32618 to EPSG:3857") {
+      val extent = Extent(394800.000, 4567140.000, 410160.000, 4582500.000)
+      val (cols, rows) = (512, 512)
+      val rasterExtent = RasterExtent(extent, cols, rows)
+
+      val expectedExtent = Extent(-8489029.279, 5049106.840, -8468324.230, 5069891.832)
+      val (expectedCols, expectedRows) = (518, 520)
+      val ree @ RasterExtent(_, expectedCellWidth, expectedCellHeight, _, _) = RasterExtent(expectedExtent, expectedCols, expectedRows)
+
+      val src = CRS.fromEpsgCode(32618)
+      val dest = CRS.fromEpsgCode(3857)
+
+      val rea @ RasterExtent(actualExtent, actualCellWidth, actualCellHeight, actualCols, actualRows) = ReprojectRasterExtent(rasterExtent, src, dest)
+
+      // println(formatExtent("GTA", rea))
+      // println(formatExtent("EXP", ree))
+
+      actualExtent.toPolygon should matchGeom (expectedExtent.toPolygon, 1.0)
+      actualCols should be (expectedCols +- 1)
+      actualRows should be (expectedRows +- 1)
+    }
+
+    it("should be in approximation to GDAL EPSG:32618 to EPSG:4326") {
+      val extent = Extent(394800.000, 4567140.000, 410160.000, 4582500.000)
+      val (cols, rows) = (512, 512)
+      val rasterExtent = RasterExtent(extent, cols, rows)
+
+      val expectedExtent = Extent(-76.2582475,  41.2488530, -76.0722134,  41.3890157)
+      val (expectedCols, expectedRows) = (584, 440)
+      val ree = RasterExtent(expectedExtent, expectedCols, expectedRows)
+
+      val src = CRS.fromEpsgCode(32618)
+      val dest = CRS.fromEpsgCode(4326)
+
+      val rea @ RasterExtent(actualExtent, _, _, actualCols, actualRows) = ReprojectRasterExtent(rasterExtent, src, dest)
+
+      // println(formatExtent("GTA", rea))
+      // println(formatExtent("EXP", ree))
+
+      actualExtent.toPolygon should matchGeom (expectedExtent.toPolygon, 1.0)
+      actualCols should be (expectedCols +- 1)
+      actualRows should be (expectedRows +- 1)
+    }
+  }
+}

--- a/raster-test/src/test/scala/geotrellis/raster/reproject/RowTransformSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/reproject/RowTransformSpec.scala
@@ -143,11 +143,8 @@ class RowTransformSpec extends FunSpec
       val srcProjected = src.map(_.reproject(utmToWebMercator))
       val dest = destX.zip(destY).map { case (x, y) => Point(x, y) }
 
-      println(Seq(Extent(-78.0000, 0.0000, -72.0000, 84.0000), Line(src.map(_.reproject(utm, LatLng)))).toGeoJson)
-
       src.zip(srcProjected).zip(dest)
         .foreach { case ((sp1, p1), p2) =>
-          println(s"$sp1 $p1 $p2")
           val dx = math.abs(p1.x - p2.x)
           val dy = math.abs(p1.y - p2.y)
           val d  = dx + dy

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
@@ -12,6 +12,8 @@ class MultiBandGeoTiff(
   val tags: Tags,
   options: GeoTiffOptions
 ) extends GeoTiff {
+  def rasterExtent: RasterExtent = RasterExtent(extent, tile.cols, tile.rows)
+
   def mapTile(f: MultiBandTile => MultiBandTile): MultiBandGeoTiff =
     MultiBandGeoTiff(f(tile), extent, crs, tags, options)
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SingleBandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SingleBandGeoTiff.scala
@@ -14,6 +14,7 @@ class SingleBandGeoTiff(
 ) extends GeoTiff {
   def projectedRaster: ProjectedRaster = ProjectedRaster(tile, extent, crs)
   def raster: Raster = Raster(tile, extent)
+  def rasterExtent: RasterExtent = RasterExtent(extent, tile.cols, tile.rows)
 
   def mapTile(f: Tile => Tile): SingleBandGeoTiff =
     SingleBandGeoTiff(f(tile), extent, crs, tags, options)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -98,8 +98,13 @@ object TiffTagFieldValue {
       shortValues(start + 3) = shortGeoKeys(i)._4.toShort
     }
 
-    fieldValues += TiffTagFieldValue(GeoKeyDirectoryTag, ShortsFieldType, shortValues.length, toBytes(shortValues))
-    fieldValues += TiffTagFieldValue(GeoDoubleParamsTag, DoublesFieldType, doubleGeoKeys.length, toBytes(doubleGeoKeys))
+    if(!shortValues.isEmpty) {
+      fieldValues += TiffTagFieldValue(GeoKeyDirectoryTag, ShortsFieldType, shortValues.length, toBytes(shortValues))
+    }
+
+    if(!doubleGeoKeys.isEmpty) {
+      fieldValues += TiffTagFieldValue(GeoDoubleParamsTag, DoublesFieldType, doubleGeoKeys.length, toBytes(doubleGeoKeys))
+    }
 
     // Not written (what goes here?):
     //GeoKeyDirectory ASCII     TagCodes.GeoAsciiParamsTag, TiffFieldType.AsciisFieldType, N = Number of Characters (pipe sparated |), GeoKeyAsciis _

--- a/raster/src/main/scala/geotrellis/raster/reproject/Reproject.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/Reproject.scala
@@ -22,12 +22,12 @@ object Reproject {
       val cellheight = re.cellheight
 
       val transform = Transform(src, dest)
+      val inverseTransform = Transform(dest, src)
+
       val newRe @ RasterExtent(newExtent, newCellWidth, newCellHeight, newCols, newRows) =
         ReprojectRasterExtent(re, transform)
 
       val newTile = ArrayTile.empty(tile.cellType, newCols, newRows)
-
-      val inverseTransform = Transform(dest, src)
 
       val rowTransform: RowTransform =
         if (options.errorThreshold != 0.0)

--- a/spark/src/main/scala/geotrellis/spark/op/focal/FocalOperation.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/focal/FocalOperation.scala
@@ -21,7 +21,7 @@ object FocalOperation {
       (calc: (Tile, Neighborhood, Option[GridBounds]) => Tile): RDD[(K, Tile)] = {
 
     val bounds = opBounds.getOrElse(GridBounds(Int.MinValue, Int.MinValue, Int.MaxValue, Int.MaxValue))
-    val m: Int = neighborhood.extent // how many pixels we need for the margin        
+    val m: Int = neighborhood.extent // how many pixels we need for the margin
     
     rdd
       .flatMap { case record @ (key, tile) =>
@@ -36,10 +36,10 @@ object FocalOperation {
         // ex: adding "TopLeft" corner of this tile to contribute to "TopLeft" tile at key
         def addSlice(spatialKey: SpatialKey, direction: => Direction, sliver: => Tile) {
           if (bounds.contains(spatialKey.col, spatialKey.row))
-            slivers += key.updateSpatialComponent(spatialKey) -> (direction, sliver.toArrayTile) // force tile crop                    
+            slivers += key.updateSpatialComponent(spatialKey) -> (direction, sliver.toArrayTile) // force tile crop
         }
 
-        // ex: A tile that contributes to the top (tile above it) will give up it's top slice, which will be placed at the bottom of the target focal window        
+        // ex: A tile that contributes to the top (tile above it) will give up it's top slice, which will be placed at the bottom of the target focal window
         addSlice(SpatialKey(col,row), Center, tile)
       
         addSlice(SpatialKey(col-1, row), Left, tile.crop(0, 0, mm, rows))

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -7,6 +7,9 @@ import geotrellis.vector.reproject._
 import geotrellis.proj4._
 
 object MapKeyTransform {
+  def apply(crs: CRS, level: LayoutLevel): MapKeyTransform =
+    apply(crs.worldExtent, level.layout.layoutCols, level.layout.layoutRows)
+
   def apply(crs: CRS, layoutDimensions: (Int, Int)): MapKeyTransform =
     apply(crs.worldExtent, layoutDimensions)
 


### PR DESCRIPTION
This PR includes some changes to raster reprojection, mainly

- The extent for the reprojected raster uses a densified version of the extent, reducing the code from the GDAL ported method.
- There was a "bug" in how we were determining the pixel size (I say "bug" in quotes because it's just an estimate). This more closely mirrors what GDAL is doing, which is verified by some tests around reprojecting raster extents from tiles of a landsat image.

Other changes include:
- Added a `fromEpsgCode` to CRS
- Added a `MapKeyTransform` that takes a layout level
- Fixed a GeoTiff writing bug that was happening when we were writing GeoTiffs without any GeoDoubleKey tags.

Also, this PR adds an `.sbtignore` that aims to reduce the output of the build (especially in travis). This will potentially have the effect of hiding information that one would expect from the build, so if this ends up biting us I'll take it back out.