### PR TITLE
Hilbert Curve Fixes

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
+++ b/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
@@ -41,7 +41,7 @@ object SpatialKey {
   implicit object Boundable extends Boundable[SpatialKey] {
     def minBound(a: SpatialKey, b: SpatialKey) = {
       SpatialKey(math.min(a.col, b.col), math.min(a.row, b.row))
-    }    
+    }
     def maxBound(a: SpatialKey, b: SpatialKey) = {
       SpatialKey(math.max(a.col, b.col), math.max(a.row, b.row))
     }

--- a/spark/src/main/scala/geotrellis/spark/io/index/HilbertKeyIndexMethod.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/HilbertKeyIndexMethod.scala
@@ -11,19 +11,18 @@ private[index] trait HilbertKeyIndexMethod
 object HilbertKeyIndexMethod extends HilbertKeyIndexMethod {
   implicit def spatialKeyIndexIndex(m: HilbertKeyIndexMethod): KeyIndexMethod[SpatialKey] =
     new KeyIndexMethod[SpatialKey] {
-      def createIndex(keyBounds: KeyBounds[SpatialKey]): KeyIndex[SpatialKey] = {
-        val xResolution = resolution(keyBounds.maxKey.row - keyBounds.minKey.row)
-        val yResolution = resolution(keyBounds.maxKey.col - keyBounds.minKey.col)
+      def createIndex(keyBounds: KeyBounds[SpatialKey]) = {
+        val xResolution = resolution(keyBounds.maxKey.col, keyBounds.minKey.col)
+        val yResolution = resolution(keyBounds.maxKey.row, keyBounds.minKey.row)
         HilbertSpatialKeyIndex(keyBounds, xResolution, yResolution)
       }
     }
 
   def apply(temporalResolution: Int): KeyIndexMethod[SpaceTimeKey] =
     new KeyIndexMethod[SpaceTimeKey] {
-      def createIndex(keyBounds: KeyBounds[SpaceTimeKey]): KeyIndex[SpaceTimeKey] = {
-        val xResolution = resolution(keyBounds.maxKey.row - keyBounds.minKey.row)
-        val yResolution = resolution(keyBounds.maxKey.col - keyBounds.minKey.col)
-
+      def createIndex(keyBounds: KeyBounds[SpaceTimeKey]) = {
+        val xResolution = resolution(keyBounds.maxKey.col, keyBounds.minKey.col)
+        val yResolution = resolution(keyBounds.maxKey.row, keyBounds.minKey.row)
         HilbertSpaceTimeKeyIndex(keyBounds, xResolution, yResolution, temporalResolution)
       }
     }
@@ -36,8 +35,8 @@ object HilbertKeyIndexMethod extends HilbertKeyIndexMethod {
           val maxKey = keyBounds.maxKey
           KeyBounds[SpaceTimeKey](SpaceTimeKey(minKey.col, minKey.row, minDate), SpaceTimeKey(maxKey.col, maxKey.row, maxDate))
         }
-        val xResolution = resolution(keyBounds.maxKey.row - keyBounds.minKey.row)
-        val yResolution = resolution(keyBounds.maxKey.col - keyBounds.minKey.col)
+        val xResolution = resolution(keyBounds.maxKey.col, keyBounds.minKey.col)
+        val yResolution = resolution(keyBounds.maxKey.row, keyBounds.minKey.row)
         HilbertSpaceTimeKeyIndex(adjustedKeyBounds, xResolution, yResolution, temporalResolution)
       }
     }

--- a/spark/src/main/scala/geotrellis/spark/io/index/KeyIndex.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/KeyIndex.scala
@@ -31,7 +31,10 @@ trait KeyIndex[K] extends Serializable {
 
 trait KeyIndexMethod[K] extends Serializable {
   /** Helper method to get the resolution of a dimension. Takes the ceiling. */
-  def resolution(length: Double): Int = math.ceil(scala.math.log(length) / scala.math.log(2)).toInt
+  def resolution(max: Double, min: Double): Int = {
+    val length = max - min + 1
+    math.ceil(scala.math.log(length) / scala.math.log(2)).toInt
+  }
 
   def createIndex(keyBounds: KeyBounds[K]): KeyIndex[K]
 }

--- a/spark/src/main/scala/geotrellis/spark/io/index/RowMajorKeyIndexMethod.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/RowMajorKeyIndexMethod.scala
@@ -10,7 +10,7 @@ private[index] trait RowMajorKeyIndexMethod
 object RowMajorKeyIndexMethod extends RowMajorKeyIndexMethod {
   implicit def spatialKeyIndexMethod(m: RowMajorKeyIndexMethod): KeyIndexMethod[SpatialKey] =
     new KeyIndexMethod[SpatialKey] {
-      def createIndex(keyBounds: KeyBounds[SpatialKey]): KeyIndex[SpatialKey] = 
+      def createIndex(keyBounds: KeyBounds[SpatialKey]): KeyIndex[SpatialKey] =
         new RowMajorSpatialKeyIndex(keyBounds)
     }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndex.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndex.scala
@@ -40,28 +40,28 @@ class HilbertSpaceTimeKeyIndex(
   val startMillis = keyBounds.minKey.temporalKey.time.getMillis
   val timeWidth = keyBounds.maxKey.temporalKey.time.getMillis - startMillis
   val temporalBinCount = math.pow(2, temporalResolution)
- 
+
   @transient lazy val chc = {
     val dimensionSpec =
-      new MultiDimensionalSpec( 
+      new MultiDimensionalSpec(
         List(
           math.pow(2, xResolution).toInt,
           math.pow(2, yResolution).toInt,
           math.pow(2, temporalResolution).toInt
-        ).map(new java.lang.Integer(_)) 
+        ).map(new java.lang.Integer(_))
       )
 
     new CompactHilbertCurve(dimensionSpec)
   }
 
   def binTime(key: SpaceTimeKey): Long = {
-    // index requires right bound to be exclusive but KeyBounds do not, fake that.      
+    // index requires right bound to be exclusive but KeyBounds do not, fake that.
     val bin = (((key.temporalKey.time.getMillis - startMillis) * temporalBinCount) / timeWidth)
     (if (bin == temporalBinCount) bin - 1  else bin).toLong
   }
 
   def toIndex(key: SpaceTimeKey): Long = {
-    val bitVectors = 
+    val bitVectors =
       Array(
         BitVectorFactories.OPTIMAL.apply(xResolution),
         BitVectorFactories.OPTIMAL.apply(yResolution),
@@ -88,7 +88,7 @@ class HilbertSpaceTimeKeyIndex(
         LongRange.of(binTime(keyRange._1), binTime(keyRange._2) + 1)
       )
 
-    val  regionInspector: RegionInspector[LongRange, LongContent] = 
+    val  regionInspector: RegionInspector[LongRange, LongContent] =
       SimpleRegionInspector.create(
         List(ranges),
         new LongContent(1),
@@ -97,10 +97,10 @@ class HilbertSpaceTimeKeyIndex(
         new LongContent(0L)
       )
 
-    val combiner = 
-      new PlainFilterCombiner[LongRange, java.lang.Long, LongContent, LongRange](LongRange.of(0, 1));
+    val combiner =
+      new PlainFilterCombiner[LongRange, java.lang.Long, LongContent, LongRange](LongRange.of(0, 1))
 
-    val queryBuilder = 
+    val queryBuilder =
       BacktrackingQueryBuilder.create(
         regionInspector,
         combiner,

--- a/spark/src/main/scala/geotrellis/spark/io/index/hilbert/README.md
+++ b/spark/src/main/scala/geotrellis/spark/io/index/hilbert/README.md
@@ -1,0 +1,35 @@
+This document is a gathering-place for useful information about the Hilbert Curve Index implementation in Geotrellis and the `uzaygezen` library on which it is based.
+
+### The Index Resolution Changes Index Order ###
+
+This is a well-known fact, but there is no harm in a reminder.
+
+Changing the resolution (in bits) of the index causes a rotation and/or reflection of the points with respect to curve-order.
+
+An example is in the test file `HilbertSpaceTimeKeyIndexSpec.scala` where the line
+```scala
+HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),2,1)
+```
+appears (with the last two arguments being resolutions).  If that is changed to
+```scala
+HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),3,1)
+```
+then the index-order of the points will be different.
+
+### 62-bit Limit ###
+
+Currently, the spatial and temporal resolution required to index the points, expressed in bits, must sum to 62 bits or fewer.
+
+For example, the following code appears in `HilbertSpacetimeKeyIndex.scala`:
+```scala
+@transient lazy val chc = {
+  val dimensionSpec =
+    new MultiDimensionalSpec(
+      List(
+        xResolution,
+        yResolution,
+        temporalResolution
+      ).map(new java.lang.Integer(_))
+    )
+```
+where `xResolution`, `yResolution` and `temporalResolution` are numbers of bits required to express possible locations in each of those dimensions.  If those three integers sum to more than 62 bits, an error will be thrown at runtime.

--- a/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
@@ -104,7 +104,7 @@ abstract class PersistenceSpec[K: ClassTag, V: ClassTag, M] extends FunSpec with
     mover.move(movedLayerId, layerId)
   }
 
-  it("should not reindex a layer which doesn't exists") {
+  it("should not reindex a layer which doesn't exist") {
     intercept[LayerNotFoundError] {
       reindexer.reindex(movedLayerId)
     }

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeAlternativeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeAlternativeSpec.scala
@@ -9,7 +9,7 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.json._
 import geotrellis.spark.io.avro.codecs._
 
-class AccumuloSpaceTimeAlternativeSpec 
+class AccumuloSpaceTimeAlternativeSpec
     extends PersistenceSpec[SpaceTimeKey, Tile, RasterMetaData]
     with TestEnvironment
     with TestFiles

--- a/spark/src/test/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndexSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndexSpec.scala
@@ -14,26 +14,26 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
 
     it("indexes col, row, and time"){
       val hst = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(0,0,y2k.plusMillis(upperBound)),4 , 4)
-      val keys = 
+      val keys =
         for(col <- 0 until upperBound;
              row <- 0 until upperBound;
                 t <- 0 until upperBound) yield {
           hst.toIndex(SpaceTimeKey(col,row,y2k.plusMillis(t)))
-        } 
+        }
 
       keys.distinct.size should be (upperBound * upperBound * upperBound)
       keys.min should be (0)
       keys.max should be (upperBound * upperBound * upperBound - 1)
     }
-     
+
 
     it("generates hand indexes you can hand check 2x2x2"){
-     val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),1,1) 
+     val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),1,1)
      val idx = List[SpaceTimeKey](SpaceTimeKey(0,0,y2k), SpaceTimeKey(0,1,y2k),
                                   SpaceTimeKey(1,1,y2k), SpaceTimeKey(1,0,y2k),
                                   SpaceTimeKey(1,0,y2k.plusMillis(1)), SpaceTimeKey(1,1,y2k.plusMillis(1)),
                                   SpaceTimeKey(0,1,y2k.plusMillis(1)), SpaceTimeKey(0,0,y2k.plusMillis(1)))
-     
+
      for(i<-0 to 7 ){
        hilbert.toIndex(idx(i)) should be (i)
      }
@@ -43,7 +43,7 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
       val t1 = y2k
       val t2 = y2k.plusMillis(1)
 
-      //hand checked examples for a 2x2x2 
+      //hand checked examples for a 2x2x2
       // note: The col/row of the end key does not matter here, eh ?
       val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,t1), SpaceTimeKey(1,1,t2), 1, 1)
 
@@ -77,6 +77,6 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
       idx = hilbert.indexRanges((SpaceTimeKey(0,1,t1), SpaceTimeKey(1,1,t2)))
       idx.length should be (2)
       idx.toSet should be (Set(1->2, 5->6))
-    } 
+    }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndexSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndexSpec.scala
@@ -27,8 +27,8 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
     }
 
 
