### PR TITLE
Double Histogram

### DIFF
--- a/dev/src/main/scala/geotrellis/dev/RemoteClient.scala
+++ b/dev/src/main/scala/geotrellis/dev/RemoteClient.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -125,11 +125,10 @@ case class HelloWorldOp[String](s:Op[String]) extends Op1(s)({
   }
 })
 
+case class MinFromHistogram(h:Op[Histogram[Int]]) extends Op1(h)({
+  (h) => Result(h.getMinValue)
+})
 
-  case class MinFromHistogram(h:Op[Histogram]) extends Op1(h)({
-    (h) => Result(h.getMinValue)
-  })
-
-  case class FindMin(ints:Op[Seq[Int]]) extends Op1(ints)({
-    (ints) => Result(ints.reduce(math.min(_,_)))
-  })
+case class FindMin(ints:Op[Seq[Int]]) extends Op1(ints)({
+  (ints) => Result(ints.reduce(math.min(_,_)))
+})

--- a/engine-test/src/test/scala/geotrellis/engine/RasterSourceSpec.scala
+++ b/engine-test/src/test/scala/geotrellis/engine/RasterSourceSpec.scala
@@ -171,8 +171,8 @@ class RasterSourceSpec extends FunSpec
       val d = getRasterSource
 
       val hist = d.tileHistograms
-      val hist2:DataSource[Histogram,Histogram] = d.tileHistograms
-      case class MinFromHistogram(h:Op[Histogram]) extends Op1(h)({
+      val hist2:DataSource[Histogram[Int], Histogram[Int]] = d.tileHistograms
+      case class MinFromHistogram(h:Op[Histogram[Int]]) extends Op1(h)({
         (h) => Result(h.getMinValue)
       })
 

--- a/engine-test/src/test/scala/geotrellis/engine/RasterSourceSpec.scala
+++ b/engine-test/src/test/scala/geotrellis/engine/RasterSourceSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,11 +30,11 @@ import geotrellis.raster.io.arg._
 
 import org.scalatest._
 
-class RasterSourceSpec extends FunSpec 
-                          with Matchers 
-                          with TestEngine 
+class RasterSourceSpec extends FunSpec
+                          with Matchers
+                          with TestEngine
                           with TileBuilders {
-  def getRasterSource = 
+  def getRasterSource =
     RasterSource("mtsthelens_tiled_cached")
 
   def getSmallRasterSource =
@@ -59,7 +59,7 @@ class RasterSourceSpec extends FunSpec
           .rasterExtent
           .get
 
-      val newRe = 
+      val newRe =
         RasterExtent(
           Extent(xmin,ymax-(ch*256),xmin+(cw*256),ymax),
           cw,ch,256,256)
@@ -85,7 +85,7 @@ class RasterSourceSpec extends FunSpec
     }
 
     it("should read from metadata and match an arg reader with a target RasterExtent") {
-      val RasterExtent(Extent(xmin, ymin, xmax, ymax), cw, ch, cols, rows) = 
+      val RasterExtent(Extent(xmin, ymin, xmax, ymax), cw, ch, cols, rows) =
         RasterSource("SBN_inc_percap").rasterExtent.get
       val qw = (xmax - xmin) / 4
       val qh = (ymax - ymin) / 4
@@ -103,7 +103,7 @@ class RasterSourceSpec extends FunSpec
           .rasterExtent
           .get
 
-      val combinedExtent = 
+      val combinedExtent =
         RasterSource("mtsthelens_tiled")
           .mapWithExtent { (tile, extent) =>
             extent
@@ -134,7 +134,7 @@ class RasterSourceSpec extends FunSpec
     }
 
     it("should converge a tiled raster") {
-      val s = 
+      val s =
         RasterSource("mtsthelens_tiled_cached")
           .renderPng
 
@@ -142,14 +142,14 @@ class RasterSourceSpec extends FunSpec
 
     }
 
-    it("should return a RasterSource when possible") { 
+    it("should return a RasterSource when possible") {
       val d1 = getRasterSource
 
       val d2:RasterSource = d1.localAdd(3)
       val d3:RasterSource  = d2 mapTile(local.Add(_, 3))
       val d4:RasterSource = d3 mapTile(r => r.map(z => z + 3))
       val d5:DataSource[Int,Seq[Int]] = d3 map(r => r.findMinMax._2)
-      
+
       val result1 = get(d1)
       val result2 = get(d2)
       val result3 = get(d3)
@@ -181,7 +181,7 @@ class RasterSourceSpec extends FunSpec
       })
 
       val ints:DataSource[Int,Seq[Int]] = hist.mapOp(MinFromHistogram(_))
-     
+
       val seqIntVS:ValueSource[Seq[Int]] = ints.converge
 
       val intVS:ValueSource[Int] = seqIntVS.map( seqInt => seqInt.reduce(math.min(_,_)))
@@ -197,7 +197,7 @@ class RasterSourceSpec extends FunSpec
       histogramResult.getMaxValue should be (8367)
       intsResult.length should be (12)
       intResult should be (directIntResult)
-      
+
     }
 
     it("should handle combine") {

--- a/engine-test/src/test/scala/geotrellis/engine/SerializationTest.scala
+++ b/engine-test/src/test/scala/geotrellis/engine/SerializationTest.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,9 +28,9 @@ import org.scalatest._
 
 import java.io._
 
-class SerializationTest extends FunSuite 
-                        with Matchers 
-                        with TileBuilders 
+class SerializationTest extends FunSuite
+                        with Matchers
+                        with TileBuilders
                         with TestEngine {
 
   // Operations and data objects that may be sent remotely must be serializable.
@@ -53,5 +53,5 @@ class SerializationTest extends FunSuite
   def pickle(o:AnyRef) = {
     val stream = new ObjectOutputStream(new ByteArrayOutputStream())
     stream.writeObject(o)
-  } 
+  }
 }

--- a/engine-test/src/test/scala/geotrellis/engine/SerializationTest.scala
+++ b/engine-test/src/test/scala/geotrellis/engine/SerializationTest.scala
@@ -41,7 +41,7 @@ class SerializationTest extends FunSuite
     pickle(addOp)
     pickle(local.Add(addOp, 2))
     pickle(FastMapHistogram())
-    pickle(Statistics(0,0,0,0,0,0))
+    pickle(Statistics[Int](0,0,0,0,0,0,0))
     pickle(Point(0,0))
     pickle(Polygon( Line(Point(1,9) :: Point(1,6) :: Point(4,6) :: Point(4,9) :: Point(1,9) :: Nil)))
   }

--- a/engine-test/src/test/scala/geotrellis/engine/op/zonal/ZonalHistogramSpec.scala
+++ b/engine-test/src/test/scala/geotrellis/engine/op/zonal/ZonalHistogramSpec.scala
@@ -84,7 +84,7 @@ class ZonalHistogramSpec extends FunSpec
               .toMap
         }
 
-      val result: Map[Int, Histogram] = rs.zonalHistogram(zonesSource).get
+      val result: Map[Int, Histogram[Int]] = rs.zonalHistogram(zonesSource).get
 
       result.keys should be (expected.keys)
 

--- a/engine-test/src/test/scala/geotrellis/engine/op/zonal/ZonalHistogramSpec.scala
+++ b/engine-test/src/test/scala/geotrellis/engine/op/zonal/ZonalHistogramSpec.scala
@@ -84,7 +84,7 @@ class ZonalHistogramSpec extends FunSpec
               .toMap
         }
 
