### PR TITLE
Remove 'Extent' from the Geometry type hierarchy

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/Raster.scala
+++ b/raster/src/main/scala/geotrellis/raster/Raster.scala
@@ -6,8 +6,8 @@ import geotrellis.vector._
 import geotrellis.proj4.CRS
 
 object Raster {
-  def apply[T <: CellGrid](feature: Feature[Extent, T]): Raster[T] =
-    Raster(feature.data, feature.geom)
+  def apply[T <: CellGrid](feature: PolygonFeature[T]): Raster[T] =
+    Raster(feature.data, feature.geom.envelope)
 
   implicit def tupToRaster(tup: (Tile, Extent)): Raster[Tile] =
     Raster(tup._1, tup._2)
@@ -18,10 +18,10 @@ object Raster {
   implicit def rasterToTile[T <: CellGrid](r: Raster[T]): T =
     r.tile
 
-  implicit def rasterToFeature[T <: CellGrid](r: Raster[T]): Feature[Extent, T] =
+  implicit def rasterToFeature[T <: CellGrid](r: Raster[T]): PolygonFeature[T] =
     r.asFeature
 
-  implicit def featureToRaster[T <: CellGrid](feature: Feature[Extent, T]): Raster[T] =
+  implicit def featureToRaster[T <: CellGrid](feature: PolygonFeature[T]): Raster[T] =
      apply(feature)
 }
 
@@ -33,7 +33,7 @@ case class Raster[+T <: CellGrid](tile: T, extent: Extent) extends Product2[T, E
   def rows: Int = tile.rows
   def dimensions: (Int, Int) = tile.dimensions
 
-  def asFeature(): Feature[Extent, T] = ExtentFeature(extent, tile: T)
+  def asFeature(): PolygonFeature[T] = PolygonFeature(extent.toPolygon, tile: T)
 
   def _1: T = tile
 

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/summary/TileIntersection.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/summary/TileIntersection.scala
@@ -4,9 +4,9 @@ import geotrellis.raster._
 import geotrellis.vector._
 import geotrellis.vector.op._
 
-trait TileIntersectionHandler[T] extends ZonalSummaryHandler[Extent, Tile, T] {
-  def handleContains(feature: Feature[Extent, Tile]): T = handleFullTile(feature.data)
-  def handleIntersection(polygon: Polygon, feature: Feature[Extent, Tile]) = handlePartialTile(feature, polygon)
+trait TileIntersectionHandler[T] extends ZonalSummaryHandler[Polygon, Tile, T] {
+  def handleContains(feature: PolygonFeature[Tile]): T = handleFullTile(feature.data)
+  def handleIntersection(polygon: Polygon, feature: PolygonFeature[Tile]) = handlePartialTile(feature, polygon)
 
   def handlePartialTile(raster: Raster[Tile], intersection: Polygon): T
   def handleFullTile(tile: Tile): T

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/summary/FeatureRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/summary/FeatureRDDSpec.scala
@@ -22,9 +22,9 @@ class FeatureRDDSpec extends FunSpec
 
       val polygon = Polygon( (2, 2), (4, 6), (6, 2), (2, 2) )
 
-      val featureRdd = sc.parallelize(Array(lowerExtent, middleExtent, upperExtent).map { e => Feature(e, e.area) })
+      val featureRdd = sc.parallelize(Array(lowerExtent, middleExtent, upperExtent).map { e => Feature(e.toPolygon, e.area) })
       val result = featureRdd.zonalSummary(polygon, 0.0)(
-        ZonalSummaryHandler({ feature: Feature[Extent, Double] => feature.data })
+        ZonalSummaryHandler({ feature: Feature[Polygon, Double] => feature.data })
                            ({ (polygon, feature) => polygon.intersection(feature.geom).asMultiPolygon.map(_.area).getOrElse(0.0) })
                            ({ (v1, v2) => v1 + v2 })
       )

--- a/vector-test/src/test/scala/spec/geotrellis/vector/io/json/GeoJsonSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/io/json/GeoJsonSpec.scala
@@ -225,16 +225,6 @@ class GeoJsonSpec extends FlatSpec with Matchers {
     }
   }
 
-  it should "create a geometry collection with a polygon and extent" in {
-    val extent = Extent(0.0, 0.0, 1.0, 2.0)
-    val p = Polygon((10.0, 10.0), (10.0, 20.0), (30.0, 30.0), (10.0, 10.0))
-
-    val geoJson = Seq(extent, p).toGeoJson
-    val gc = geoJson.parseGeoJson[GeometryCollection]
-    gc.polygons.size should be (2)
-    gc.polygons.toSet should be (Set(extent.toPolygon, p))
-  }
-
   it should "create a feature collection out of a set of features" in {
     val f1 = Feature(Polygon((10.0, 10.0), (10.0, 20.0), (30.0, 30.0), (10.0, 10.0)), JsObject("value" -> JsNumber(1)))
     val f2 = Feature(Polygon((-10.0, -10.0), (-10.0, -20.0), (-30.0, -30.0), (-10.0, -10.0)), JsObject("value" -> JsNumber(2)))

--- a/vector/src/main/scala/geotrellis/vector/Extent.scala
+++ b/vector/src/main/scala/geotrellis/vector/Extent.scala
@@ -41,7 +41,7 @@ object ProjectedExtent {
  * An Extent represents a rectangular region of geographic space (with a
  * particular projection). It is expressed in map coordinates.
  */
-case class Extent(xmin: Double, ymin: Double, xmax: Double, ymax: Double) extends Geometry {
+case class Extent(xmin: Double, ymin: Double, xmax: Double, ymax: Double) {
 
   // Validation: Do not accept extents min values greater than max values.
   if (xmin > xmax) { throw ExtentRangeError(s"Invalid Extent: xmin must be less than xmax (xmin=$xmin, xmax=$xmax)")  }
@@ -60,11 +60,6 @@ case class Extent(xmin: Double, ymin: Double, xmax: Double, ymax: Double) extend
       ),
       null
     )
-
-  override def isValid: Boolean = true
-  override def centroid: PointOrNoResult = PointResult(center)
-  override def envelope: Extent = this
-  override def interiorPoint: PointOrNoResult = PointResult(center)
 
   val width = xmax - xmin
   val height = ymax - ymin

--- a/vector/src/main/scala/geotrellis/vector/Feature.scala
+++ b/vector/src/main/scala/geotrellis/vector/Feature.scala
@@ -52,14 +52,6 @@ object PolygonFeature {
     Some(feature.geom -> feature.data)
 }
 
-// object ExtentFeature {
-//   def apply[D](geom: Extent, data: D): Feature[Extent, D] =
-//     Feature(geom, data)
-// 
-//   def unapply[D](feature: Feature[Extent, D]) =
-//     Some(feature.geom -> feature.data)
-// }
-
 object MultiPointFeature {
   def apply[D](geom: MultiPoint, data: D): Feature[MultiPoint, D] =
     Feature(geom, data)

--- a/vector/src/main/scala/geotrellis/vector/Feature.scala
+++ b/vector/src/main/scala/geotrellis/vector/Feature.scala
@@ -52,13 +52,13 @@ object PolygonFeature {
     Some(feature.geom -> feature.data)
 }
 
-object ExtentFeature {
-  def apply[D](geom: Extent, data: D): Feature[Extent, D] =
-    Feature(geom, data)
-
-  def unapply[D](feature: Feature[Extent, D]) =
-    Some(feature.geom -> feature.data)
-}
+// object ExtentFeature {
+//   def apply[D](geom: Extent, data: D): Feature[Extent, D] =
+//     Feature(geom, data)
+// 
+//   def unapply[D](feature: Feature[Extent, D]) =
+//     Some(feature.geom -> feature.data)
+// }
 
 object MultiPointFeature {
   def apply[D](geom: MultiPoint, data: D): Feature[MultiPoint, D] =

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -26,7 +26,6 @@ package object vector extends SeqMethods {
   type PointFeature[D] = Feature[Point, D]
   type LineFeature[D] = Feature[Line, D]
   type PolygonFeature[D] = Feature[Polygon, D]
-  // type ExtentFeature[D] = Feature[Extent, D]
   type MultiPointFeature[D] = Feature[MultiPoint, D]
   type MultiLineFeature[D] = Feature[MultiLine, D]
   type MultiPolygonFeature[D] = Feature[MultiPolygon, D]

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -26,12 +26,11 @@ package object vector extends SeqMethods {
   type PointFeature[D] = Feature[Point, D]
   type LineFeature[D] = Feature[Line, D]
   type PolygonFeature[D] = Feature[Polygon, D]
-  type ExtentFeature[D] = Feature[Extent, D]
+  // type ExtentFeature[D] = Feature[Extent, D]
   type MultiPointFeature[D] = Feature[MultiPoint, D]
   type MultiLineFeature[D] = Feature[MultiLine, D]
   type MultiPolygonFeature[D] = Feature[MultiPolygon, D]
   type GeometryCollectionFeature[D] = Feature[GeometryCollection, D]
-
 
   implicit def tupleOfIntToPoint(t: (Double, Double)): Point =
     Point(t._1,t._2)

--- a/vector/src/main/scala/geotrellis/vector/reproject/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/reproject/package.scala
@@ -53,11 +53,11 @@ package object reproject {
     def polygonFeature[D](pf: PolygonFeature[D], transform: Transform): PolygonFeature[D] =
       PolygonFeature(apply(pf.geom, transform), pf.data)
 
-    def extentFeature[D](ef: ExtentFeature[D], src: CRS, dest: CRS): ExtentFeature[D] =
-      ExtentFeature(apply(ef.geom, src, dest).envelope, ef.data)
+    // def extentFeature[D](ef: ExtentFeature[D], src: CRS, dest: CRS): ExtentFeature[D] =
+    //   ExtentFeature(apply(ef.geom, src, dest).envelope, ef.data)
 
-    def extentFeature[D](ef: ExtentFeature[D], transform: Transform): ExtentFeature[D] =
-      ExtentFeature(apply(ef.geom, transform).envelope, ef.data)
+    // def extentFeature[D](ef: ExtentFeature[D], transform: Transform): ExtentFeature[D] =
+    //   ExtentFeature(apply(ef.geom, transform).envelope, ef.data)
 
     def apply(mp: MultiPoint, src: CRS, dest: CRS): MultiPoint =
       apply(mp, Transform(src, dest))
@@ -147,7 +147,7 @@ package object reproject {
         case p: Point => pointFeature(Feature(p, f.data), transform)
         case l: Line => lineFeature(Feature(l, f.data), transform)
         case p: Polygon => polygonFeature(Feature(p, f.data), transform)
-        case e: Extent => extentFeature(Feature(e, f.data), transform)
+        // case e: Extent => extentFeature(Feature(e, f.data), transform)
         case mp: MultiPoint => multiPointFeature(Feature(mp, f.data), transform)
         case ml: MultiLine => multiLineFeature(Feature(ml, f.data), transform)
         case mp: MultiPolygon => multiPolygonFeature(Feature(mp, f.data), transform)

--- a/vector/src/main/scala/geotrellis/vector/reproject/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/reproject/package.scala
@@ -53,12 +53,6 @@ package object reproject {
     def polygonFeature[D](pf: PolygonFeature[D], transform: Transform): PolygonFeature[D] =
       PolygonFeature(apply(pf.geom, transform), pf.data)
 
-    // def extentFeature[D](ef: ExtentFeature[D], src: CRS, dest: CRS): ExtentFeature[D] =
-    //   ExtentFeature(apply(ef.geom, src, dest).envelope, ef.data)
-
-    // def extentFeature[D](ef: ExtentFeature[D], transform: Transform): ExtentFeature[D] =
-    //   ExtentFeature(apply(ef.geom, transform).envelope, ef.data)
-
     def apply(mp: MultiPoint, src: CRS, dest: CRS): MultiPoint =
       apply(mp, Transform(src, dest))
 
@@ -147,7 +141,6 @@ package object reproject {
         case p: Point => pointFeature(Feature(p, f.data), transform)
         case l: Line => lineFeature(Feature(l, f.data), transform)
         case p: Polygon => polygonFeature(Feature(p, f.data), transform)
-        // case e: Extent => extentFeature(Feature(e, f.data), transform)
         case mp: MultiPoint => multiPointFeature(Feature(mp, f.data), transform)
         case ml: MultiLine => multiLineFeature(Feature(ml, f.data), transform)
         case mp: MultiPolygon => multiPolygonFeature(Feature(mp, f.data), transform)


### PR DESCRIPTION
This does have an impact throughout the codebase since some parts of the code convert tiles to features and back.  In this branch I've simply used PolygonFeature for this instead of ExtentFeature - I could also look into extending Feature to support "geometries" that are not part of the Geometry type hierarchy to avoid converting back-and-forth.