-    it("generates hand indexes you can hand check 2x2x2"){
-     val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),1,1)
+    it("generates hand indexes you can hand check 3x3x2"){
+     val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),2,1)
      val idx = List[SpaceTimeKey](SpaceTimeKey(0,0,y2k), SpaceTimeKey(0,1,y2k),
                                   SpaceTimeKey(1,1,y2k), SpaceTimeKey(1,0,y2k),
                                   SpaceTimeKey(1,0,y2k.plusMillis(1)), SpaceTimeKey(1,1,y2k.plusMillis(1)),
@@ -40,11 +40,11 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
     }
 
     it("Generates a Seq[(Long,Long)] given a key range (SpatialKey,SpatialKey)"){
+      // See http://mathworld.wolfram.com/HilbertCurve.html for reference
       val t1 = y2k
       val t2 = y2k.plusMillis(1)
 
       //hand checked examples for a 2x2x2
-      // note: The col/row of the end key does not matter here, eh ?
       val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,t1), SpaceTimeKey(1,1,t2), 1, 1)
 
       // select origin point only
@@ -60,23 +60,23 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
 
       // first 4 sub cubes (along y), front face
       idx = hilbert.indexRanges((SpaceTimeKey(0,0,t1), SpaceTimeKey(1,1,t1)))
