### PR TITLE
Check the cast in Geometry#apply for earlier failures

### DIFF
--- a/slick/src/main/scala/geotrellis/slick/PostGisProjectionSupport.scala
+++ b/slick/src/main/scala/geotrellis/slick/PostGisProjectionSupport.scala
@@ -115,9 +115,9 @@ object PostGisProjectionSupportUtils {
       case (srid, wkt) =>
         val geom =
           if (wkt.startsWith("00") || wkt.startsWith("01"))
-            WKB.read[Geometry](wkt)
-          else 
-            WKT.read[Geometry](wkt)
+            WKB.read(wkt)
+          else
+            WKT.read(wkt)
 
         if (srid != -1)
           Projected(geom, srid).asInstanceOf[T]

--- a/slick/src/main/scala/geotrellis/slick/PostGisSupport.scala
+++ b/slick/src/main/scala/geotrellis/slick/PostGisSupport.scala
@@ -111,13 +111,13 @@ class PostGisSupport(override val driver: JdbcDriver) extends PostGisExtensions 
 object PostGisSupportUtils {  
   def toLiteral(geom: Geometry): String = WKT.write(geom)
 
-  def fromLiteral[T <: Geometry](value: String): T = {
+  def fromLiteral[T <: Geometry : ClassTag](value: String): T = {
     splitRSIDAndWKT(value) match {
       case (srid, wkt) => { //TODO - SRID is ignored
         if (wkt.startsWith("00") || wkt.startsWith("01"))
-          WKB.read[T](wkt)
+          WKB.read(wkt).as[T].get
         else 
-          WKT.read[T](wkt)
+          WKT.read(wkt).as[T].get
       }
     }
   }

--- a/slick/src/test/scala/geotrellis/slick/Data.scala
+++ b/slick/src/test/scala/geotrellis/slick/Data.scala
@@ -55,11 +55,16 @@ object util {
   .map(str => (str.substring(7,12), str.substring(15,20), str.substring(22)))
   .map(_ match {
     case (lat,lng,city) =>
-      (city, WKT.read[Point](s"POINT(${lng.toDouble} ${lat.toDouble})"))
+      (city, Point(lng.toDouble, lat.toDouble))
   })
 
   def bboxBuffer(x: Double, y: Double, d: Double) =
-    WKT.read[Polygon](s"POLYGON((${x - d} ${y - d}, ${x - d} ${y + d}, ${x + d} ${y + d}, ${x + d} ${y - d}, ${x - d} ${y - d}))")
+    Polygon(Line(
+      (x - d, y - d),
+      (x - d, y + d),
+      (x + d, y + d),
+      (x + d, y - d),
+      (x - d, y - d)))
 
   def pt(x: Double, y: Double) = Point(x, y)
 }

--- a/vector/src/main/scala/geotrellis/vector/Geometry.scala
+++ b/vector/src/main/scala/geotrellis/vector/Geometry.scala
@@ -76,24 +76,20 @@ trait Geometry {
 }
 
 object Geometry {
-  import scala.reflect.{ ClassTag, classTag }
   /**
-   * Wraps JTS Geometry in correct container and attempts to cast.
+   * Wraps JTS Geometry in correct container.
    * Useful when sourcing objects from JTS interface.
    */
-  def apply[G <: Geometry : ClassTag](obj: jts.Geometry): G = {
-    val result =
-      obj match {
-        case obj: jts.Point => Point(obj)
-        case obj: jts.LineString => Line(obj)
-        case obj: jts.Polygon => Polygon(obj)
-        case obj: jts.MultiPoint => MultiPoint(obj)
-        case obj: jts.MultiLineString => MultiLine(obj)
-        case obj: jts.MultiPolygon => MultiPolygon(obj)
-        case obj: jts.GeometryCollection => GeometryCollection(obj)
-      }
-    classTag[G].runtimeClass.cast(result).asInstanceOf[G]
-  }
+  implicit def apply(obj: jts.Geometry): Geometry =
+    obj match {
+      case obj: jts.Point => Point(obj)
+      case obj: jts.LineString => Line(obj)
+      case obj: jts.Polygon => Polygon(obj)
+      case obj: jts.MultiPoint => MultiPoint(obj)
+      case obj: jts.MultiLineString => MultiLine(obj)
+      case obj: jts.MultiPolygon => MultiPolygon(obj)
+      case obj: jts.GeometryCollection => GeometryCollection(obj)
+    }
 }
 
 trait Relatable { self: Geometry =>

--- a/vector/src/main/scala/geotrellis/vector/Geometry.scala
+++ b/vector/src/main/scala/geotrellis/vector/Geometry.scala
@@ -76,21 +76,24 @@ trait Geometry {
 }
 
 object Geometry {
+  import scala.reflect.{ ClassTag, classTag }
   /**
    * Wraps JTS Geometry in correct container and attempts to cast.
    * Useful when sourcing objects from JTS interface.
    */
-  def apply[G <: Geometry](obj: jts.Geometry): G = {
-    obj match {
-      case obj: jts.Point => Point(obj)
-      case obj: jts.LineString => Line(obj)
-      case obj: jts.Polygon => Polygon(obj)
-      case obj: jts.MultiPoint => MultiPoint(obj)
-      case obj: jts.MultiLineString => MultiLine(obj)
-      case obj: jts.MultiPolygon => MultiPolygon(obj)
-      case obj: jts.GeometryCollection => GeometryCollection(obj)
-    }
-  }.asInstanceOf[G]
+  def apply[G <: Geometry : ClassTag](obj: jts.Geometry): G = {
+    val result =
+      obj match {
+        case obj: jts.Point => Point(obj)
+        case obj: jts.LineString => Line(obj)
+        case obj: jts.Polygon => Polygon(obj)
+        case obj: jts.MultiPoint => MultiPoint(obj)
+        case obj: jts.MultiLineString => MultiLine(obj)
+        case obj: jts.MultiPolygon => MultiPolygon(obj)
+        case obj: jts.GeometryCollection => GeometryCollection(obj)
+      }
+    classTag[G].runtimeClass.cast(result).asInstanceOf[G]
+  }
 }
 
 trait Relatable { self: Geometry =>

--- a/vector/src/main/scala/geotrellis/vector/Geometry.scala
+++ b/vector/src/main/scala/geotrellis/vector/Geometry.scala
@@ -20,6 +20,7 @@ import com.vividsolutions.jts.{geom => jts}
 import com.vividsolutions.jts.geom.TopologyException
 import GeomFactory._
 import geotrellis.proj4.CRS
+import scala.reflect.{ ClassTag, classTag }
 
 trait Geometry {
 
@@ -61,6 +62,13 @@ trait Geometry {
     catch {
       case _: TopologyException => simplifier.reduce(jtsGeom).intersection(simplifier.reduce(g.jtsGeom))
     }
+
+  def as[G <: Geometry : ClassTag]: Option[G] = {
+    if (classTag[G].runtimeClass.isInstance(this)) 
+      Some(this.asInstanceOf[G])
+    else
+      None
+  }
 
   override
   def equals(other: Any): Boolean =

--- a/vector/src/main/scala/geotrellis/vector/affine/AffineTransformation.scala
+++ b/vector/src/main/scala/geotrellis/vector/affine/AffineTransformation.scala
@@ -22,7 +22,7 @@ trait AffineTransformation {
   def transform(geom: MultiLine): MultiLine = MultiLine(transform(geom.jtsGeom))
   def transform(geom: MultiPolygon): MultiPolygon = MultiPolygon(transform(geom.jtsGeom))
   def transform(geom: GeometryCollection): GeometryCollection = GeometryCollection(transform(geom.jtsGeom))
-  def transform(geom: Geometry): Geometry = Geometry(transform(geom.jtsGeom))
+  def transform(geom: Geometry): Geometry = Geometry[Geometry](transform(geom.jtsGeom))
 
   private def transform[D <: jts.Geometry](g: D): D = trans.transform(g).asInstanceOf[D]
 

--- a/vector/src/main/scala/geotrellis/vector/affine/AffineTransformation.scala
+++ b/vector/src/main/scala/geotrellis/vector/affine/AffineTransformation.scala
@@ -22,7 +22,7 @@ trait AffineTransformation {
   def transform(geom: MultiLine): MultiLine = MultiLine(transform(geom.jtsGeom))
   def transform(geom: MultiPolygon): MultiPolygon = MultiPolygon(transform(geom.jtsGeom))
   def transform(geom: GeometryCollection): GeometryCollection = GeometryCollection(transform(geom.jtsGeom))
-  def transform(geom: Geometry): Geometry = Geometry[Geometry](transform(geom.jtsGeom))
+  def transform(geom: Geometry): Geometry = Geometry(transform(geom.jtsGeom))
 
   private def transform[D <: jts.Geometry](g: D): D = trans.transform(g).asInstanceOf[D]
 

--- a/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.vector.io.wkb
 
+import scala.reflect.ClassTag
 import com.vividsolutions.jts.io.{WKBReader}
 import com.vividsolutions.jts.{geom => jts}
 import geotrellis.vector._
@@ -27,12 +28,12 @@ object WKB {
   private val readerBox = new ThreadLocal[WKBReader]
   private val writerBox = new ThreadLocal[WKBWriter]
 
-  def read[G <: Geometry](value: Array[Byte]): G = {
+  def read[G <: Geometry : ClassTag](value: Array[Byte]): G = {
     if (readerBox.get == null) readerBox.set(new WKBReader(GeomFactory.factory))
     Geometry[G](readerBox.get.read(value))
   }
 
-  def read[G <: Geometry](hex: String): G = {
+  def read[G <: Geometry : ClassTag](hex: String): G = {
     if (readerBox.get == null) readerBox.set(new WKBReader(GeomFactory.factory))
     Geometry[G](readerBox.get.read(WKBReader.hexToBytes(hex)))
   }

--- a/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
@@ -16,7 +16,6 @@
 
 package geotrellis.vector.io.wkb
 
-import scala.reflect.ClassTag
 import com.vividsolutions.jts.io.{WKBReader}
 import com.vividsolutions.jts.{geom => jts}
 import geotrellis.vector._
@@ -28,14 +27,14 @@ object WKB {
   private val readerBox = new ThreadLocal[WKBReader]
   private val writerBox = new ThreadLocal[WKBWriter]
 
-  def read[G <: Geometry](value: Array[Byte]): G = {
+  def read(value: Array[Byte]): Geometry = {
     if (readerBox.get == null) readerBox.set(new WKBReader(GeomFactory.factory))
-    Geometry(readerBox.get.read(value)).asInstanceOf[G]
+    Geometry(readerBox.get.read(value))
   }
 
-  def read[G <: Geometry](hex: String): G = {
+  def read(hex: String): Geometry = {
     if (readerBox.get == null) readerBox.set(new WKBReader(GeomFactory.factory))
-    Geometry(readerBox.get.read(WKBReader.hexToBytes(hex))).asInstanceOf[G]
+    Geometry(readerBox.get.read(WKBReader.hexToBytes(hex)))
   }
 
   def write(geom: Geometry, srid: Int = 0): Array[Byte] = {

--- a/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
@@ -28,14 +28,14 @@ object WKB {
   private val readerBox = new ThreadLocal[WKBReader]
   private val writerBox = new ThreadLocal[WKBWriter]
 
-  def read[G <: Geometry : ClassTag](value: Array[Byte]): G = {
+  def read[G <: Geometry](value: Array[Byte]): G = {
     if (readerBox.get == null) readerBox.set(new WKBReader(GeomFactory.factory))
-    Geometry[G](readerBox.get.read(value))
+    Geometry(readerBox.get.read(value)).asInstanceOf[G]
   }
 
-  def read[G <: Geometry : ClassTag](hex: String): G = {
+  def read[G <: Geometry](hex: String): G = {
     if (readerBox.get == null) readerBox.set(new WKBReader(GeomFactory.factory))
-    Geometry[G](readerBox.get.read(WKBReader.hexToBytes(hex)))
+    Geometry(readerBox.get.read(WKBReader.hexToBytes(hex))).asInstanceOf[G]
   }
 
   def write(geom: Geometry, srid: Int = 0): Array[Byte] = {

--- a/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
@@ -16,7 +16,6 @@
 
 package geotrellis.vector.io.wkt
 
-import scala.reflect.ClassTag
 import com.vividsolutions.jts.io.{WKTReader, WKTWriter}
 import com.vividsolutions.jts.{geom => jts}
 import geotrellis.vector._
@@ -28,9 +27,9 @@ object WKT {
   private val readerBox = new ThreadLocal[WKTReader]
   private val writerBox = new ThreadLocal[WKTWriter]
 
-  def read[G <: Geometry](value: String): G = {
+  def read(value: String): Geometry = {
     if (readerBox.get == null) readerBox.set(new WKTReader(GeomFactory.factory))
-    Geometry(readerBox.get.read(value)).asInstanceOf[G]
+    Geometry(readerBox.get.read(value))
   }
 
   def write(geom: Geometry): String = {

--- a/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.vector.io.wkt
 
+import scala.reflect.ClassTag
 import com.vividsolutions.jts.io.{WKTReader, WKTWriter}
 import com.vividsolutions.jts.{geom => jts}
 import geotrellis.vector._
@@ -27,7 +28,7 @@ object WKT {
   private val readerBox = new ThreadLocal[WKTReader]
   private val writerBox = new ThreadLocal[WKTWriter]
 
-  def read[G <: Geometry](value: String): G = {
+  def read[G <: Geometry : ClassTag](value: String): G = {
     if (readerBox.get == null) readerBox.set(new WKTReader(GeomFactory.factory))
     Geometry[G](readerBox.get.read(value))
   }

--- a/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
@@ -28,9 +28,9 @@ object WKT {
   private val readerBox = new ThreadLocal[WKTReader]
   private val writerBox = new ThreadLocal[WKTWriter]
 
-  def read[G <: Geometry : ClassTag](value: String): G = {
+  def read[G <: Geometry](value: String): G = {
     if (readerBox.get == null) readerBox.set(new WKTReader(GeomFactory.factory))
-    Geometry[G](readerBox.get.read(value))
+    Geometry(readerBox.get.read(value)).asInstanceOf[G]
   }
 
   def write(geom: Geometry): String = {

--- a/vector/src/main/scala/geotrellis/vector/io/WKT/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKT/package.scala
@@ -4,12 +4,12 @@ import geotrellis.vector._
 
 package object wkt {
   implicit class WktWrapper(val g: Geometry) {
-    def toWKT(): String =
+    def toWKT: String =
       WKT.write(g)
   }
 
   implicit class WktStringWrapper(val s: String) {
-    def parseWKT[G <: Geometry](): G =
+    def parseWKT(): Geometry =
       WKT.read(s)
   }
 }


### PR DESCRIPTION
Geometry#apply includes an unsafe cast for convenience when converting general JTS Geometry instances into geotrellis.vector.Geometry.  However because the cast is done with type parameter instead of a concrete class, no check is actually performed in the apply method, and in the event of a programmer error the runtime exception may happen far from the call.  With this PR, Geometry.apply would perform the check before the converted object is returned, throwing an exception on failure.