### PR TITLE
BitType raster fixes

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/BitArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/BitArrayTile.scala
@@ -79,7 +79,7 @@ final case class BitArrayTile(array: Array[Byte], cols: Int, rows: Int)
 
   override def mapDouble(f: Double => Double) = map(z => d2i(f(i2d(z))))
 
-  def copy = ArrayTile(array.clone, cols, rows)
+  def copy = BitArrayTile(array.clone, cols, rows)
 
   def toBytes: Array[Byte] = array.clone
 }

--- a/raster/src/main/scala/geotrellis/raster/CellType.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellType.scala
@@ -70,6 +70,7 @@ object CellType {
   }
 
   def fromString(name: String): CellType = name match {
+    case "bool"     => TypeBit
     case "int8"     => TypeByte
     case "uint8"    => TypeUByte
     case "int16"    => TypeShort


### PR DESCRIPTION
* Fixes `CellType.fromString` function (added `bool` case, useful for etl)
* Fixed `copy` function for `BitArrayTile` (it copied `BitArrayTile` to `ByteArrayTile`)