-      idx.length should be (1)
-      idx.toSet should be (Set(0->3))
-
-      // second 4 sub cubes (along y), back face
-      idx = hilbert.indexRanges((SpaceTimeKey(0,0,t2), SpaceTimeKey(1,1,t2)))
-      idx.length should be (1)
-      idx.toSet should be (Set(4->7))
-
-      //4 sub cubes (along x), floor
-      idx = hilbert.indexRanges((SpaceTimeKey(0,0,t1), SpaceTimeKey(1,0,t2)))
       idx.length should be (3)
       idx.toSet should be (Set(0->0, 3->4, 7->7))
 
-      //next 4 sub cubes (along x)
-      idx = hilbert.indexRanges((SpaceTimeKey(0,1,t1), SpaceTimeKey(1,1,t2)))
+      // second 4 sub cubes (along y), back face
+      idx = hilbert.indexRanges((SpaceTimeKey(0,0,t2), SpaceTimeKey(1,1,t2)))
       idx.length should be (2)
       idx.toSet should be (Set(1->2, 5->6))
+
+      //4 sub cubes (along x), bottom face
+      idx = hilbert.indexRanges((SpaceTimeKey(0,0,t1), SpaceTimeKey(1,0,t2)))
+      idx.length should be (2)
+      idx.toSet should be (Set(0->1, 6->7))
+
+      //next 4 sub cubes (along x), top face
+      idx = hilbert.indexRanges((SpaceTimeKey(0,1,t1), SpaceTimeKey(1,1,t2)))
+      idx.length should be (1)
+      idx.toSet should be (Set(2->5))
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
@@ -125,7 +125,7 @@ trait TestFiles { self: TestEnvironment =>
     spaceTimeTestFile("spacetime-all-hundreds")
 
   /** Coordinates are CCC,RRR.TTT where C = column, R = row, T = time (year in 2010 + T).
-    * So 34,025.004 would represent col 34, row 25, year 2014
+    * So 34,025,004 would represent col 34, row 25, year 2014
     */
   lazy val CoordinateSpaceTime =
     spaceTimeTestFile("spacetime-coordinates")


### PR DESCRIPTION
Contains the following changes:

   * The x- and y-dimensions had been transposed in the Hilbert Index creation code.  This was probably not detected earlier because the two dimensions are typically about the same size?
   * The calculation of the location on the Hilbert curve corresponding to a particular key has been adjusted.
   * A corner-case in the calculation of the number of bits required to represent numbers has been adjusted.
   * The resolution function has been changed to take the minimum and maximum of the range as parameters, rather than the length as a single parameter.  This makes usage mistakes less likely.

https://github.com/geotrellis/geotrellis/pull/1303 ⊂ https://github.com/geotrellis/geotrellis/pull/1299
https://github.com/geotrellis/geotrellis/pull/1303 ⊂ https://github.com/pomadchin/geotrellis/pull/2