-      val result: Map[Int, Histogram[Int]] = rs.zonalHistogram(zonesSource).get
+      val result: Map[Int, Histogram[Int]] = rs.zonalHistogramInt(zonesSource).get
 
       result.keys should be (expected.keys)
 

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/ZonalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/ZonalRasterSourceMethods.scala
@@ -33,7 +33,7 @@ trait ZonalRasterSourceMethods extends RasterSourceMethods {
    *          If you use a Raster with a Double CellType (TypeFloat, TypeDouble)
    *          the data values will be rounded to integers.
    */
-  def zonalHistogram(zonesSource: RasterSource): ValueSource[Map[Int, Histogram]] =
+  def zonalHistogram(zonesSource: RasterSource): ValueSource[Map[Int, Histogram[Int]]] =
     ValueSource(
       (rasterSource.convergeOp, zonesSource.convergeOp).map { (tile, zones) =>
         ZonalHistogram(tile, zones)

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/ZonalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/ZonalRasterSourceMethods.scala
@@ -29,17 +29,28 @@ trait ZonalRasterSourceMethods extends RasterSourceMethods {
   /**
    * Given a raster, return a histogram summary of the cells within each zone.
    *
-   * @note    zonalHistogram does not currently support Double raster data.
+   * @note    zonalHistogramInt does not support Double raster data.
    *          If you use a Raster with a Double CellType (TypeFloat, TypeDouble)
    *          the data values will be rounded to integers.
    */
-  def zonalHistogram(zonesSource: RasterSource): ValueSource[Map[Int, Histogram[Int]]] =
+  def zonalHistogramInt(zonesSource: RasterSource): ValueSource[Map[Int, Histogram[Int]]] = {
     ValueSource(
       (rasterSource.convergeOp, zonesSource.convergeOp).map { (tile, zones) =>
-        ZonalHistogram(tile, zones)
+        ZonalHistogramInt(tile, zones)
       }
     )
+  }
 
+  /**
+   * Given a raster, return a histogram summary of the cells within each zone.
+   */
+  def zonalHistogramDouble(zonesSource: RasterSource): ValueSource[Map[Int, Histogram[Double]]] = {
+    ValueSource(
+      (rasterSource.convergeOp, zonesSource.convergeOp).map { (tile, zones) =>
+        ZonalHistogramDouble(tile, zones)
+      }
+    )
+  }
 
   /**
    * Given a raster and a raster representing it's zones, sets all pixels

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/package.scala
@@ -3,6 +3,6 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object zonal {
-  implicit class ZonalRasterSourceMethodExtensions(val rasterSource: RasterSource) 
+  implicit class ZonalRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends ZonalRasterSourceMethods { }
 }

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/summary/ZonalSummaryRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/summary/ZonalSummaryRasterSourceMethods.scala
@@ -99,10 +99,10 @@ trait ZonalSummaryRasterSourceMethods extends RasterSourceMethods {
     mapIntersecting(p, cachedResult)(handler)
       .converge(handler.combineResults)
 
-  def zonalHistogram(p: Polygon): ValueSource[Histogram] =
+  def zonalHistogram(p: Polygon): ValueSource[Histogram[Int]] =
     zonalSummary(Histogram, p, None)
 
-  def zonalHistogram(p: Polygon, cached: DataSource[Histogram, _]): ValueSource[Histogram] =
+  def zonalHistogram(p: Polygon, cached: DataSource[Histogram[Int], _]): ValueSource[Histogram[Int]] =
     zonalSummary(Histogram, p, Some(cached))
 
   def zonalSum(p: Polygon): ValueSource[Long] =

--- a/engine/src/main/scala/geotrellis/engine/stats/StatsRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/stats/StatsRasterSourceMethods.scala
@@ -30,7 +30,7 @@ trait StatsRasterSourceMethods extends RasterSourceMethods {
   def histogram(): ValueSource[Histogram[Int]] =
     rasterSource map(_.histogram) converge(convergeHistograms)
 
-  def statistics(): ValueSource[Statistics] =
+  def statistics(): ValueSource[Statistics[Int]] =
     histogram map (_.generateStatistics())
 
   def classBreaks(numBreaks: Int): ValueSource[Array[Int]] =

--- a/engine/src/main/scala/geotrellis/engine/stats/StatsRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/stats/StatsRasterSourceMethods.scala
@@ -22,12 +22,12 @@ import geotrellis.raster.histogram._
 import geotrellis.raster.op.stats._
 
 trait StatsRasterSourceMethods extends RasterSourceMethods {
-  private def convergeHistograms(histograms: Seq[Histogram]): Histogram = FastMapHistogram.fromHistograms(histograms)
+  private def convergeHistograms(histograms: Seq[Histogram[Int]]): Histogram[Int] = FastMapHistogram.fromHistograms(histograms)
 
-  def tileHistograms(): DataSource[Histogram, Histogram] =
+  def tileHistograms(): DataSource[Histogram[Int], Histogram[Int]] =
     rasterSource map (_.histogram) withConverge(convergeHistograms)
 
-  def histogram(): ValueSource[Histogram] =
+  def histogram(): ValueSource[Histogram[Int]] =
     rasterSource map(_.histogram) converge(convergeHistograms)
 
   def statistics(): ValueSource[Statistics] =

--- a/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.histogram
+
+import geotrellis.raster._
+
+import org.scalatest._
+import math.abs
+import scala.util.Random
+
+class StreamingHistogramSpec extends FunSpec with Matchers {
+  val r = Random
+  val list1 = List(1,2,3,3,4,5,6,6,6,7,8,9,9,9,9,10,11,12,12,13,14,14,15,16,17,17,18,19)
+  val list2 = List(1, 32, 243, 243, 1024, 3125, 7776, 7776, 7776, 16807, 32768, 59049, 59049, 59049)
+  val list3 = List(1, 32, 243, 243, 1024, 1024, 7776, 7776, 7776, 16807, 32768, 59049, 59049,
+    59049, 59049, 100000, 161051, 248832, 248832, 371293, 537824, 537824, 759375, 1048576,
+    1419857, 1419857, 1889568, 2476099, 2147483647)
+
+  describe("mode calculation") {
+    it("should return NODATA if no items are counted") {
+      val h = StreamingHistogram()
+      h.getMode.isNaN should equal (true)
+    }
+
+    it("should return the same result for getMode and generateStatistics.mode") {
+      val h = StreamingHistogram()
+
+      list3.foreach({i => h.countItem(i) })
+
+      val mode = h.getMode()
+      mode should equal (59049)
+      mode should equal (h.generateStatistics.mode)
+    }
+
+    it(".getMode and .generateStatistics.mode should agree on a mode of a unique list") {
+      val h = StreamingHistogram()
+      val list = List(9, 8, 7, 6, 5, 4, 3, 2, -10)
+      for(i <- list) {
+        h.countItem(i)
+      }
+
+      val mode = h.getMode()
+      mode should equal (h.generateStatistics.mode)
+    }
+  }
+
+  describe("median calculations") {
+    it("should return the same result for getMedian and generateStatistics.median") {
+      val h = StreamingHistogram()
+
+      list1.foreach({ i => h.countItem(i) })
+
+      h.getMedian should equal (8.75)
+      h.getMedian should equal (h.generateStatistics.median)
+    }
+
+    it("getMedian should work when n is large with repeated elements") {
+      val h = StreamingHistogram()
+
+      Iterator.continually(list1)
+        .flatten.take(list1.length * 10000)
+        .foreach({ i => h.countItem(i) })
+
+      h.getMedian should equal (8.75)
+      h.getMedian should equal (h.generateStatistics.median)
+    }
+
+    it("getMedian should work when n is large with unique elements") {
+      val h = StreamingHistogram()
+
+      Iterator.continually(list1)
+        .flatten.take(list1.length * 10000)
+        .foreach({ i => h.countItem(i + r.nextDouble / 1000.0) })
+
+      h.getMedian.toInt should equal (9)
+      h.getMedian should equal (h.generateStatistics.median)
+    }
+  }
+
+  describe("mean calculation") {
+    it("should return the same result for getMean and generateStatistics.mean") {
+      val h = StreamingHistogram()
+
+      list2.foreach({ i => h.countItem(i) })
+
+      val mean = h.getMean()
+      println(s"$mean")
+      abs(mean - 18194.14285714286) should be < 1e-7
+      mean should equal (h.generateStatistics.mean)
+    }
+
+    it("getMean should work when n is large with repeated elements") {
+      val h = StreamingHistogram()
+
+      Iterator.continually(list2)
+        .flatten.take(list2.length * 10000)
+        .foreach({ i => h.countItem(i) })
+
+      val mean = h.getMean()
+      abs(mean - 18194.14285714286) should be < 1e-7
+      mean should equal (h.generateStatistics.mean)
+    }
+
+    it("getMean should work when n is large with unique elements") {
+      val h = StreamingHistogram()
+
+      Iterator.continually(list2)
+        .flatten.take(list2.length * 10000)
+        .foreach({ i => h.countItem(i + r.nextDouble / 100000.0) })
+
+      val mean = h.getMean()
+      abs(mean - 18194.14285714286) should be < 1e-5
+      mean should equal (h.generateStatistics.mean)
+    }
+  }
+
+}

--- a/raster-test/src/test/scala/geotrellis/raster/op/focal/TileWithNeighborsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/op/focal/TileWithNeighborsSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,7 @@ class TileWithNeighborsSpec extends FunSpec with TileBuilders
              }
             .collect
         )
-        .map { case (r,neighbors) => 
+        .map { case (r,neighbors) =>
             val twn = TileWithNeighbors(r,neighbors)
             (r,neighbors,twn._1,twn._2)
         }
@@ -64,7 +64,7 @@ class TileWithNeighborsSpec extends FunSpec with TileBuilders
               assertEqual(tiledRaster,
                 Array( 1,1,1,  2,2,2,
                        1,1,1,  2,2,2,
-                       
+
                        4,4,4,  5,5,5,
                        4,4,4,  5,5,5)
               )
@@ -75,7 +75,7 @@ class TileWithNeighborsSpec extends FunSpec with TileBuilders
               assertEqual(tiledRaster,
                 Array( 1,1,1,  2,2,2,  3,3,3,
                        1,1,1,  2,2,2,  3,3,3,
-                       
+
                        4,4,4,  5,5,5,  6,6,6,
                        4,4,4,  5,5,5,  6,6,6)
               )
@@ -86,7 +86,7 @@ class TileWithNeighborsSpec extends FunSpec with TileBuilders
               assertEqual(tiledRaster,
                 Array( 2,2,2,  3,3,3,
                        2,2,2,  3,3,3,
-                       
+
                        5,5,5,  6,6,6,
                        5,5,5,  6,6,6)
               )
@@ -97,7 +97,7 @@ class TileWithNeighborsSpec extends FunSpec with TileBuilders
               assertEqual(tiledRaster,
                 Array( 1,1,1,  2,2,2,
                        1,1,1,  2,2,2,
-                       
+
                        4,4,4,  5,5,5,
                        4,4,4,  5,5,5,
 
@@ -112,7 +112,7 @@ class TileWithNeighborsSpec extends FunSpec with TileBuilders
               assertEqual(tiledRaster,
                 Array( 1,1,1,  2,2,2,  3,3,3,
                        1,1,1,  2,2,2,  3,3,3,
-                       
+
                        4,4,4,  5,5,5,  6,6,6,
                        4,4,4,  5,5,5,  6,6,6,
 
@@ -127,7 +127,7 @@ class TileWithNeighborsSpec extends FunSpec with TileBuilders
               assertEqual(tiledRaster,
                 Array( 2,2,2,  3,3,3,
                        2,2,2,  3,3,3,
-                       
+
                        5,5,5,  6,6,6,
                        5,5,5,  6,6,6,
 
@@ -226,7 +226,7 @@ class TileWithNeighborsSpec extends FunSpec with TileBuilders
 
     it("should tile correctly for an untiled raster") {
       val r = IntConstantTile(1, 4, 4)
-      val (tiled,analysisArea) = 
+      val (tiled,analysisArea) =
         TileWithNeighbors(r,Seq[Option[Tile]]())
       analysisArea should be (GridBounds(0,0,3,3))
       assertEqual(r,tiled)

--- a/raster-test/src/test/scala/geotrellis/raster/op/stats/StatsMethodsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/op/stats/StatsMethodsSpec.scala
@@ -39,7 +39,7 @@ class StatsMethodsSpec extends FunSpec
       val stats = RasterSource.fromPath("raster-test/data/quad8.arg").get.statistics
 
       val dev = math.sqrt((2 * (0.5 * 0.5) + 2 * (1.5 * 1.5)) / 4)
-      val expected = Statistics(400, 2.5, 3, 1, dev, 1, 4)
+      val expected = Statistics[Int](400, 2.5, 3, 1, dev, 1, 4)
 
       stats should be (expected)
     }

--- a/raster-test/src/test/scala/geotrellis/raster/op/zonal/ZonalHistogramSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/op/zonal/ZonalHistogramSpec.scala
@@ -82,7 +82,7 @@ class ZonalHistogramSpec extends FunSpec
 
 
     it("gives correct histogram map for example raster") {
-      val histograms = r.zonalHistogram(zones)
+      val histograms = r.zonalHistogramInt(zones)
       histograms.keys should be (expected.keys)
 
       for(zone <- histograms.keys) {

--- a/raster-test/src/test/scala/geotrellis/raster/op/zonal/ZonalStatisticsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/op/zonal/ZonalStatisticsSpec.scala
@@ -75,7 +75,7 @@ class ZonalStatisticsSpec extends FunSpec
     it("gives correct Statistics values") {
       stats(1).mean should be (1)
       stats(3).mean should be (3)
-      stats(1) should be (Statistics(4, 1.0, 1, 1, 0.0, 1, 1))
+      stats(1) should be (Statistics[Int](4, 1.0, 1, 1, 0.0, 1, 1))
     }
   }
 }

--- a/raster-test/src/test/scala/geotrellis/raster/op/zonal/ZonalStatisticsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/op/zonal/ZonalStatisticsSpec.scala
@@ -63,7 +63,7 @@ class ZonalStatisticsSpec extends FunSpec
             .toMap
       }
 
-    val stats = r.zonalStatistics(zones)
+    val stats = r.zonalStatisticsInt(zones)
 
     it("gives correct Statistics for example raster") {
       stats.keys should be (expected.keys)

--- a/raster/src/main/scala/geotrellis/raster/histogram/ArrayHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/ArrayHistogram.scala
@@ -43,7 +43,7 @@ object ArrayHistogram {
   * Data object representing a histogram that uses an array for internal storage.
   */
 class ArrayHistogram(val counts: Array[Int], var total: Int)
-    extends MutableHistogram {
+    extends MutableHistogramInt {
   def size = counts.length
 
   def getTotalCount = total

--- a/raster/src/main/scala/geotrellis/raster/histogram/ArrayHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/ArrayHistogram.scala
@@ -30,7 +30,7 @@ object ArrayHistogram {
     h
   }
 
-  def fromHistograms(hs: List[Histogram], n: Int): ArrayHistogram = {
+  def fromHistograms(hs: List[Histogram[Int]], n: Int): ArrayHistogram = {
     val total = ArrayHistogram(n)
     hs.foreach(h => total.update(h))
     total

--- a/raster/src/main/scala/geotrellis/raster/histogram/ConstantHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/ConstantHistogram.scala
@@ -27,7 +27,7 @@ case class ConstantHistogram(value:Int,size:Int) extends HistogramInt {
   def getValues():Array[Int] = Array(value)
   def rawValues():Array[Int] = Array(value)
   def getQuantileBreaks(num:Int):Array[Int] = Array(value)
-  def mutable():MutableHistogram = {
+  def mutable():MutableHistogramInt = {
     val fmh = FastMapHistogram(size)
     fmh.setItem(value,size)
     fmh

--- a/raster/src/main/scala/geotrellis/raster/histogram/ConstantHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/ConstantHistogram.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.raster.histogram
 
-case class ConstantHistogram(value:Int,size:Int) extends Histogram {
+case class ConstantHistogram(value:Int,size:Int) extends HistogramInt {
   def copy = ConstantHistogram(value,size)
 
   def foreachValue(f:Int=>Unit) = f(value)

--- a/raster/src/main/scala/geotrellis/raster/histogram/FastMapHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/FastMapHistogram.scala
@@ -37,7 +37,7 @@ object FastMapHistogram {
     h
   }
 
-  def fromHistograms(hs: TraversableOnce[Histogram]): FastMapHistogram = {
+  def fromHistograms(hs: TraversableOnce[Histogram[Int]]): FastMapHistogram = {
     val total = FastMapHistogram()
     hs.foreach(h => total.update(h))
     total

--- a/raster/src/main/scala/geotrellis/raster/histogram/FastMapHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/FastMapHistogram.scala
@@ -65,7 +65,7 @@ object FastMapHistogram {
 }
 
 class FastMapHistogram(_size: Int, _buckets: Array[Int], _used: Int, _total: Int)
-    extends MutableHistogram {
+    extends MutableHistogramInt {
   if (_size <= 0) error("initializeSize must be > 0")
 
   // we are reserving this value

--- a/raster/src/main/scala/geotrellis/raster/histogram/Histogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/Histogram.scala
@@ -53,7 +53,7 @@ abstract trait Histogram[T] extends Serializable {
   /**
    * Return a mutable copy of this histogram.
    */
-  def mutable(): MutableHistogram
+  def mutable(): MutableHistogram[T]
 
   def getValues(): Array[T]
 

--- a/raster/src/main/scala/geotrellis/raster/histogram/Histogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/Histogram.scala
@@ -25,7 +25,7 @@ import spire.syntax.cfor._
 /**
   * Data object representing a histogram of values.
   */
-abstract trait Histogram[T] extends Serializable {
+abstract trait Histogram[@specialized (Int, Double) T] extends Serializable {
   /**
    * Return the number of occurances for 'item'.
    */

--- a/raster/src/main/scala/geotrellis/raster/histogram/Histogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/Histogram.scala
@@ -25,7 +25,7 @@ import spire.syntax.cfor._
 /**
   * Data object representing a histogram of values.
   */
-abstract trait Histogram[@specialized (Int, Double) T] extends Serializable {
+abstract trait Histogram[@specialized (Int, Double) T <: AnyVal] extends Serializable {
   /**
    * Return the number of occurances for 'item'.
    */

--- a/raster/src/main/scala/geotrellis/raster/histogram/MapHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/MapHistogram.scala
@@ -32,7 +32,7 @@ object MapHistogram {
   * Data object representing a histogram that uses a Map (as in hashtable map/dictionary) for internal storage.
   *
   */
-class MapHistogram(counts: Map[Int, Int], var total: Int) extends MutableHistogram {
+class MapHistogram(counts: Map[Int, Int], var total: Int) extends MutableHistogramInt {
   def getTotalCount = this.total
 
   def mutable() = MapHistogram(this.counts.clone, this.total)

--- a/raster/src/main/scala/geotrellis/raster/histogram/MutableHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/MutableHistogram.scala
@@ -33,9 +33,7 @@ abstract class MutableHistogram[T] extends Histogram[T] {
    */
   def uncountItem(item: T): Unit
 
-  def update(other: Histogram[T]) {
-    other.foreach((z, count) => countItem(z, count))
-  }
+  def update(other: Histogram[T]): Unit
 
   /**
    * Sets the item to the given count.
@@ -49,6 +47,11 @@ abstract class MutableHistogram[T] extends Histogram[T] {
 }
 
 abstract class MutableHistogramInt extends MutableHistogram[Int] with HistogramInt {
+
+  def update(other: Histogram[Int]): Unit = {
+    other.foreach((z, count) => countItem(z, count))
+  }
+
   /**
    * Return 'num' evenly spaced Doubles from 0.0 to 1.0.
    */

--- a/raster/src/main/scala/geotrellis/raster/histogram/MutableHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/MutableHistogram.scala
@@ -18,7 +18,7 @@ package geotrellis.raster.histogram
 
 import math.{abs, round, sqrt}
 
-abstract class MutableHistogram[T] extends Histogram[T] {
+abstract class MutableHistogram[@specialized (Int, Double) T] extends Histogram[T] {
   /**
    * Note the occurance of 'item'.
    *
@@ -27,6 +27,8 @@ abstract class MutableHistogram[T] extends Histogram[T] {
    * of occurances of 'item'.
    */
   def countItem(item: T, count: Int = 1): Unit
+
+  def countItemInt(item: Int, count: Int = 1): Unit
 
   /**
    * Forget all occurances of 'item'.
@@ -47,6 +49,7 @@ abstract class MutableHistogram[T] extends Histogram[T] {
 }
 
 abstract class MutableHistogramInt extends MutableHistogram[Int] with HistogramInt {
+  def countItemInt(item: Int, count: Int = 1): Unit = countItem(item, count)
 
   def update(other: Histogram[Int]): Unit = {
     other.foreach((z, count) => countItem(z, count))

--- a/raster/src/main/scala/geotrellis/raster/histogram/MutableHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/MutableHistogram.scala
@@ -18,7 +18,7 @@ package geotrellis.raster.histogram
 
 import math.{abs, round, sqrt}
 
-abstract class MutableHistogram[@specialized (Int, Double) T] extends Histogram[T] {
+abstract class MutableHistogram[@specialized (Int, Double) T <: AnyVal] extends Histogram[T] {
   /**
    * Note the occurance of 'item'.
    *

--- a/raster/src/main/scala/geotrellis/raster/histogram/MutableHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/MutableHistogram.scala
@@ -18,7 +18,7 @@ package geotrellis.raster.histogram
 
 import math.{abs, round, sqrt}
 
-abstract class MutableHistogram extends Histogram {
+abstract class MutableHistogram extends HistogramInt {
   /**
    * Note the occurance of 'item'.
    *
@@ -33,7 +33,7 @@ abstract class MutableHistogram extends Histogram {
    */
   def uncountItem(item: Int): Unit
 
-  def update(other: Histogram) {
+  def update(other: Histogram[Int]) {
     other.foreach((z, count) => countItem(z, count))
   }
 
@@ -60,7 +60,7 @@ abstract class MutableHistogram extends Histogram {
     // remove extreme values. an extreme value is one that would automatically
     // overflow any bucket it is in (even alone). if size=100, and there are
     // 200 cells with the value "1" then 1 would be an extreme value.
-    val h: Histogram = normalizeExtremeValues(num, size)
+    val h: Histogram[Int] = normalizeExtremeValues(num, size)
 
     // now we'll store some data about the histogram, our quantiles, etc, for
     // future use and fast access.
@@ -129,7 +129,7 @@ abstract class MutableHistogram extends Histogram {
    * This is a heuristic used by getQuantileBreaks, which mutates the
    * histogram.
    */
-  private def normalizeExtremeValues(num: Int, cutoff: Int): Histogram = {
+  private def normalizeExtremeValues(num: Int, cutoff: Int): Histogram[Int] = {
     val (zmin, zmax) = getMinMaxValues()
 
     // see how many (if any) extreme values we have, and store their indices

--- a/raster/src/main/scala/geotrellis/raster/histogram/StreamingHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/StreamingHistogram.scala
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.histogram
+
+import geotrellis.raster._
+import geotrellis.raster.op.stats.Statistics
+
+import java.util.TreeMap
+import java.util.Comparator
+import scala.collection.JavaConverters._
+import StreamingHistogram.{BucketType, DeltaType}
+
+
+object StreamingHistogram {
+  private type BucketType = (Double, Int)
+  private type DeltaType = (Double, BucketType, BucketType)
+
+  def apply(m: Int) = new StreamingHistogram(m, None, None)
+
+  def apply(m: Int, buckets: TreeMap[Double, Int], deltas: TreeMap[DeltaType, Unit]) =
+    new StreamingHistogram(m, Some(buckets), Some(deltas))
+}
+
+/**
+  * Ben-Haim, Yael, and Elad Tom-Tov. "A streaming parallel decision
+  * tree algorithm."  The Journal of Machine Learning Research 11
+  * (2010): 849-872.
+  */
+class StreamingHistogram(
+  m: Int,
+  startingBuckets: Option[TreeMap[Double, Int]],
+  startingDeltas: Option[TreeMap[DeltaType, Unit]]
+) extends MutableHistogram[Double] {
+
+  class DeltaCompare extends Comparator[DeltaType] {
+    def compare(a: DeltaType, b: DeltaType): Int =
+      if (a._1 < b._1) -1
+      else if (a._1 > b._1) 1
+      else {
+        if (a._2._1 < b._2._1) -1
+        else if (a._2._1 > b._2._1) 1
+        else 0
+      }
+  }
+
+  private val buckets = startingBuckets.getOrElse(new TreeMap[Double, Int])
+  private val deltas = startingDeltas.getOrElse(new TreeMap[DeltaType, Unit](new DeltaCompare))
+
+  /* The number of samples represented by this histogram */
+  var n = buckets.asScala.map(_._2).sum
+
+  /**
+    * Take two buckets and return their composite.
+    */
+  private def merge(left: BucketType, right: BucketType): BucketType = {
+    val (value1, count1) = left
+    val (value2, count2) = right
+    ((value1*count1 + value2*count2)/(count1 + count2), (count1 + count2))
+  }
+
+  /**
+    * Merge the two closest-together buckets.
+    *
+    * Before: left ----- middle1 ----- middle2 ----- right
+    *
+    * After: left ------------- middle ------------- right
+    *
+    * This function appropriately modifies both the buckets and the
+    * deltas.  The deltas on either side of the collapsed pair are
+    * removed and replaced with deltas between the mid-point and
+    * respective extremes.
+    */
+  private def merge(): Unit = {
+    val delta = deltas.firstKey
+    val (_, middle1, middle2) = delta
+    val middle = merge(middle1, middle2)
+    val left = {
+      val entry = buckets.lowerEntry(middle1._1)
+      if (entry != null) Some(entry.getKey, entry.getValue); else None
+    }
+    val right = {
+      val entry = buckets.higherEntry(middle2._1)
+      if (entry != null) Some(entry.getKey, entry.getValue); else None
+    }
+
+    /* remove delta between middle1 and middle2 */
+    deltas.remove(delta)
+
+    /* Replace delta to the left the merged buckets */
+    if (left != None) {
+      val other = left.get
+      val oldDelta = middle1._1 - other._1
+      val newDelta = middle._1 - other._1
+      deltas.remove((oldDelta, other, middle1))
+      deltas.put((newDelta, other, middle), Unit)
+    }
+
+    /* Replace delta to the right the merged buckets */
+    if (right != None) {
+      val other = right.get
+      val oldDelta = other._1 - middle2._1
+      val newDelta = other._1 - middle._1
+      deltas.remove((oldDelta, middle2, other))
+      deltas.put((newDelta, middle, other), Unit)
+    }
+
+    /* Replace merged buckets with their average */
+    buckets.remove(middle1._1)
+    buckets.remove(middle2._1)
+    buckets.put(middle._1, middle._2)
+  }
+
+  /**
+    * Add a bucket to this histogram.  This can be used to add a new
+    * sample to the histogram by letting the bucket-count be equal to
+    * one, or it can be used to incrementally merge two histograms.
+    */
+  private def countItem(b: BucketType): Unit = {
+    /* First entry */
+    if (buckets.size == 0)
+      buckets.put(b._1, b._2)
+    /* Duplicate entry */
+    else if (buckets.containsKey(b._1))
+      buckets.put(b._1, buckets.get(b._1) + b._2)
+    /* Create new entry */
+    else {
+      val smaller = {
+        val entry = buckets.lowerEntry(b._1)
+        if (entry != null) Some(entry.getKey, entry.getValue); else None
+      }
+      val larger = {
+        val entry = buckets.higherEntry(b._1)
+        if (entry != null) Some(entry.getKey, entry.getValue); else None
+      }
+
+      /* Remove delta containing new bucket */
+      if (smaller != None && larger != None) {
+        val large = larger.get
+        val small = smaller.get
+        val delta = large._1 - small._1
+        deltas.remove((delta, small, large))
+      }
+
+      /* Add delta between new bucket and next-largest bucket */
+      if (larger != None) {
+        val large = larger.get
+        val delta = large._1 - b._1
+        deltas.put((delta, b, large), Unit)
+      }
+
+      /* Add delta between new bucket and next-smallest bucket */
+      if (smaller != None) {
+        val small = smaller.get
+        val delta = b._1 - small._1
+        deltas.put((delta, small, b), Unit)
+      }
+    }
+
+    n += b._2
+    buckets.put(b._1, b._2)
+    if (buckets.size > m) merge
+  }
+
+  /**
+    * Additional count(|Int)Item(|s) methods.
+    */
+  def countItem(item: Double, count: Int = 1): Unit =
+    countItem((item, count))
+  def countIntItem(item: Int, count: Int = 1): Unit =
+    countItem((item.toDouble, count))
+  def countItems(items: Seq[BucketType]): Unit =
+    items.foreach({ item => countItem(item) })
+  def countItems(items: Seq[Double])(implicit dummy: DummyImplicit): Unit =
+    items.foreach({ item => countItem((item, 1)) })
+
+  /**
+    * Unimplementable in principle.
+    */
+  def uncountItem(item: Double): Unit = ???
+  def setItem(item: Double, count: Int): Unit = ???
+  def getValues(): Array[Double] = ???
+  def rawValues(): Array[Double] = ???
+  def foreach(f: (Double, Int) => Unit): Unit = ???
+  def foreachValue(f: Double => Unit): Unit = ???
+  def getItemCount(item: Double): Int = ???
+
+  /**
+    * Generate Statistics.
+    */
+  def generateStatistics(): Statistics[Double] = {
+    val dataCount = getTotalCount
+    val mean = getMean
+    val median = getMedian
+    val mode = getMode
+    val stddev: Double = ???
+    val zmin = getMinValue
+    val zmax = getMaxValue
+
+    Statistics[Double](dataCount, mean, median, mode, stddev, zmin, zmax)
+  }
+
+  /**
+    * Update this histogram with the entries from another.
+    */
+  def update(other: Histogram[Double]): Unit = {
+    if (other.isInstanceOf[StreamingHistogram])
+      this.countItems(other.asInstanceOf[StreamingHistogram].getBuckets)
+    else
+      ???
+  }
+
+  def mutable(): StreamingHistogram =
+    StreamingHistogram(this.m, this.buckets, this.deltas)
+
+  /**
+    * Combine operator: create a new histogram from this one and
+    * another without altering either.
+    */
+  def +(other: StreamingHistogram): StreamingHistogram = {
+    val sh = StreamingHistogram(this.m, this.buckets, this.deltas)
+    sh.countItems(other.getBuckets)
+    sh
+  }
+
+  /**
+    * Return the approximate mode of the distribution.  This is done
+    * by simply returning the most populous bucket (so this answer
+    * could be really bad).
+    */
+  def getMode(): Double = {
+    buckets.asScala.reduce({ (l,r) =>
+      if (l._2 > r._2) l; else r
+    })._1
+  }
+
+  /**
+    * Median.
+    */
+  def getMedian(): Double = getPercentile(0.50)
+
+  /**
+    *  Mean.
+    */
+  def getMean(): Double = {
+    val weightedSum =
+      buckets
+        .asScala.foldLeft(0.0)({ (acc,bucket) =>
+          acc + (bucket._1 * bucket._2)
+        })
+    weightedSum / getTotalCount
+  }
+
+  /**
+    * Total number of samples used to build this histogram.
+    */
+  def getTotalCount(): Int = n
+
+  /**
+    * Get the (approximate) min value.  This is only approximate
+    * because the lowest bucket may be a composite one.
+    */
+  def getMinValue(): Double = {
+    val entry = buckets.higherEntry(Double.NegativeInfinity)
+    if (entry != null) entry.getKey; else Double.NaN
+  }
+
+  /**
+    * Get the (approximate) max value.
+    */
+  def getMaxValue(): Double = {
+    val entry = buckets.lowerEntry(Double.PositiveInfinity)
+    if (entry != null) entry.getKey; else Double.NaN
+  }
+
+  /**
+    * This returns a tuple of tuples, where the inner tuples contain a
+    * bucket label and its percentile.
+    */
+  private def getCdfIntervals(): Iterator[((Double, Double), (Double, Double))] = {
+    val scalaBuckets = buckets.asScala
+    val ds = scalaBuckets.map(_._1)
+    val pdf = scalaBuckets.map(_._2.toDouble / n)
+    val cdf = pdf.scanLeft(0.0)(_ + _).drop(1)
+    val data = ds.zip(cdf).sliding(2)
+    data.map({ ab => (ab.head, ab.tail.head) })
+  }
+
+  /**
+    * Get the (approximate) percentile of this item.
+    */
+  def getPercentileRanking(item: Double): Double = {
+    val data = getCdfIntervals
+    val tt = data.dropWhile(_._2._1 <= item).next
+    val (d1, pct1) = tt._1
+    val (d2, pct2) = tt._2
+    val x = (item - d1) / (item - d2)
+    ((x*pct2) + (1-x)*pct1)
+  }
+
+  /**
+    * For each q in qs, all between 0 and 1, find a number
+    * (approximately) at the qth percentile.
+    */
+  def getPercentileBreaks(qs: Seq[Double]): Seq[Double] = {
+    val data = getCdfIntervals
+    qs.map({ q =>
+      val tt = data.dropWhile(_._2._2 <= q).next
+      val (d1, pct1) = tt._1
+      val (d2, pct2) = tt._2
+      val x = (q - pct1) / (pct2 - pct1)
+      ((x*d2) + (1-x)*d1)
+    })
+  }
+
+  def getPercentile(q: Double): Double =
+    getPercentileBreaks(List(q)).head
+
+  def getQuantileBreaks(num: Int): Array[Double] =
+    getPercentileBreaks(List.range(0,num).map(_ / num.toDouble)).toArray
+
+  def getBuckets(): List[BucketType] = buckets.asScala.toList
+
+  def getDeltas(): List[DeltaType] = deltas.keySet.asScala.toList
+}

--- a/raster/src/main/scala/geotrellis/raster/io/json/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/json/package.scala
@@ -8,8 +8,8 @@ import geotrellis.vector.io.json._
 import spray.json._
 
 package object json {
-  implicit object HistogramFormat extends RootJsonFormat[Histogram] {
-    def write(h: Histogram): JsValue = {
+  implicit object HistogramFormat extends RootJsonFormat[Histogram[Int]] {
+    def write(h: Histogram[Int]): JsValue = {
       var pairs: List[JsArray] = Nil
       h.foreach{ (value, count) => pairs = JsArray(JsNumber(value), JsNumber(count)) :: pairs }
       JsArray(pairs:_*)

--- a/raster/src/main/scala/geotrellis/raster/op/stats/Statistics.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/stats/Statistics.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.raster.op.stats
 
-import geotrellis.raster.{Nodata, doubleNODATA, NODATA}
+import geotrellis.raster.{doubleNODATA, NODATA}
 
 /**
   * Data object for sharing the basic statistics about a raster or region.

--- a/raster/src/main/scala/geotrellis/raster/op/stats/Statistics.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/stats/Statistics.scala
@@ -16,16 +16,44 @@
 
 package geotrellis.raster.op.stats
 
-import geotrellis.raster.NODATA
+import geotrellis.raster.{Nodata, doubleNODATA, NODATA}
 
 /**
   * Data object for sharing the basic statistics about a raster or region.
   */
-case class Statistics(dataCells: Long = 0, mean: Double = Double.NaN,
-                      median: Int = NODATA, mode: Int = NODATA,
-                      stddev: Double = Double.NaN,zmin: Int = NODATA,
-                      zmax: Int = NODATA)
+case class Statistics[@specialized (Int, Double) T]
+(
+  dataCells: Long = 0,
+  mean: Double = Double.NaN,
+  median: T,
+  mode: T,
+  stddev: Double = Double.NaN,
+  zmin: T,
+  zmax: T
+)
 
 object Statistics {
-  val EMPTY = Statistics()
+  def EMPTYInt() = {
+    Statistics[Int](
+      dataCells = 0,
+      mean = Double.NaN,
+      median = NODATA,
+      mode = NODATA,
+      stddev = Double.NaN,
+      zmin = NODATA,
+      zmax = NODATA
+    )
+  }
+
+  def EMPTYDouble() = {
+    Statistics[Double](
+      dataCells = 0,
+      mean = Double.NaN,
+      median = doubleNODATA,
+      mode = doubleNODATA,
+      stddev = Double.NaN,
+      zmin = doubleNODATA,
+      zmax = doubleNODATA
+    )
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/op/stats/StatsMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/stats/StatsMethods.scala
@@ -11,7 +11,7 @@ trait StatsMethods extends MethodExtensions[Tile] {
     *           rounded to integers when making the Histogram.
     */
   def histogram: Histogram[Int] =
-    FastMapHistogram.fromTile(tile)
+    FastMapHistogram.fromTile(self)
 
   /**
     * Implements a histogram in terms of an array of the given size.
@@ -42,7 +42,7 @@ trait StatsMethods extends MethodExtensions[Tile] {
     * @param significantDigits   Number of significant digits to preserve by multiplying
     */
   def doubleHistogram(significantDigits: Int): Histogram[Int] =
-    FastMapHistogram.fromTileDouble(tile, significantDigits)
+    FastMapHistogram.fromTileDouble(self, significantDigits)
 
   /**
   * Generate quantile class breaks for a given raster.

--- a/raster/src/main/scala/geotrellis/raster/op/stats/StatsMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/stats/StatsMethods.scala
@@ -10,8 +10,8 @@ trait StatsMethods extends MethodExtensions[Tile] {
     * @note     Tiles with a double type (TypeFloat, TypeDouble) will have their values
     *           rounded to integers when making the Histogram.
     */
-  def histogram: Histogram =
-    FastMapHistogram.fromTile(self)
+  def histogram: Histogram[Int] =
+    FastMapHistogram.fromTile(tile)
 
   /**
     * Implements a histogram in terms of an array of the given size.
@@ -41,8 +41,8 @@ trait StatsMethods extends MethodExtensions[Tile] {
     *
     * @param significantDigits   Number of significant digits to preserve by multiplying
     */
-  def doubleHistogram(significantDigits: Int): Histogram =
-    FastMapHistogram.fromTileDouble(self, significantDigits)
+  def doubleHistogram(significantDigits: Int): Histogram[Int] =
+    FastMapHistogram.fromTileDouble(tile, significantDigits)
 
   /**
   * Generate quantile class breaks for a given raster.

--- a/raster/src/main/scala/geotrellis/raster/op/stats/StatsMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/stats/StatsMethods.scala
@@ -55,7 +55,7 @@ trait StatsMethods extends MethodExtensions[Tile] {
     *
     * This includes mean, median, mode, stddev, and min and max values.
     */
-  def statistics: Statistics =
+  def statistics: Statistics[Int] =
     histogram.generateStatistics
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalHistograms.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalHistograms.scala
@@ -30,7 +30,7 @@ import scala.collection.mutable
  *          If you use a Raster with a Double CellType (TypeFloat, TypeDouble)
  *          the data values will be rounded to integers.
  */
-trait ZonalHistogram[@specialized (Int, Double) T] {
+trait ZonalHistogram[@specialized (Int, Double) T <: AnyVal] {
   def apply(tile: Tile, zones: Tile): Map[Int, Histogram[T]]
 }
 

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalHistograms.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalHistograms.scala
@@ -30,10 +30,14 @@ import scala.collection.mutable
  *          If you use a Raster with a Double CellType (TypeFloat, TypeDouble)
  *          the data values will be rounded to integers.
  */
-object ZonalHistogram {
+trait ZonalHistogram[@specialized (Int, Double) T] {
+  def apply(tile: Tile, zones: Tile): Map[Int, Histogram[T]]
+}
+
+object ZonalHistogramInt extends ZonalHistogram[Int] {
 
   def apply(tile: Tile, zones: Tile): Map[Int, Histogram[Int]] = {
-    val histMap = mutable.Map[Int, FastMapHistogram]()
+    val histMap = mutable.Map[Int, MutableHistogram[Int]]()
 
     val rows  = tile.rows
     val cols  = tile.cols
@@ -43,6 +47,30 @@ object ZonalHistogram {
         val v = tile.get(col, row)
         val z = zones.get(col, row)
         if(!histMap.contains(z)) { histMap(z) = FastMapHistogram() }
+        histMap(z).countItem(v)
+      }
+    }
+
+    histMap.toMap
+  }
+}
+
+object ZonalHistogramDouble extends ZonalHistogram[Double] {
+
+  def apply(tile: Tile, zones: Tile): Map[Int, Histogram[Double]] =
+    apply(tile, zones, 80)
+
+  def apply(tile: Tile, zones: Tile, n: Int): Map[Int, Histogram[Double]] = {
+    val histMap = mutable.Map[Int, MutableHistogram[Double]]()
+
+    val rows  = tile.rows
+    val cols  = tile.cols
+
+    cfor(0)(_ < rows, _ + 1) { row =>
+      cfor(0)(_ < cols, _ + 1) { col =>
+        val v = tile.get(col, row)
+        val z = zones.get(col, row)
+        if(!histMap.contains(z)) { histMap(z) = StreamingHistogram(n) }
         histMap(z).countItem(v)
       }
     }

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalHistograms.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalHistograms.scala
@@ -32,7 +32,7 @@ import scala.collection.mutable
  */
 object ZonalHistogram {
 
-  def apply(tile: Tile, zones: Tile): Map[Int, Histogram] = {
+  def apply(tile: Tile, zones: Tile): Map[Int, Histogram[Int]] = {
     val histMap = mutable.Map[Int, FastMapHistogram]()
 
     val rows  = tile.rows

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalMethods.scala
@@ -4,13 +4,13 @@ import geotrellis.raster._
 import geotrellis.raster.op.stats._
 import geotrellis.raster.histogram._
 
-trait ZonalMethods extends MethodExtensions[Tile] {
-  def zonalHistogram(zones: Tile): Map[Int, Histogram] =
-    ZonalHistogram(self, zones)
+trait ZonalMethods extends TileMethods {
+  def zonalHistogram(zones: Tile): Map[Int, Histogram[Int]] =
+    ZonalHistogram(tile, zones)
 
   def zonalStatistics(zones: Tile): Map[Int, Statistics] =
-    ZonalHistogram(self, zones)
-      .map { case (zone: Int, hist: Histogram) => (zone -> hist.generateStatistics) }
+    ZonalHistogram(tile, zones)
+      .map { case (zone: Int, hist: Histogram[Int]) => (zone -> hist.generateStatistics) }
       .toMap
 
   def zonalPercentage(zones: Tile): Tile =

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalMethods.scala
@@ -5,12 +5,20 @@ import geotrellis.raster.op.stats._
 import geotrellis.raster.histogram._
 
 trait ZonalMethods extends TileMethods {
-  def zonalHistogram(zones: Tile): Map[Int, Histogram[Int]] =
-    ZonalHistogram(tile, zones)
+  def zonalHistogramInt(zones: Tile): Map[Int, Histogram[Int]] =
+    ZonalHistogramInt(tile, zones)
 
-  def zonalStatistics(zones: Tile): Map[Int, Statistics[Int]] =
-    ZonalHistogram(tile, zones)
+  def zonalStatisticsInt(zones: Tile): Map[Int, Statistics[Int]] =
+    ZonalHistogramInt(tile, zones)
       .map { case (zone: Int, hist: Histogram[Int]) => (zone -> hist.generateStatistics) }
+      .toMap
+
+  def zonalHistogramDouble(zones: Tile): Map[Int, Histogram[Double]] =
+    ZonalHistogramDouble(tile, zones)
+
+  def zonalStatisticsDouble(zones: Tile): Map[Int, Statistics[Double]] =
+    ZonalHistogramDouble(tile, zones)
+      .map { case (zone: Int, hist: Histogram[Double]) => (zone -> hist.generateStatistics) }
       .toMap
 
   def zonalPercentage(zones: Tile): Tile =

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalMethods.scala
@@ -8,7 +8,7 @@ trait ZonalMethods extends TileMethods {
   def zonalHistogram(zones: Tile): Map[Int, Histogram[Int]] =
     ZonalHistogram(tile, zones)
 
-  def zonalStatistics(zones: Tile): Map[Int, Statistics] =
+  def zonalStatistics(zones: Tile): Map[Int, Statistics[Int]] =
     ZonalHistogram(tile, zones)
       .map { case (zone: Int, hist: Histogram[Int]) => (zone -> hist.generateStatistics) }
       .toMap

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalMethods.scala
@@ -4,20 +4,20 @@ import geotrellis.raster._
 import geotrellis.raster.op.stats._
 import geotrellis.raster.histogram._
 
-trait ZonalMethods extends TileMethods {
+trait ZonalMethods extends MethodExtensions[Tile] {
   def zonalHistogramInt(zones: Tile): Map[Int, Histogram[Int]] =
-    ZonalHistogramInt(tile, zones)
+    ZonalHistogramInt(self, zones)
 
   def zonalStatisticsInt(zones: Tile): Map[Int, Statistics[Int]] =
-    ZonalHistogramInt(tile, zones)
+    ZonalHistogramInt(self, zones)
       .map { case (zone: Int, hist: Histogram[Int]) => (zone -> hist.generateStatistics) }
       .toMap
 
   def zonalHistogramDouble(zones: Tile): Map[Int, Histogram[Double]] =
-    ZonalHistogramDouble(tile, zones)
+    ZonalHistogramDouble(self, zones)
 
   def zonalStatisticsDouble(zones: Tile): Map[Int, Statistics[Double]] =
-    ZonalHistogramDouble(tile, zones)
+    ZonalHistogramDouble(self, zones)
       .map { case (zone: Int, hist: Histogram[Double]) => (zone -> hist.generateStatistics) }
       .toMap
 

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalPercentage.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/ZonalPercentage.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,18 +24,18 @@ import spire.syntax.cfor._
 
 /**
  * Given a raster and a raster representing it's zones, sets all pixels
- * within each zone to the percentage of those pixels having values equal 
+ * within each zone to the percentage of those pixels having values equal
  * to that of the given pixel.
  *
  * Percentages are integer values from 0 - 100.
- * 
+ *
  * @note    ZonalPercentage does not currently support Double raster data.
  *          If you use a Raster with a Double CellType (TypeFloat, TypeDouble)
  *          the data values will be rounded to integers.
  */
 object ZonalPercentage {
   def apply(r: Tile, zones: Tile): Tile = {
-    val zonesToValueCounts = mutable.Map[Int, mutable.Map[Int, Int]]()       
+    val zonesToValueCounts = mutable.Map[Int, mutable.Map[Int, Int]]()
     val zoneTotals = mutable.Map[Int, Int]()
 
     val (cols, rows) = (r.cols, r.rows)
@@ -44,12 +44,12 @@ object ZonalPercentage {
       sys.error(s"The zone raster is not the same dimensions as the data raster.")
     }
 
-    cfor(0)(_ < rows, _ + 1) { row => 
+    cfor(0)(_ < rows, _ + 1) { row =>
       cfor(0)(_ < cols, _ + 1) { col =>
         val value = r.get(col, row)
         val zone = zones.get(col, row)
 
-        if(!zonesToValueCounts.contains(zone)) { 
+        if(!zonesToValueCounts.contains(zone)) {
           zonesToValueCounts(zone) = mutable.Map[Int, Int]()
           zoneTotals(zone) = 0
         }
@@ -65,7 +65,7 @@ object ZonalPercentage {
 
     val tile = IntArrayTile.empty(cols, rows)
 
-    cfor(0)(_ < rows, _ + 1) { row => 
+    cfor(0)(_ < rows, _ + 1) { row =>
       cfor(0)(_ < cols, _ + 1) { col =>
         val v = r.get(col, row)
         val z = zones.get(col, row)

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/summary/Histogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/summary/Histogram.scala
@@ -5,8 +5,8 @@ import geotrellis.vector._
 import geotrellis.raster.rasterize._
 import geotrellis.raster.histogram._
 
-object Histogram extends TileIntersectionHandler[Histogram] {
-  def handlePartialTile(raster: Raster[Tile], polygon: Polygon): Histogram = {
+object Histogram extends TileIntersectionHandler[Histogram[Int]] {
+  def handlePartialTile(raster: Raster[Tile], polygon: Polygon): Histogram[Int] = {
     val Raster(tile, _) = raster
     val rasterExtent = raster.rasterExtent
     val histogram = FastMapHistogram()
@@ -17,12 +17,12 @@ object Histogram extends TileIntersectionHandler[Histogram] {
     histogram
   }
 
-  def handleFullTile(tile: Tile): Histogram = {
+  def handleFullTile(tile: Tile): Histogram[Int] = {
     val histogram = FastMapHistogram()
     tile.foreach { (z: Int) => if (isData(z)) histogram.countItem(z, 1) }
     histogram
   }
 
-  def combineResults(rs: Seq[Histogram]): Histogram =
+  def combineResults(rs: Seq[Histogram[Int]]): Histogram[Int] =
     FastMapHistogram.fromHistograms(rs)
 }

--- a/raster/src/main/scala/geotrellis/raster/op/zonal/summary/ZonalSummaryMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/op/zonal/summary/ZonalSummaryMethods.scala
@@ -44,10 +44,10 @@ trait ZonalSummaryMethods extends MethodExtensions[Tile] {
     handler.combineResults(results)
   }
 
-  def zonalHistogram(extent: Extent, geom: Polygon): histogram.Histogram =
+  def zonalHistogram(extent: Extent, geom: Polygon): histogram.Histogram[Int] =
     zonalSummary(extent, geom, Histogram)
 
-  def zonalHistogram(extent: Extent, geom: MultiPolygon): histogram.Histogram =
+  def zonalHistogram(extent: Extent, geom: MultiPolygon): histogram.Histogram[Int] =
     zonalSummary(extent, geom, Histogram)
 
   def zonalMax(extent: Extent, geom: Polygon): Int =

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -29,6 +29,16 @@ package object raster
   type SingleBandRaster = Raster[Tile]
   type MultiBandRaster = Raster[MultiBandTile]
 
+  implicit class Nodata[T](x: T) {
+    def get() = {
+      x match {
+        case _: Int => NODATA
+        case _: Double => doubleNODATA
+        case _ => throw new Exception
+      }
+    }
+  }
+
   // Implicit method extension for core types
 
   implicit class withRasterExtentRasterizeMethods(val self: RasterExtent) extends MethodExtensions[RasterExtent]

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -29,19 +29,6 @@ package object raster
   type SingleBandRaster = Raster[Tile]
   type MultiBandRaster = Raster[MultiBandTile]
 
-  implicit class Nodata[T](x: T) {
-    def getNodata() = {
-      x match {
-        case _: Byte => byteNODATA
-        case _: Double => doubleNODATA
-        case _: Float => floatNODATA
-        case _: Int => NODATA
-        case _: Short => shortNODATA
-        case _ => throw new Exception
-      }
-    }
-  }
-
   // Implicit method extension for core types
 
   implicit class withRasterExtentRasterizeMethods(val self: RasterExtent) extends MethodExtensions[RasterExtent]

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -30,10 +30,13 @@ package object raster
   type MultiBandRaster = Raster[MultiBandTile]
 
   implicit class Nodata[T](x: T) {
-    def get() = {
+    def getNodata() = {
       x match {
-        case _: Int => NODATA
+        case _: Byte => byteNODATA
         case _: Double => doubleNODATA
+        case _: Float => floatNODATA
+        case _: Int => NODATA
+        case _: Short => shortNODATA
         case _ => throw new Exception
       }
     }

--- a/raster/src/main/scala/geotrellis/raster/render/JpgRenderMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/JpgRenderMethods.scala
@@ -57,11 +57,11 @@ trait JpgRenderMethods extends MethodExtensions[Tile] {
     * [[geotrellis.raster.stats.op.stat.GetClassBreaks]] operation to generate
     * quantile class breaks.
     */
-  def renderJpg(colorBreaks: ColorBreaks, noDataColor: Int, histogram: Histogram): Jpg =
+  def renderJpg(colorBreaks: ColorBreaks, noDataColor: Int, histogram: Histogram[Int]): Jpg =
     renderJpg(colorBreaks, noDataColor, Some(histogram))
 
   private
-  def renderJpg(colorBreaks: ColorBreaks, noDataColor: Int, histogram: Option[Histogram]): Jpg = {
+  def renderJpg(colorBreaks: ColorBreaks, noDataColor: Int, histogram: Option[Histogram[Int]]): Jpg = {
     val renderer =
       histogram match {
         case Some(h) => Renderer(colorBreaks, noDataColor, h)

--- a/raster/src/main/scala/geotrellis/raster/render/PngRenderMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/PngRenderMethods.scala
@@ -54,11 +54,11 @@ trait PngRenderMethods extends MethodExtensions[Tile] {
     * [[geotrellis.raster.stats.op.stat.GetClassBreaks]] operation to generate
     * quantile class breaks.
     */
-  def renderPng(colorBreaks: ColorBreaks, noDataColor: Int, histogram: Histogram): Png =
+  def renderPng(colorBreaks: ColorBreaks, noDataColor: Int, histogram: Histogram[Int]): Png =
     renderPng(colorBreaks, noDataColor, Some(histogram))
 
   private
-  def renderPng(colorBreaks: ColorBreaks, noDataColor: Int, histogram: Option[Histogram]): Png = {
+  def renderPng(colorBreaks: ColorBreaks, noDataColor: Int, histogram: Option[Histogram[Int]]): Png = {
     val renderer =
       histogram match {
         case Some(h) => Renderer(colorBreaks, noDataColor, h)

--- a/raster/src/main/scala/geotrellis/raster/render/Renderer.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/Renderer.scala
@@ -40,14 +40,14 @@ object Renderer {
   // def apply(limits: Array[Double], colors: Array[Int], nodata: Int): Renderer =
   //   apply(ColorBreaks(limits, colors), nodata, None)
 
-  def apply(limits: Array[Int], colors: Array[Int], nodata: Int, h: Histogram): Renderer =
+  def apply(limits: Array[Int], colors: Array[Int], nodata: Int, h: Histogram[Int]): Renderer =
     apply(ColorBreaks(limits, colors), nodata, Some(h))
 
-  def apply(colorBreaks: ColorBreaks, nodata: Int, h: Histogram): Renderer =
+  def apply(colorBreaks: ColorBreaks, nodata: Int, h: Histogram[Int]): Renderer =
     apply(colorBreaks, nodata, Some(h))
 
   /** Include a precomputed histogram to cache the color map and speed up the rendering. */
-  def apply(colorBreaks: ColorBreaks, nodata: Int, h: Option[Histogram]): Renderer = {
+  def apply(colorBreaks: ColorBreaks, nodata: Int, h: Option[Histogram[Int]]): Renderer = {
     val len = colorBreaks.length
     if(len <= 256) {
       val indices = (0 until len).toArray

--- a/raster/src/main/scala/geotrellis/raster/render/color/ColorBreaks.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/color/ColorBreaks.scala
@@ -143,7 +143,7 @@ object ColorBreaks {
   def apply(limits: Array[Double], colors: Array[Int]): DoubleColorBreaks =
     new DoubleColorBreaks(limits, sample(colors, limits.length))
 
-  def apply(histogram: Histogram, colors: Array[Int]): IntColorBreaks = {
+  def apply(histogram: Histogram[Int], colors: Array[Int]): IntColorBreaks = {
     val limits = histogram.getQuantileBreaks(colors.length)
     new IntColorBreaks(limits, sample(colors, limits.length))
   }

--- a/raster/src/main/scala/geotrellis/raster/render/color/ColorMap.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/color/ColorMap.scala
@@ -129,7 +129,7 @@ trait ColorMap {
 
   def render(r: Tile): Tile
 
-  def cache(h: Histogram): ColorMap
+  def cache(h: Histogram[Int]): ColorMap
 }
 
 case class IntColorMap(breaksToColors: Map[Int, Int],
@@ -183,20 +183,20 @@ case class IntColorMap(breaksToColors: Map[Int, Int],
   def render(r: Tile) =
       r.convert(TypeByte).map { z => apply(z) }
 
-  def cache(h: Histogram): ColorMap = {
+  def cache(h: Histogram[Int]): ColorMap = {
     val ch = h.mutable
     h.foreachValue(z => ch.setItem(z, apply(z)))
     CachedColorMap(orderedColors, options, ch)
   }
 }
 
-case class CachedColorMap(colors: Array[Int], options: ColorMapOptions, h: Histogram)
+case class CachedColorMap(colors: Array[Int], options: ColorMapOptions, h: Histogram[Int])
   extends ColorMap with Function1[Int, Int] {
   final val noDataColor = options.noDataColor
   def render(r: Tile) =
     r.map(this)
   final def apply(z: Int) = { if(isNoData(z)) noDataColor else h.getItemCount(z) }
-  def cache(h: Histogram) = this
+  def cache(h: Histogram[Int]) = this
 }
 
 case class DoubleColorMap(breaksToColors: Map[Double, Int],
@@ -249,7 +249,7 @@ case class DoubleColorMap(breaksToColors: Map[Double, Int],
   def render(r: Tile) =
       r.mapDouble { z => apply(z) }
 
-  def cache(h: Histogram): ColorMap = {
+  def cache(h: Histogram[Int]): ColorMap = {
     val ch = h.mutable
 
     h.foreachValue(z => ch.setItem(z, apply(z)))
@@ -261,7 +261,7 @@ case class DoubleColorMap(breaksToColors: Map[Double, Int],
       val options = opts
       def render(r: Tile) =
         r.map { z => if(z == NODATA) options.noDataColor else ch.getItemCount(z) }
-      def cache(h: Histogram) = this
+      def cache(h: Histogram[Int]) = this
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/op/stats/StatsTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/stats/StatsTileRDDMethods.scala
@@ -28,7 +28,7 @@ trait StatsTileRDDMethods[K] extends TileRDDMethods[K] {
       .mapValues { case (tile, count) => tile / count}
   }
 
-  def histogram: Histogram = {
+  def histogram: Histogram[Int] = {
     self
       .map { case (key, tile) => tile.histogram }
       .reduce { (h1, h2) => FastMapHistogram.fromHistograms(Array(h1,h2)) }

--- a/spark/src/main/scala/geotrellis/spark/op/zonal/ZonalTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/zonal/ZonalTileRDDMethods.scala
@@ -27,11 +27,11 @@ trait ZonalTileRDDMethods[K] extends TileRDDMethods[K] {
     res
   }
 
-  def zonalHistogram(zonesRasterRDD: RDD[(K, Tile)], partitioner: Option[Partitioner] = None): Map[Int, Histogram] =
-    partitioner
-      .fold(self.join(zonesRasterRDD))(self.join(zonesRasterRDD, _))
-      .map((t: (K, (Tile, Tile))) => ZonalHistogram(t._2._1, t._2._2))
+  def zonalHistogram(zonesRasterRDD: RDD[(K, Tile)]): Map[Int, Histogram[Int]] = {
+    self.join(zonesRasterRDD)
+      .map((t: (K, (Tile, Tile))) => ZonalHistogramInt(t._2._1, t._2._2))
       .fold(Map[Int, Histogram[Int]]())(mergeMaps)
+  }
 
   def zonalPercentage(zonesRasterRDD: RDD[(K, Tile)], partitioner: Option[Partitioner] = None): RDD[(K, Tile)] = {
     val sc = self.sparkContext

--- a/spark/src/main/scala/geotrellis/spark/op/zonal/ZonalTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/zonal/ZonalTileRDDMethods.scala
@@ -14,7 +14,7 @@ import spire.syntax.cfor._
 
 trait ZonalTileRDDMethods[K] extends TileRDDMethods[K] {
 
-  private def mergeMaps(a: Map[Int, Histogram], b: Map[Int, Histogram]) = {
+  private def mergeMaps(a: Map[Int, Histogram[Int]], b: Map[Int, Histogram[Int]]) = {
     var res = a
     for ((k, v) <- b)
       res = res + (k ->
@@ -31,7 +31,7 @@ trait ZonalTileRDDMethods[K] extends TileRDDMethods[K] {
     partitioner
       .fold(self.join(zonesRasterRDD))(self.join(zonesRasterRDD, _))
       .map((t: (K, (Tile, Tile))) => ZonalHistogram(t._2._1, t._2._2))
-      .fold(Map[Int, Histogram]())(mergeMaps)
+      .fold(Map[Int, Histogram[Int]]())(mergeMaps)
 
   def zonalPercentage(zonesRasterRDD: RDD[(K, Tile)], partitioner: Option[Partitioner] = None): RDD[(K, Tile)] = {
     val sc = self.sparkContext

--- a/spark/src/main/scala/geotrellis/spark/op/zonal/ZonalTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/zonal/ZonalTileRDDMethods.scala
@@ -27,8 +27,9 @@ trait ZonalTileRDDMethods[K] extends TileRDDMethods[K] {
     res
   }
 
-  def zonalHistogram(zonesRasterRDD: RDD[(K, Tile)]): Map[Int, Histogram[Int]] = {
-    self.join(zonesRasterRDD)
+  def zonalHistogram(zonesRasterRDD: RDD[(K, Tile)], partitioner: Option[Partitioner] = None): Map[Int, Histogram[Int]] = {
+    partitioner
+      .fold(self.join(zonesRasterRDD))(self.join(zonesRasterRDD, _))
       .map((t: (K, (Tile, Tile))) => ZonalHistogramInt(t._2._1, t._2._2))
       .fold(Map[Int, Histogram[Int]]())(mergeMaps)
   }

--- a/spark/src/main/scala/geotrellis/spark/op/zonal/summary/ZonalSummaryRasterRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/zonal/summary/ZonalSummaryRasterRDDMethods.scala
@@ -107,10 +107,10 @@ abstract class ZonalSummaryRasterRDDMethods[K: ClassTag] extends MethodExtension
       .map { case (key, raster) => (fKey(key), raster.asFeature) }
       .zonalSummaryByKey(multiPolygon, zeroValue, partitioner)(handler)
 
-  def regionHistogram(polygon: Polygon): Histogram =
+  def regionHistogram(polygon: Polygon): Histogram[Int] =
     zonalSummary(polygon, FastMapHistogram(), Histogram)
 
-  def regionHistogram(multiPolygon: MultiPolygon): Histogram =
+  def regionHistogram(multiPolygon: MultiPolygon): Histogram[Int] =
     zonalSummary(multiPolygon, FastMapHistogram(), Histogram)
 
   def zonalMax(polygon: Polygon): Int =

--- a/spark/src/test/scala/geotrellis/spark/io/AttributeStoreSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/AttributeStoreSpec.scala
@@ -49,7 +49,7 @@ abstract class AttributeStoreSpec
 
     attributeStore.write(layerId, "histogram", histo)
 
-    val loaded = attributeStore.read[Histogram](layerId, "histogram")
+    val loaded = attributeStore.read[Histogram[Int]](layerId, "histogram")
     loaded.getMean should be (histo.getMean)
   }
 

--- a/spark/src/test/scala/geotrellis/spark/op/zonal/HistogramSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/zonal/HistogramSpec.scala
@@ -76,7 +76,7 @@ class HistogramSpec extends FunSpec
             .toMap
         }
 
-      val result: Map[Int, Histogram] = rdd.zonalHistogram(zonesRDD)
+      val result: Map[Int, Histogram[Int]] = rdd.zonalHistogram(zonesRDD)
       result.keys should be (expected.keys)
 
       for(zone <- result.keys) {

--- a/testkit/src/main/scala/geotrellis/testkit/TileBuilders.scala
+++ b/testkit/src/main/scala/geotrellis/testkit/TileBuilders.scala
@@ -71,7 +71,7 @@ trait TileBuilders {
   }
 
   def createTile(arr: Array[Short]) = {
-    val d = scala.math.sqrt(arr.length).toInt    
+    val d = scala.math.sqrt(arr.length).toInt
     ShortArrayTile(arr, d, d)
   }
 


### PR DESCRIPTION
The histogram type hierarchy has been been parameterized so that there is a notion of double-valued histograms, as well as integer-valued ones.  A new class called `StreamingHistogram`, derived from `MutableHistogram[Double]` has been created.

Please see: https://github.com/jamesmcclain/StreamingHistogram
Benchmarks: https://github.com/geotrellis/geotrellis-benchmark/pull/2

### Benchmarks ###

#### Geotrellis 0.9.2 ####
```txt
Running benchmarks for Histogram Benchmarks...
  1 of 1: Integer Histogram             40963369.71 ns; σ=43179182.97422 ns @ 10 trials        

  Name                                    ms  linear runtime
  Integer Histogram                    40.96  =============================
[info] HistogramBenchmark:
[info] - [scaliper] Histogram Benchmarks
[info] Run completed in 12 seconds, 879 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

#### Geotrellis with this patch ####
```txt
Running benchmarks for Histogram Benchmarks...
  1 of 3: Integer Histogram             41275413.75 ns; σ=43508106.27487 ns @ 10 trials       
  2 of 3: Double Histogram 80 Bucke     329380463.45 ns; σ=347197493.75461 ns @ 10 trials
  3 of 3: Double Histogram 1000 Buc     328685618.78 ns; σ=346465063.15693 ns @ 10 trials

  Name                                    ms  linear runtime
  Integer Histogram                    41.28  ===
  Double Histogram 80 Buckets         329.38  =============================
  Double Histogram 1000 Buckets       328.69  =============================
[info] HistogramBenchmark:
[info] - [scaliper] Histogram Benchmarks
[info] Run completed in 35 seconds, 862 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

### Still Need To ###
   - [x] Decide how the `DoubleHistogram` relates to the existing histogram types, in particular `Histogram` and `MutableHistogram`.
   - [x] Understand the issue of boxing of primitive types vis-a-vis generics and type erasure
   - [x] ~~Discover/document cases when boxing will occur~~ Unable to come up with many realistic scenarios in which boxing might be a problem
   - [x] Graft `StreamingHistogram` code into Geotrellis tree
   - [x] Integrate `StreamingHistogram` so that it is usable
   - [x] Benchmark 0.9 versus HEAD
   - [x] Benchmark integer histogram versus double histogram in this branch
   - [x] Write StreamingHistogram tests