### PR TITLE
Deprecate the geotrellis-engine Project

### DIFF
--- a/engine/src/main/scala/geotrellis/engine/ArgFileRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ArgFileRasterLayer.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,7 @@ import java.io.File
 object ArgFileRasterLayerBuilder
 extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
-    val f = 
+    val f =
       if(json.hasPath("path")) {
         val f = new File(json.getString("path"))
         if(f.isAbsolute) {
@@ -50,7 +50,7 @@ extends RasterLayerBuilder {
       val (cellWidth, cellHeight) = getCellWidthAndHeight(json)
       val rasterExtent = RasterExtent(getExtent(json), cellWidth, cellHeight, cols, rows)
 
-      val info = 
+      val info =
         RasterLayerInfo(
           LayerId(ds, getName(json)),
           getCellType(json),
@@ -66,7 +66,7 @@ extends RasterLayerBuilder {
   }
 }
 
-class ArgFileRasterLayer(info: RasterLayerInfo, val rasterPath: String) 
+class ArgFileRasterLayer(info: RasterLayerInfo, val rasterPath: String)
 extends UntiledRasterLayer(info) {
   def getRaster(targetExtent: Option[RasterExtent]) = {
     if(isCached) {
@@ -91,6 +91,6 @@ extends UntiledRasterLayer(info) {
     }
   }
 
-  def cache(c: Cache[String]) = 
+  def cache(c: Cache[String]) =
     c.insert(info.id.toString, Filesystem.slurp(rasterPath))
 }

--- a/engine/src/main/scala/geotrellis/engine/ArgFileRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ArgFileRasterLayer.scala
@@ -24,6 +24,7 @@ import com.typesafe.config.Config
 
 import java.io.File
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object ArgFileRasterLayerBuilder
 extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
@@ -66,6 +67,7 @@ extends RasterLayerBuilder {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class ArgFileRasterLayer(info: RasterLayerInfo, val rasterPath: String)
 extends UntiledRasterLayer(info) {
   def getRaster(targetExtent: Option[RasterExtent]) = {

--- a/engine/src/main/scala/geotrellis/engine/ArgFileRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ArgFileRasterLayer.scala
@@ -24,7 +24,7 @@ import com.typesafe.config.Config
 
 import java.io.File
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object ArgFileRasterLayerBuilder
 extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
@@ -67,7 +67,7 @@ extends RasterLayerBuilder {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class ArgFileRasterLayer(info: RasterLayerInfo, val rasterPath: String)
 extends UntiledRasterLayer(info) {
   def getRaster(targetExtent: Option[RasterExtent]) = {

--- a/engine/src/main/scala/geotrellis/engine/ArgUrlRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ArgUrlRasterLayer.scala
@@ -32,6 +32,7 @@ import spray.client.pipelining._
 
 import com.typesafe.config.Config
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object ArgUrlRasterLayerBuilder
 extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
@@ -63,6 +64,7 @@ extends RasterLayerBuilder {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class ArgUrlRasterLayer(info: RasterLayerInfo, rasterUrl: String)
 extends UntiledRasterLayer(info) {
   def getRaster(targetExtent: Option[RasterExtent]) =

--- a/engine/src/main/scala/geotrellis/engine/ArgUrlRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ArgUrlRasterLayer.scala
@@ -32,7 +32,7 @@ import spray.client.pipelining._
 
 import com.typesafe.config.Config
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object ArgUrlRasterLayerBuilder
 extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
@@ -64,7 +64,7 @@ extends RasterLayerBuilder {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class ArgUrlRasterLayer(info: RasterLayerInfo, rasterUrl: String)
 extends UntiledRasterLayer(info) {
   def getRaster(targetExtent: Option[RasterExtent]) =

--- a/engine/src/main/scala/geotrellis/engine/ArgUrlRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ArgUrlRasterLayer.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,7 +35,7 @@ import com.typesafe.config.Config
 object ArgUrlRasterLayerBuilder
 extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
-    val url = 
+    val url =
       if(json.hasPath("url")) {
         json.getString("url")
       } else {
@@ -48,7 +48,7 @@ extends RasterLayerBuilder {
     val (cellWidth, cellHeight) = getCellWidthAndHeight(json)
     val rasterExtent = RasterExtent(getExtent(json), cellWidth, cellHeight, cols, rows)
 
-    val info = 
+    val info =
       RasterLayerInfo(
         LayerId(ds, getName(json)),
         getCellType(json),
@@ -63,7 +63,7 @@ extends RasterLayerBuilder {
   }
 }
 
-class ArgUrlRasterLayer(info: RasterLayerInfo, rasterUrl: String) 
+class ArgUrlRasterLayer(info: RasterLayerInfo, rasterUrl: String)
 extends UntiledRasterLayer(info) {
   def getRaster(targetExtent: Option[RasterExtent]) =
     if(isCached) {
@@ -104,7 +104,7 @@ extends UntiledRasterLayer(info) {
     }
   }
 
-  def cache(c: Cache[String]) = 
+  def cache(c: Cache[String]) =
         c.insert(info.id.toString, getBytes)
 
   private def fromBytes(arr: Array[Byte], target: Option[RasterExtent]) = {

--- a/engine/src/main/scala/geotrellis/engine/AsciiRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/AsciiRasterLayer.scala
@@ -25,6 +25,7 @@ import geotrellis.vector.Extent
 import java.io.{File, BufferedReader}
 import com.typesafe.config.Config
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object AsciiRasterLayerBuilder
 extends RasterLayerBuilder {
   val intRe = """^(-?[0-9]+)$""".r
@@ -151,6 +152,7 @@ extends RasterLayerBuilder {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class AsciiRasterLayer(info: RasterLayerInfo, noDataValue: Int, rasterPath: String)
 extends UntiledRasterLayer(info) {
   private var cached = false

--- a/engine/src/main/scala/geotrellis/engine/AsciiRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/AsciiRasterLayer.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ extends RasterLayerBuilder {
   val floatRe = """^(-?[0-9]+\.[0-9]+)$""".r
 
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
-    val path = 
+    val path =
       if(json.hasPath("path")) {
         json.getString("path")
       } else {
@@ -43,7 +43,7 @@ extends RasterLayerBuilder {
         }
       }
 
-    val cellType: CellType = 
+    val cellType: CellType =
       if(json.hasPath("type")) {
         val t = getCellType(json)
         if(t.isFloatingPoint) {
@@ -60,7 +60,7 @@ extends RasterLayerBuilder {
     } else {
       val (rasterExtent, noDataValue) = loadMetaData(path)
 
-      val info = 
+      val info =
         RasterLayerInfo(
           LayerId(ds, getName(json)),
           cellType,
@@ -83,7 +83,7 @@ extends RasterLayerBuilder {
 
     val name = Filesystem.basename(f.getName)
 
-    val info = 
+    val info =
       RasterLayerInfo(
         LayerId(name),
         IntConstantNoDataCellType,
@@ -118,10 +118,10 @@ extends RasterLayerBuilder {
       while (!done) {
         val line = br.readLine().trim()
         val toks = line.split(" ")
-  
+
         if (line == null) throw new Exception(s"premature end of file: $path")
         if (toks.length == 0) throw new Exception(s"illegal empty line: $path")
-  
+
         if (line.charAt(0).isDigit) {
           done = true
         } else {
@@ -132,7 +132,7 @@ extends RasterLayerBuilder {
             case Array("yllcorner", floatRe(n)) => yllcorner = n.toDouble
             case Array("cellsize", floatRe(n)) => cellsize = n.toDouble
             case Array("nodata_value", intRe(n)) => nodata_value = n.toInt
-  
+
             case _ => throw new Exception(s"mal-formed line '$line'")
           }
         }
@@ -151,7 +151,7 @@ extends RasterLayerBuilder {
   }
 }
 
-class AsciiRasterLayer(info: RasterLayerInfo, noDataValue: Int, rasterPath: String) 
+class AsciiRasterLayer(info: RasterLayerInfo, noDataValue: Int, rasterPath: String)
 extends UntiledRasterLayer(info) {
   private var cached = false
 
@@ -167,7 +167,7 @@ extends UntiledRasterLayer(info) {
       getReader.readPath(info.cellType, info.rasterExtent, targetExtent)
     }
 
-  def cache(c: Cache[String]) = 
+  def cache(c: Cache[String]) =
     c.insert(info.id.toString, Filesystem.slurp(rasterPath))
 
   private def getReader = new AsciiReader(rasterPath, noDataValue)

--- a/engine/src/main/scala/geotrellis/engine/AsciiRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/AsciiRasterLayer.scala
@@ -25,7 +25,7 @@ import geotrellis.vector.Extent
 import java.io.{File, BufferedReader}
 import com.typesafe.config.Config
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object AsciiRasterLayerBuilder
 extends RasterLayerBuilder {
   val intRe = """^(-?[0-9]+)$""".r
@@ -152,7 +152,7 @@ extends RasterLayerBuilder {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class AsciiRasterLayer(info: RasterLayerInfo, noDataValue: Int, rasterPath: String)
 extends UntiledRasterLayer(info) {
   private var cached = false

--- a/engine/src/main/scala/geotrellis/engine/Cache.scala
+++ b/engine/src/main/scala/geotrellis/engine/Cache.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/Cache.scala
+++ b/engine/src/main/scala/geotrellis/engine/Cache.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable
 /**
  * Trait for a T-keyed, any valued cache.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait Cache[T] extends Serializable {
   /** Lookup the value for key k
    * @return Some(v) if the value was cached, None otherwise
@@ -57,7 +57,7 @@ trait Cache[T] extends Serializable {
 /**
  * Simple HashMap backed cache keyed by String and can hold any type.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class HashCache[T] extends Cache[T] {
   val cache = new mutable.HashMap[T,Any].empty
 

--- a/engine/src/main/scala/geotrellis/engine/Cache.scala
+++ b/engine/src/main/scala/geotrellis/engine/Cache.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable
 /**
  * Trait for a T-keyed, any valued cache.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait Cache[T] extends Serializable {
   /** Lookup the value for key k
    * @return Some(v) if the value was cached, None otherwise
@@ -56,6 +57,7 @@ trait Cache[T] extends Serializable {
 /**
  * Simple HashMap backed cache keyed by String and can hold any type.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class HashCache[T] extends Cache[T] {
   val cache = new mutable.HashMap[T,Any].empty
 

--- a/engine/src/main/scala/geotrellis/engine/Catalog.scala
+++ b/engine/src/main/scala/geotrellis/engine/Catalog.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -66,7 +66,7 @@ case class Catalog(name:String, stores:Map[String, DataStore], json: String,sour
 
   def getRasterLayer(layerId:LayerId):Try[RasterLayer] =
     layerId.store match {
-      case Some(ds) => 
+      case Some(ds) =>
         stores.get(ds) match {
           case Some(store) =>
             store.getRasterLayer(layerId.name) match {
@@ -75,7 +75,7 @@ case class Catalog(name:String, stores:Map[String, DataStore], json: String,sour
             }
           case None => Failure(new java.io.IOException(s"No store with name $ds exists in the catalog."))
         }
-      case None => 
+      case None =>
         stores.values.flatMap(_.getRasterLayer(layerId.name)).toList match {
           case Nil => Failure(new java.io.IOException(s"No raster with name ${layerId.name} exists in the catalog."))
           case layer :: Nil => Success(layer)
@@ -107,7 +107,7 @@ case class Catalog(name:String, stores:Map[String, DataStore], json: String,sour
 }
 
 object Catalog {
-  private val stringToRasterLayerBuilder = 
+  private val stringToRasterLayerBuilder =
     mutable.Map[String,RasterLayerBuilder](
       "constant" -> ConstantRasterLayerBuilder,
       "ascii" -> AsciiRasterLayerBuilder,
@@ -123,7 +123,7 @@ object Catalog {
       stringToRasterLayerBuilder(layerType) = builder
     }
 
-  def getRasterLayerBuilder(layerType:String):Option[RasterLayerBuilder] = 
+  def getRasterLayerBuilder(layerType:String):Option[RasterLayerBuilder] =
     if(stringToRasterLayerBuilder.contains(layerType)) {
       Some(stringToRasterLayerBuilder(layerType))
     } else {
@@ -141,7 +141,7 @@ object Catalog {
   /**
    * Build a Catalog instance given a string of JSON data.
    */
-  def fromJSON(data:String,path:String): Catalog = 
+  def fromJSON(data:String,path:String): Catalog =
     json.CatalogParser(data,path).create(data,path)
 
   /**

--- a/engine/src/main/scala/geotrellis/engine/Catalog.scala
+++ b/engine/src/main/scala/geotrellis/engine/Catalog.scala
@@ -34,6 +34,7 @@ import scala.util._
  * Represents a named collection of data stores. We expect each JSON file to
  * correspond to one catalog.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class Catalog(name:String, stores:Map[String, DataStore], json: String,source: String) {
 
   private var cacheSet = false
@@ -106,6 +107,7 @@ case class Catalog(name:String, stores:Map[String, DataStore], json: String,sour
   def getStore(name:String) = stores.get(name)
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object Catalog {
   private val stringToRasterLayerBuilder =
     mutable.Map[String,RasterLayerBuilder](

--- a/engine/src/main/scala/geotrellis/engine/Catalog.scala
+++ b/engine/src/main/scala/geotrellis/engine/Catalog.scala
@@ -34,7 +34,7 @@ import scala.util._
  * Represents a named collection of data stores. We expect each JSON file to
  * correspond to one catalog.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class Catalog(name:String, stores:Map[String, DataStore], json: String,source: String) {
 
   private var cacheSet = false
@@ -107,7 +107,7 @@ case class Catalog(name:String, stores:Map[String, DataStore], json: String,sour
   def getStore(name:String) = stores.get(name)
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object Catalog {
   private val stringToRasterLayerBuilder =
     mutable.Map[String,RasterLayerBuilder](

--- a/engine/src/main/scala/geotrellis/engine/ConstantRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ConstantRasterLayer.scala
@@ -21,7 +21,7 @@ import geotrellis.raster._
 
 import com.typesafe.config.Config
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object ConstantRasterLayerBuilder extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
     val cols = json.getInt("cols")

--- a/engine/src/main/scala/geotrellis/engine/ConstantRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ConstantRasterLayer.scala
@@ -21,6 +21,7 @@ import geotrellis.raster._
 
 import com.typesafe.config.Config
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object ConstantRasterLayerBuilder extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
     val cols = json.getInt("cols")
@@ -47,7 +48,6 @@ object ConstantRasterLayerBuilder extends RasterLayerBuilder {
     }
   }
 }
-
 
 class IntConstantLayer(info: RasterLayerInfo, value: Int)
 extends UntiledRasterLayer(info) {

--- a/engine/src/main/scala/geotrellis/engine/ConstantRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ConstantRasterLayer.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@ object ConstantRasterLayerBuilder extends RasterLayerBuilder {
     val rasterExtent = RasterExtent(getExtent(json), cellWidth, cellHeight, cols, rows)
 
     val cellType = getCellType(json)
-    val info = 
+    val info =
       RasterLayerInfo(
         LayerId(ds, getName(json)),
         getCellType(json),
@@ -48,7 +48,8 @@ object ConstantRasterLayerBuilder extends RasterLayerBuilder {
   }
 }
 
-class IntConstantLayer(info: RasterLayerInfo, value: Int) 
+
+class IntConstantLayer(info: RasterLayerInfo, value: Int)
 extends UntiledRasterLayer(info) {
   def getRaster(targetExtent: Option[RasterExtent] = None) = {
     val re = targetExtent match {
@@ -61,7 +62,7 @@ extends UntiledRasterLayer(info) {
   def cache(c: Cache[String]) = {} // No-op
 }
 
-class DoubleConstantLayer(info: RasterLayerInfo, value: Double) 
+class DoubleConstantLayer(info: RasterLayerInfo, value: Double)
 extends UntiledRasterLayer(info) {
   def getRaster(targetExtent: Option[RasterExtent]) = {
     val re = targetExtent match {
@@ -73,4 +74,3 @@ extends UntiledRasterLayer(info) {
 
   def cache(c: Cache[String]) = {} // No-op
 }
-

--- a/engine/src/main/scala/geotrellis/engine/DataSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/DataSource.scala
@@ -24,6 +24,7 @@ import scala.language.higherKinds
  * DataSource[T, V]esents a data source that may be distributed across machines (logical data source)
  * or loaded in memory on a specific machine.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait DataSource[T, +V] extends OpSource[V] {
   type Self <: DataSource[T, V]
 
@@ -137,6 +138,7 @@ trait DataSource[T, +V] extends OpSource[V] {
   def cached(implicit engine: Engine): Self
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object DataSource {
   def convergeSeq[A](elementOps: (Op[Seq[Op[A]]])) =
     logic.Collect(elementOps)

--- a/engine/src/main/scala/geotrellis/engine/DataSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/DataSource.scala
@@ -24,7 +24,7 @@ import scala.language.higherKinds
  * DataSource[T, V]esents a data source that may be distributed across machines (logical data source)
  * or loaded in memory on a specific machine.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait DataSource[T, +V] extends OpSource[V] {
   type Self <: DataSource[T, V]
 
@@ -138,7 +138,7 @@ trait DataSource[T, +V] extends OpSource[V] {
   def cached(implicit engine: Engine): Self
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object DataSource {
   def convergeSeq[A](elementOps: (Op[Seq[Op[A]]])) =
     logic.Collect(elementOps)

--- a/engine/src/main/scala/geotrellis/engine/DataStore.scala
+++ b/engine/src/main/scala/geotrellis/engine/DataStore.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/DataStore.scala
+++ b/engine/src/main/scala/geotrellis/engine/DataStore.scala
@@ -26,7 +26,7 @@ import scala.util._
  * Represents a location where data can be loaded from (e.g. the filesystem,
  * postgis, a web service, etc).
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class DataStore(name:String, path:String, hasCacheAll:Boolean) {
 
   private val layers = mutable.Map.empty[String, RasterLayer]

--- a/engine/src/main/scala/geotrellis/engine/DataStore.scala
+++ b/engine/src/main/scala/geotrellis/engine/DataStore.scala
@@ -26,6 +26,7 @@ import scala.util._
  * Represents a location where data can be loaded from (e.g. the filesystem,
  * postgis, a web service, etc).
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class DataStore(name:String, path:String, hasCacheAll:Boolean) {
 
   private val layers = mutable.Map.empty[String, RasterLayer]

--- a/engine/src/main/scala/geotrellis/engine/Engine.scala
+++ b/engine/src/main/scala/geotrellis/engine/Engine.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,7 +48,7 @@ class Engine(id: String, val catalog: Catalog) extends Serializable {
 
   def startUp: Unit = ()
 
-  def shutdown(): Unit = { 
+  def shutdown(): Unit = {
     Engine.actorSystem.shutdown()
     Engine.actorSystem.awaitTermination()
   }
@@ -56,8 +56,8 @@ class Engine(id: String, val catalog: Catalog) extends Serializable {
   private val routers = mutable.Map[String, ActorRef]()
   def getRouter(): ActorRef = getRouter("clusterRouter")
   def getRouter(routerName: String): ActorRef = {
-    if(!routers.contains(routerName)) { 
-      routers(routerName) = 
+    if(!routers.contains(routerName)) {
+      routers(routerName) =
         system.actorOf(
           Props.empty.withRouter(FromConfig),
           name = routerName)
@@ -74,8 +74,8 @@ class Engine(id: String, val catalog: Catalog) extends Serializable {
         println(s"Operation Error. Trace: $trace")
         sys.error(msg)
     }
-  
-  def get[T](op: Op[T]): T = 
+
+  def get[T](op: Op[T]): T =
     run(op) match {
       case Complete(value, _) => value
       case Error(msg, trace) =>
@@ -86,7 +86,7 @@ class Engine(id: String, val catalog: Catalog) extends Serializable {
   def run[T](src: OpSource[T]): OperationResult[T] =
     run(src.convergeOp)
 
-  def run[T](op: Op[T]): OperationResult[T] = 
+  def run[T](op: Op[T]): OperationResult[T] =
     _run(op)
 
   def layerExists(layerId: LayerId): Boolean = catalog.layerExists(layerId)
@@ -97,7 +97,7 @@ class Engine(id: String, val catalog: Catalog) extends Serializable {
 
     val d = Duration.create(60000, TimeUnit.SECONDS)
     implicit val t = Timeout(d)
-    val future = 
+    val future =
         (actor ? Run(op)).mapTo[PositionedResult[T]]
 
     val result = Await.result(future, d)
@@ -120,6 +120,6 @@ object Engine {
   def startActorSystem {
     if (actorSystem.isTerminated) {
       actorSystem = akka.actor.ActorSystem("GeoTrellis", ConfigFactory.load())
-    } 
+    }
   }
 }

--- a/engine/src/main/scala/geotrellis/engine/Engine.scala
+++ b/engine/src/main/scala/geotrellis/engine/Engine.scala
@@ -32,7 +32,7 @@ import com.typesafe.config.ConfigFactory
 
 import scala.collection.mutable
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class Engine(id: String, val catalog: Catalog) extends Serializable {
   val debug = false
 
@@ -111,7 +111,7 @@ class Engine(id: String, val catalog: Catalog) extends Serializable {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object Engine {
   def apply(id: String, path: String) = new Engine(id, Catalog.fromPath(path))
   def apply(id: String, catalog: Catalog) = new Engine(id, catalog)

--- a/engine/src/main/scala/geotrellis/engine/Engine.scala
+++ b/engine/src/main/scala/geotrellis/engine/Engine.scala
@@ -32,6 +32,7 @@ import com.typesafe.config.ConfigFactory
 
 import scala.collection.mutable
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class Engine(id: String, val catalog: Catalog) extends Serializable {
   val debug = false
 
@@ -110,6 +111,7 @@ class Engine(id: String, val catalog: Catalog) extends Serializable {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object Engine {
   def apply(id: String, path: String) = new Engine(id, Catalog.fromPath(path))
   def apply(id: String, catalog: Catalog) = new Engine(id, catalog)

--- a/engine/src/main/scala/geotrellis/engine/GeoTrellis.scala
+++ b/engine/src/main/scala/geotrellis/engine/GeoTrellis.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -66,8 +66,8 @@ object GeoTrellis {
   }
 
   def shutdown() = {
-    if(_engine != null) { 
-      _engine.shutdown() 
+    if(_engine != null) {
+      _engine.shutdown()
       _engine = null
     }
   }

--- a/engine/src/main/scala/geotrellis/engine/GeoTrellis.scala
+++ b/engine/src/main/scala/geotrellis/engine/GeoTrellis.scala
@@ -19,6 +19,7 @@ package geotrellis.engine
 import geotrellis.engine._
 import geotrellis.raster._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object GeoTrellis {
   private var _engine: Engine = null
   def engine = {

--- a/engine/src/main/scala/geotrellis/engine/GeoTrellis.scala
+++ b/engine/src/main/scala/geotrellis/engine/GeoTrellis.scala
@@ -19,7 +19,7 @@ package geotrellis.engine
 import geotrellis.engine._
 import geotrellis.raster._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object GeoTrellis {
   private var _engine: Engine = null
   def engine = {

--- a/engine/src/main/scala/geotrellis/engine/History.scala
+++ b/engine/src/main/scala/geotrellis/engine/History.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable
 
 import geotrellis._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object TreeChars {
   val DOWN_OUT = "├"
   val OUT_DOWN = "┬"
@@ -30,6 +31,7 @@ object TreeChars {
   val DOWN = "│"
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object History {
   def apply(op:Op[_]) =
     new History(op.opId,Nil,None,System.currentTimeMillis,0)
@@ -43,16 +45,20 @@ object History {
   implicit def historyToString(h:History) = h.toString
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 abstract sealed trait HistoryResult {
   def toJson:String
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class SuccessHistory(value:String) extends HistoryResult {
   def toJson() = {
     val escapedVal = value.replace(""""""","""\"""")
     s"""{ "type" : "success", "value" : "$escapedVal" }"""
   }
 }
+
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class FailureHistory(msg:String,trace:String) extends HistoryResult {
   def toJson() = {
     val escapedMsg = msg.replace(""""""","""\"""")
@@ -61,6 +67,7 @@ case class FailureHistory(msg:String,trace:String) extends HistoryResult {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class History(id:String,
                    steps:List[StepHistory],
                    result:Option[HistoryResult],
@@ -171,6 +178,7 @@ case class History(id:String,
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class StepHistory(opHistories:List[History]) {
   override
   def toString:String =

--- a/engine/src/main/scala/geotrellis/engine/History.scala
+++ b/engine/src/main/scala/geotrellis/engine/History.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable
 
 import geotrellis._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object TreeChars {
   val DOWN_OUT = "├"
   val OUT_DOWN = "┬"
@@ -31,7 +31,7 @@ object TreeChars {
   val DOWN = "│"
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object History {
   def apply(op:Op[_]) =
     new History(op.opId,Nil,None,System.currentTimeMillis,0)
@@ -45,12 +45,12 @@ object History {
   implicit def historyToString(h:History) = h.toString
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 abstract sealed trait HistoryResult {
   def toJson:String
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class SuccessHistory(value:String) extends HistoryResult {
   def toJson() = {
     val escapedVal = value.replace(""""""","""\"""")
@@ -58,7 +58,7 @@ case class SuccessHistory(value:String) extends HistoryResult {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class FailureHistory(msg:String,trace:String) extends HistoryResult {
   def toJson() = {
     val escapedMsg = msg.replace(""""""","""\"""")
@@ -67,7 +67,7 @@ case class FailureHistory(msg:String,trace:String) extends HistoryResult {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class History(id:String,
                    steps:List[StepHistory],
                    result:Option[HistoryResult],
@@ -178,7 +178,7 @@ case class History(id:String,
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class StepHistory(opHistories:List[History]) {
   override
   def toString:String =

--- a/engine/src/main/scala/geotrellis/engine/History.scala
+++ b/engine/src/main/scala/geotrellis/engine/History.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,7 @@ object History {
   implicit def historyToString(h:History) = h.toString
 }
 
-abstract sealed trait HistoryResult { 
+abstract sealed trait HistoryResult {
   def toJson:String
 }
 
@@ -71,13 +71,13 @@ case class History(id:String,
 
   def withResult[T](value:T,forced:Boolean = false) = {
     val now = System.currentTimeMillis
-    val resultString = 
+    val resultString =
       value match {
         case null => "null"
         case s:String => s""""$s""""
         case i:Int => s"""$i"""
         case d:Double => s"""$d"""
-        case v:Vector[_] => 
+        case v:Vector[_] =>
           val sb = new StringBuilder
           sb.append("Vector(")
           val len = v.length
@@ -87,7 +87,7 @@ case class History(id:String,
           }
           sb.append(")")
           sb.toString
-        case l:List[_] => 
+        case l:List[_] =>
           val sb = new StringBuilder
           sb.append("List(")
           val len = l.length
@@ -100,7 +100,7 @@ case class History(id:String,
         case _ => value.getClass.getSimpleName
       }
 
-    val s = 
+    val s =
       if(forced) { resultString + " [Forced]" }
       else { resultString }
 
@@ -119,7 +119,7 @@ case class History(id:String,
     new History(id,StepHistory(stepHistorys) :: steps,result,startTime,endTime,system)
 
   override
-  def toString:String = 
+  def toString:String =
     toString("",false)
 
   def toString(indentString:String,initialIndent:Boolean,includeSystem:Boolean=true):String = {
@@ -141,7 +141,7 @@ case class History(id:String,
     sb.append("Result: ")
     sb.append(result match {
       case Some(SuccessHistory(s)) => s"$s (in ${endTime - startTime} ms)"
-      case Some(FailureHistory(msg,trace)) => 
+      case Some(FailureHistory(msg,trace)) =>
         s"ERROR: $msg (in $elapsedTime ms): \n" + trace + "\n"
       case None => "No Result"
     })
@@ -158,7 +158,7 @@ case class History(id:String,
       case None => """{ "type" : "none" }"""
     }
     val orderedSteps = steps.reverse.toList
-    val stepsJson = 
+    val stepsJson =
       (for(i <- 0 until orderedSteps.length) yield {
         orderedSteps(i).toJson(i)
       }).mkString(",")
@@ -188,14 +188,14 @@ case class StepHistory(opHistories:List[History]) {
     for(i <- 0 until len) {
       if(i == 0 && len == 1) {
         sb.append(opIndentString + (TreeChars.OUT * 2))
-      } else if(i == len - 1) { 
+      } else if(i == len - 1) {
         sb.append(lastOpIndentString)
       } else if(i == 0) {
-        sb.append(firstOpIndentString) 
-      } else { 
-        sb.append(otherOpIndentString) 
+        sb.append(firstOpIndentString)
+      } else {
+        sb.append(otherOpIndentString)
       }
-      val ins = 
+      val ins =
         if(i == len - 1) { indentString + (" " * 2) }
         else { betweenIndentString }
       sb.append(opHistories(i).toString(ins,false))

--- a/engine/src/main/scala/geotrellis/engine/LayerId.scala
+++ b/engine/src/main/scala/geotrellis/engine/LayerId.scala
@@ -22,8 +22,10 @@ package geotrellis.engine
   * tyring to load that layer without specifying a datastore will
   * error.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LayerId(store:Option[String],name:String)
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object LayerId {
   /** Create a LayerId with no data store specified */
   def apply(name:String):LayerId =

--- a/engine/src/main/scala/geotrellis/engine/LayerId.scala
+++ b/engine/src/main/scala/geotrellis/engine/LayerId.scala
@@ -22,10 +22,10 @@ package geotrellis.engine
   * tyring to load that layer without specifying a datastore will
   * error.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LayerId(store:Option[String],name:String)
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object LayerId {
   /** Create a LayerId with no data store specified */
   def apply(name:String):LayerId =

--- a/engine/src/main/scala/geotrellis/engine/LayerId.scala
+++ b/engine/src/main/scala/geotrellis/engine/LayerId.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,11 +26,11 @@ case class LayerId(store:Option[String],name:String)
 
 object LayerId {
   /** Create a LayerId with no data store specified */
-  def apply(name:String):LayerId = 
+  def apply(name:String):LayerId =
     LayerId(None,name)
 
   /** Create a LayerId with a data store specified */
-  def apply(store:String,name:String):LayerId = 
+  def apply(store:String,name:String):LayerId =
     LayerId(Some(store),name)
 
   /** LayerId for in-memory rasters */

--- a/engine/src/main/scala/geotrellis/engine/LayerLoader.scala
+++ b/engine/src/main/scala/geotrellis/engine/LayerLoader.scala
@@ -24,7 +24,7 @@ import scala.util._
   * mix in the LayerOp trait right before 'run' is called
   * on the operation step and cleared afterwards.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class LayerLoader(engine:Engine) {
   /**
    * Clients can call the raster path loading functions

--- a/engine/src/main/scala/geotrellis/engine/LayerLoader.scala
+++ b/engine/src/main/scala/geotrellis/engine/LayerLoader.scala
@@ -24,6 +24,7 @@ import scala.util._
   * mix in the LayerOp trait right before 'run' is called
   * on the operation step and cleared afterwards.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class LayerLoader(engine:Engine) {
   /**
    * Clients can call the raster path loading functions

--- a/engine/src/main/scala/geotrellis/engine/LayerLoader.scala
+++ b/engine/src/main/scala/geotrellis/engine/LayerLoader.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,7 +63,7 @@ class LayerLoader(engine:Engine) {
   /**
    * Load RasterLayer from the catalog from a url.
    */
-  def getRasterLayerFromUrl(url:String):RasterLayer = 
+  def getRasterLayerFromUrl(url:String):RasterLayer =
     RasterLayer.fromUrl(url) match {
       case Success(layer) => layer
       case Failure(e) => throw e

--- a/engine/src/main/scala/geotrellis/engine/Literal.scala
+++ b/engine/src/main/scala/geotrellis/engine/Literal.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/Literal.scala
+++ b/engine/src/main/scala/geotrellis/engine/Literal.scala
@@ -21,8 +21,8 @@ import geotrellis.engine._
 /**
  * Return the literal value specified.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class Literal[+A](val value: A) extends Op[A] {
   val nextSteps: Steps[A] = { case _ => Result(value) }
   def _run() = Result(value)
 }
-

--- a/engine/src/main/scala/geotrellis/engine/Literal.scala
+++ b/engine/src/main/scala/geotrellis/engine/Literal.scala
@@ -21,7 +21,7 @@ import geotrellis.engine._
 /**
  * Return the literal value specified.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class Literal[+A](val value: A) extends Op[A] {
   val nextSteps: Steps[A] = { case _ => Result(value) }
   def _run() = Result(value)

--- a/engine/src/main/scala/geotrellis/engine/OpSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/OpSource.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/OpSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/OpSource.scala
@@ -18,7 +18,7 @@ package geotrellis.engine
 
 import scala.language.higherKinds
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait OpSource[+V] {
   private[geotrellis] def convergeOp(): Op[V]
 

--- a/engine/src/main/scala/geotrellis/engine/OpSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/OpSource.scala
@@ -18,6 +18,7 @@ package geotrellis.engine
 
 import scala.language.higherKinds
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait OpSource[+V] {
   private[geotrellis] def convergeOp(): Op[V]
 

--- a/engine/src/main/scala/geotrellis/engine/Operation.scala
+++ b/engine/src/main/scala/geotrellis/engine/Operation.scala
@@ -22,6 +22,7 @@ import akka.actor._
 
 import scala.language.implicitConversions
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object Op {
   /**
     * Add simple syntax for creating an operation.
@@ -143,6 +144,7 @@ object Op {
  * Base Operation for all GeoTrellis functionality. All other operations must
  * extend this trait.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 abstract class Operation[+T] extends Product with Serializable {
   val nextSteps: Steps[T]
 
@@ -247,6 +249,7 @@ abstract class Operation[+T] extends Product with Serializable {
  *
  * If the initial operation is g, you can think of this operation as f(g(x))
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class CompositeOperation[+T, U](gOp: Op[U], f: (U) => Op[T]) extends Operation[T] {
   def _run() = runAsync('firstOp :: gOp :: Nil)
 
@@ -256,20 +259,24 @@ case class CompositeOperation[+T, U](gOp: Op[U], f: (U) => Op[T]) extends Operat
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 abstract class OperationWrapper[+T](op: Op[T]) extends Operation[T] {
   def _run() = op._run()
   val nextSteps: Steps[T] = op.nextSteps
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class RemoteOperation[+T](val op: Op[T], cluster: Option[ActorRef])
-extends OperationWrapper(op) {}
+    extends OperationWrapper(op) {}
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object Operation {
   implicit def implicitLiteralVal[A <: AnyVal](a: A)(implicit m: Manifest[A]): Operation[A] = Literal(a)
   implicit def implicitLiteralRef[A <: AnyRef](a: A): Operation[A] = Literal(a)
 }
 
 /** Operation that simply fails with the given message */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class FailOp[T](msg: String) extends Operation[T] {
   def _run() = StepError(msg, "")
   val nextSteps: Steps[T] = { case _ => StepError(msg, "") }
@@ -286,6 +293,7 @@ case class FailOp[T](msg: String) extends Operation[T] {
  * case class Add2(x: Op[Int], y: Op[Int]) extends Op2(x, y)(_ + _)
  */
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class Op0[T](f: ()=>StepOutput[T]) extends Operation[T] {
   def productArity = 0
   def canEqual(other: Any) = other.isInstanceOf[Op0[_]]
@@ -297,6 +305,7 @@ class Op0[T](f: ()=>StepOutput[T]) extends Operation[T] {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class Op1[A, T](a: Op[A])(f: (A)=>StepOutput[T]) extends Operation[T] {
   def _run() = runAsync(List(a))
 
@@ -309,6 +318,7 @@ class Op1[A, T](a: Op[A])(f: (A)=>StepOutput[T]) extends Operation[T] {
   val nextSteps = myNextSteps
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class Op2[A, B, T](a: Op[A], b: Op[B]) (f: (A, B)=>StepOutput[T]) extends Operation[T] {
   def productArity = 2
   def canEqual(other: Any) = other.isInstanceOf[Op2[_, _, _]]
@@ -323,6 +333,7 @@ class Op2[A, B, T](a: Op[A], b: Op[B]) (f: (A, B)=>StepOutput[T]) extends Operat
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class Op3[A, B, C, T](a: Op[A], b: Op[B], c: Op[C])
 (f: (A, B, C)=>StepOutput[T]) extends Operation[T] {
   def productArity = 3
@@ -341,6 +352,7 @@ class Op3[A, B, C, T](a: Op[A], b: Op[B], c: Op[C])
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class Op4[A, B, C, D, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D])
 (f: (A, B, C, D)=>StepOutput[T]) extends Operation[T] {
   def productArity = 4
@@ -361,6 +373,7 @@ class Op4[A, B, C, D, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D])
 
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 abstract class Op5[A, B, C, D, E, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D], e: Op[E])
 (f: (A, B, C, D, E)=>StepOutput[T]) extends Operation[T] {
   def _run() = runAsync(List(a, b, c, d, e))
@@ -372,6 +385,7 @@ abstract class Op5[A, B, C, D, E, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D], e: 
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 abstract class Op6[A, B, C, D, E, F, T]
 (a: Op[A], b: Op[B], c: Op[C], d: Op[D], e: Op[E], f: Op[F])
 (ff: (A, B, C, D, E, F)=>StepOutput[T]) extends Operation[T] {

--- a/engine/src/main/scala/geotrellis/engine/Operation.scala
+++ b/engine/src/main/scala/geotrellis/engine/Operation.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -129,7 +129,7 @@ object Op {
       (Op[A], Op[B], Op[C], Op[D]) => Op4[A, B, C, D, T] =
     (a: Op[A], b: Op[B], c: Op[C], d: Op[D]) => new Op4(a, b, c, d)((a, b, c, d) =>
       StepRequiresAsync(List(f(a, b, c, d)), (l) => Result(l.head.asInstanceOf[T])))
-  
+
   /**
     * Create an operation from a 4-arg function that returns a literal value.
     */
@@ -143,7 +143,7 @@ object Op {
  * Base Operation for all GeoTrellis functionality. All other operations must
  * extend this trait.
  */
-abstract class Operation[+T] extends Product with Serializable {    
+abstract class Operation[+T] extends Product with Serializable {
   val nextSteps: Steps[T]
 
   val debug = false
@@ -157,9 +157,9 @@ abstract class Operation[+T] extends Product with Serializable {
   def withName(n: String): Operation[T] = { _opId += s" ($n)"; this }
 
   protected[geotrellis] def _run(): StepOutput[T]
-  
+
   /**
-   * Execute this operation and return the result.  
+   * Execute this operation and return the result.
    */
   def run(): StepOutput[T] =
     _run()
@@ -198,7 +198,7 @@ abstract class Operation[+T] extends Product with Serializable {
   /**
    * Create a new operation with a function that takes the result of this operation
    * and returns a new operation.
-   * 
+   *
    * Same as flatMap.
    */
   def withResult[U](f: T=>Operation[U]): Operation[U] = flatMap(f)
@@ -212,7 +212,7 @@ abstract class Operation[+T] extends Product with Serializable {
 
   def andThen[U](f: T => Op[U]) = flatMap(f)
 
-  /** 
+  /**
    * Call the given function with this operation as its argument.
    *
    * This is primarily useful for code readability.
@@ -230,7 +230,7 @@ abstract class Operation[+T] extends Product with Serializable {
           sb.append(s"LT{${lit.value}}")
         case op: Operation[_] =>
           sb.append(s"OP{${op.opId}}")
-        case x => 
+        case x =>
           sb.append(s"$x")
       }
       if(i < arity - 1) { sb.append(",") }
@@ -244,16 +244,16 @@ abstract class Operation[+T] extends Product with Serializable {
 /**
  * Given an operation and a function that takes the result of that operation and returns
  * a new operation, return an operation of the return type of the function.
- * 
- * If the initial operation is g, you can think of this operation as f(g(x)) 
+ *
+ * If the initial operation is g, you can think of this operation as f(g(x))
  */
 case class CompositeOperation[+T, U](gOp: Op[U], f: (U) => Op[T]) extends Operation[T] {
   def _run() = runAsync('firstOp :: gOp :: Nil)
 
   val nextSteps: Steps[T] = {
-    case 'firstOp :: u :: Nil => runAsync('result :: f(u.asInstanceOf[U]) :: Nil) 
+    case 'firstOp :: u :: Nil => runAsync('result :: f(u.asInstanceOf[U]) :: Nil)
     case 'result :: t :: Nil => Result(t.asInstanceOf[T])
-  } 
+  }
 }
 
 abstract class OperationWrapper[+T](op: Op[T]) extends Operation[T] {
@@ -318,7 +318,7 @@ class Op2[A, B, T](a: Op[A], b: Op[B]) (f: (A, B)=>StepOutput[T]) extends Operat
     case _ => throw new IndexOutOfBoundsException()
   }
   def _run() = runAsync(List(a, b))
-  val nextSteps: Steps[T] = { 
+  val nextSteps: Steps[T] = {
     case a :: b :: Nil => f(a.asInstanceOf[A], b.asInstanceOf[B])
   }
 }
@@ -334,7 +334,7 @@ class Op3[A, B, C, T](a: Op[A], b: Op[B], c: Op[C])
     case _ => throw new IndexOutOfBoundsException()
   }
   def _run() = runAsync(List(a, b, c))
-  val nextSteps: Steps[T] = { 
+  val nextSteps: Steps[T] = {
     case a :: b :: c :: Nil => {
       f(a.asInstanceOf[A], b.asInstanceOf[B], c.asInstanceOf[C])
     }
@@ -353,7 +353,7 @@ class Op4[A, B, C, D, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D])
     case _ => throw new IndexOutOfBoundsException()
   }
   def _run() = runAsync(List(a, b, c, d))
-  val nextSteps: Steps[T] = { 
+  val nextSteps: Steps[T] = {
     case a :: b :: c :: d :: Nil => {
       f(a.asInstanceOf[A], b.asInstanceOf[B], c.asInstanceOf[C], d.asInstanceOf[D])
     }
@@ -370,7 +370,6 @@ abstract class Op5[A, B, C, D, E, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D], e: 
         d.asInstanceOf[D], e.asInstanceOf[E])
     }
   }
-  
 }
 
 abstract class Op6[A, B, C, D, E, F, T]

--- a/engine/src/main/scala/geotrellis/engine/Operation.scala
+++ b/engine/src/main/scala/geotrellis/engine/Operation.scala
@@ -22,7 +22,7 @@ import akka.actor._
 
 import scala.language.implicitConversions
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object Op {
   /**
     * Add simple syntax for creating an operation.
@@ -144,7 +144,7 @@ object Op {
  * Base Operation for all GeoTrellis functionality. All other operations must
  * extend this trait.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 abstract class Operation[+T] extends Product with Serializable {
   val nextSteps: Steps[T]
 
@@ -249,7 +249,7 @@ abstract class Operation[+T] extends Product with Serializable {
  *
  * If the initial operation is g, you can think of this operation as f(g(x))
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class CompositeOperation[+T, U](gOp: Op[U], f: (U) => Op[T]) extends Operation[T] {
   def _run() = runAsync('firstOp :: gOp :: Nil)
 
@@ -259,24 +259,24 @@ case class CompositeOperation[+T, U](gOp: Op[U], f: (U) => Op[T]) extends Operat
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 abstract class OperationWrapper[+T](op: Op[T]) extends Operation[T] {
   def _run() = op._run()
   val nextSteps: Steps[T] = op.nextSteps
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class RemoteOperation[+T](val op: Op[T], cluster: Option[ActorRef])
     extends OperationWrapper(op) {}
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object Operation {
   implicit def implicitLiteralVal[A <: AnyVal](a: A)(implicit m: Manifest[A]): Operation[A] = Literal(a)
   implicit def implicitLiteralRef[A <: AnyRef](a: A): Operation[A] = Literal(a)
 }
 
 /** Operation that simply fails with the given message */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class FailOp[T](msg: String) extends Operation[T] {
   def _run() = StepError(msg, "")
   val nextSteps: Steps[T] = { case _ => StepError(msg, "") }
@@ -293,7 +293,7 @@ case class FailOp[T](msg: String) extends Operation[T] {
  * case class Add2(x: Op[Int], y: Op[Int]) extends Op2(x, y)(_ + _)
  */
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class Op0[T](f: ()=>StepOutput[T]) extends Operation[T] {
   def productArity = 0
   def canEqual(other: Any) = other.isInstanceOf[Op0[_]]
@@ -305,7 +305,7 @@ class Op0[T](f: ()=>StepOutput[T]) extends Operation[T] {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class Op1[A, T](a: Op[A])(f: (A)=>StepOutput[T]) extends Operation[T] {
   def _run() = runAsync(List(a))
 
@@ -318,7 +318,7 @@ class Op1[A, T](a: Op[A])(f: (A)=>StepOutput[T]) extends Operation[T] {
   val nextSteps = myNextSteps
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class Op2[A, B, T](a: Op[A], b: Op[B]) (f: (A, B)=>StepOutput[T]) extends Operation[T] {
   def productArity = 2
   def canEqual(other: Any) = other.isInstanceOf[Op2[_, _, _]]
@@ -333,7 +333,7 @@ class Op2[A, B, T](a: Op[A], b: Op[B]) (f: (A, B)=>StepOutput[T]) extends Operat
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class Op3[A, B, C, T](a: Op[A], b: Op[B], c: Op[C])
 (f: (A, B, C)=>StepOutput[T]) extends Operation[T] {
   def productArity = 3
@@ -352,7 +352,7 @@ class Op3[A, B, C, T](a: Op[A], b: Op[B], c: Op[C])
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class Op4[A, B, C, D, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D])
 (f: (A, B, C, D)=>StepOutput[T]) extends Operation[T] {
   def productArity = 4
@@ -373,7 +373,7 @@ class Op4[A, B, C, D, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D])
 
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 abstract class Op5[A, B, C, D, E, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D], e: Op[E])
 (f: (A, B, C, D, E)=>StepOutput[T]) extends Operation[T] {
   def _run() = runAsync(List(a, b, c, d, e))
@@ -385,7 +385,7 @@ abstract class Op5[A, B, C, D, E, T](a: Op[A], b: Op[B], c: Op[C], d: Op[D], e: 
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 abstract class Op6[A, B, C, D, E, F, T]
 (a: Op[A], b: Op[B], c: Op[C], d: Op[D], e: Op[E], f: Op[F])
 (ff: (A, B, C, D, E, F)=>StepOutput[T]) extends Operation[T] {

--- a/engine/src/main/scala/geotrellis/engine/OperationResult.scala
+++ b/engine/src/main/scala/geotrellis/engine/OperationResult.scala
@@ -49,11 +49,13 @@ case class Inlined[T](value:T) extends InternalOperationResult[T]
 /**
  * OperationResult for a successful operation.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class Complete[T](value:T, history:History) extends OperationResult[T]
                                                     with InternalOperationResult[T]
 
 /**
  * OperationResult for a failed operation.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class Error(message:String, history:History) extends OperationResult[Nothing]
                                                      with InternalOperationResult[Nothing]

--- a/engine/src/main/scala/geotrellis/engine/OperationResult.scala
+++ b/engine/src/main/scala/geotrellis/engine/OperationResult.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,10 +27,10 @@ sealed trait OperationResult[+T]
 
 /**
  * Internal version to include Inlined;
- * outside match statements shouldn't get warned about 
+ * outside match statements shouldn't get warned about
  * not handling an Inlined case since they should never leak outside.
  */
-private[engine] 
+private[engine]
 sealed trait InternalOperationResult[+T]
 
 /**

--- a/engine/src/main/scala/geotrellis/engine/OperationResult.scala
+++ b/engine/src/main/scala/geotrellis/engine/OperationResult.scala
@@ -49,13 +49,13 @@ case class Inlined[T](value:T) extends InternalOperationResult[T]
 /**
  * OperationResult for a successful operation.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class Complete[T](value:T, history:History) extends OperationResult[T]
                                                     with InternalOperationResult[T]
 
 /**
  * OperationResult for a failed operation.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class Error(message:String, history:History) extends OperationResult[Nothing]
                                                      with InternalOperationResult[Nothing]

--- a/engine/src/main/scala/geotrellis/engine/RasterDefinition.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterDefinition.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/RasterDefinition.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterDefinition.scala
@@ -19,6 +19,7 @@ package geotrellis.engine
 import geotrellis.raster._
 import geotrellis.vector.Extent
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class RasterDefinition(layerId: LayerId,
                             rasterExtent: RasterExtent,
                             tileLayout: TileLayout,
@@ -46,6 +47,7 @@ case class RasterDefinition(layerId: LayerId,
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object RasterDefinition {
   def fromRaster(r: Tile, extent: Extent): RasterDefinition = {
     val rasterExtent = RasterExtent(extent, r.cols, r.rows)

--- a/engine/src/main/scala/geotrellis/engine/RasterDefinition.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterDefinition.scala
@@ -19,7 +19,7 @@ package geotrellis.engine
 import geotrellis.raster._
 import geotrellis.vector.Extent
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class RasterDefinition(layerId: LayerId,
                             rasterExtent: RasterExtent,
                             tileLayout: TileLayout,
@@ -47,7 +47,7 @@ case class RasterDefinition(layerId: LayerId,
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object RasterDefinition {
   def fromRaster(r: Tile, extent: Extent): RasterDefinition = {
     val rasterExtent = RasterExtent(extent, r.cols, r.rows)

--- a/engine/src/main/scala/geotrellis/engine/RasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayer.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,27 +39,27 @@ import java.io.File
 
 /**
  * Represents a Raster Layer that can give detailed information
- * about the Raster it represents, cache the raster, and get the 
+ * about the Raster it represents, cache the raster, and get the
  * raster cropped to an extent or at a different resolution.
- * 
+ *
  * This represents a layer in a bound Context, not an abstract
  * representation of the Raster. In other words, if you are
  * holding one of these objects, then the code that uses it
  * should only execute on the machine that the RasterLayer is
  * from. If you pass around RasterLayers, you will be passing around
  * the cache as well, which is not ideal.
- * 
+ *
  * To implement a new RasterLayer, inherit from this class, implement
  * the cache(c: Cache) method for caching the raster layer, and implement
  * the getRaster() (for getting a Raster with it's native RasterExtent) and
  * getRaster(rasterExtent: RasterExtent) (for getting a Raster at a different
  * extent\resolution). Optionally you can override getRaster(extent: Extent),
- * which by default just creates a RasterExtent with that extent snapped to 
+ * which by default just creates a RasterExtent with that extent snapped to
  * the raster's native resolution.
  */
 abstract class RasterLayer(val info: RasterLayerInfo) {
   private var _cache: Option[Cache[String]] = None
-  protected def getCache = 
+  protected def getCache =
     _cache match {
       case Some(c) => c
       case None =>
@@ -75,7 +75,7 @@ abstract class RasterLayer(val info: RasterLayerInfo) {
 
   def cache(): Unit = {
     _cache match {
-      case Some(c) => 
+      case Some(c) =>
         cache(c)
         _isCached = true
         info.cached = true
@@ -88,7 +88,7 @@ abstract class RasterLayer(val info: RasterLayerInfo) {
   def getRaster(): Tile = getRaster(None)
   def getRaster(targetExtent: Option[RasterExtent]): Tile
 
-  def getRaster(extent: Extent): Tile = 
+  def getRaster(extent: Extent): Tile =
     getRaster(Some(info.rasterExtent.createAlignedRasterExtent(extent)))
 
   def getTile(tileCol: Int, tileRow: Int): Tile = getTile(tileCol, tileRow,None)

--- a/engine/src/main/scala/geotrellis/engine/RasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayer.scala
@@ -57,7 +57,7 @@ import java.io.File
  * which by default just creates a RasterExtent with that extent snapped to
  * the raster's native resolution.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 abstract class RasterLayer(val info: RasterLayerInfo) {
   private var _cache: Option[Cache[String]] = None
   protected def getCache =
@@ -96,13 +96,13 @@ abstract class RasterLayer(val info: RasterLayerInfo) {
   def getTile(tileCol: Int, tileRow: Int, targetExtent: Option[RasterExtent]): Tile
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 abstract class UntiledRasterLayer(info: RasterLayerInfo) extends RasterLayer(info) {
   def getTile(tileCol: Int, tileRow: Int, targetExtent: Option[RasterExtent]) =
     getRaster(targetExtent)
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object RasterLayer {
   /**
    * Build a RasterLayer instance given a path to a JSON file.

--- a/engine/src/main/scala/geotrellis/engine/RasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayer.scala
@@ -57,6 +57,7 @@ import java.io.File
  * which by default just creates a RasterExtent with that extent snapped to
  * the raster's native resolution.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 abstract class RasterLayer(val info: RasterLayerInfo) {
   private var _cache: Option[Cache[String]] = None
   protected def getCache =
@@ -95,11 +96,13 @@ abstract class RasterLayer(val info: RasterLayerInfo) {
   def getTile(tileCol: Int, tileRow: Int, targetExtent: Option[RasterExtent]): Tile
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 abstract class UntiledRasterLayer(info: RasterLayerInfo) extends RasterLayer(info) {
   def getTile(tileCol: Int, tileRow: Int, targetExtent: Option[RasterExtent]) =
     getRaster(targetExtent)
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object RasterLayer {
   /**
    * Build a RasterLayer instance given a path to a JSON file.

--- a/engine/src/main/scala/geotrellis/engine/RasterLayerBuilder.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayerBuilder.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,21 +48,21 @@ trait RasterLayerBuilder {
     (cellWidth, cellHeight)
   }
 
-  def getEpsg(json: Config) = 
+  def getEpsg(json: Config) =
     if(json.hasPath("epsg")) {
       json.getInt("epsg")
     } else {
       3785
     }
 
-  def getXskew(json: Config) = 
+  def getXskew(json: Config) =
     if(json.hasPath("xskew")) {
       json.getDouble("xskew")
     } else {
       0.0
     }
 
-  def getYskew(json: Config) = 
+  def getYskew(json: Config) =
     if(json.hasPath("yskew")) {
       json.getDouble("yskew")
     } else {
@@ -73,7 +73,7 @@ trait RasterLayerBuilder {
     parseType(json.getString("datatype"))
   }
 
-  def getCacheFlag(json: Config): Boolean = 
+  def getCacheFlag(json: Config): Boolean =
     if(json.hasPath("cache")) {
       json.getBoolean("cache")
     } else {

--- a/engine/src/main/scala/geotrellis/engine/RasterLayerBuilder.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayerBuilder.scala
@@ -26,7 +26,7 @@ import com.typesafe.config.Config
  * to GeoTrellis. Also provides some baseline helper functions for getting
  * Information out of the metadata json files.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait RasterLayerBuilder {
   def apply(path: String, json: Config): RasterLayer =
     apply(None, path, json)

--- a/engine/src/main/scala/geotrellis/engine/RasterLayerBuilder.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayerBuilder.scala
@@ -26,6 +26,7 @@ import com.typesafe.config.Config
  * to GeoTrellis. Also provides some baseline helper functions for getting
  * Information out of the metadata json files.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait RasterLayerBuilder {
   def apply(path: String, json: Config): RasterLayer =
     apply(None, path, json)

--- a/engine/src/main/scala/geotrellis/engine/RasterLayerInfo.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayerInfo.scala
@@ -18,7 +18,7 @@ package geotrellis.engine
 
 import geotrellis.raster._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class RasterLayerInfo(id: LayerId,
                            cellType: CellType,
                            rasterExtent: RasterExtent,
@@ -31,7 +31,7 @@ case class RasterLayerInfo(id: LayerId,
 }
 
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object RasterLayerInfo {
   //* For untiled rasters */
   def apply(id: LayerId,

--- a/engine/src/main/scala/geotrellis/engine/RasterLayerInfo.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayerInfo.scala
@@ -18,6 +18,7 @@ package geotrellis.engine
 
 import geotrellis.raster._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class RasterLayerInfo(id: LayerId,
                            cellType: CellType,
                            rasterExtent: RasterExtent,
@@ -30,6 +31,7 @@ case class RasterLayerInfo(id: LayerId,
 }
 
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object RasterLayerInfo {
   //* For untiled rasters */
   def apply(id: LayerId,

--- a/engine/src/main/scala/geotrellis/engine/RasterLayerInfo.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayerInfo.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ case class RasterLayerInfo(id: LayerId,
                            epsg: Int,
                            xskew: Double,
                            yskew: Double,
-			   tileLayout: TileLayout,
+                           tileLayout: TileLayout,
                            shouldCache: Boolean = false) {
   var cached = false
 }

--- a/engine/src/main/scala/geotrellis/engine/RasterLayerType.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayerType.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/RasterLayerType.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayerType.scala
@@ -18,15 +18,15 @@ package geotrellis.engine
 
 import geotrellis._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 abstract class RasterLayerType()
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case object ArgFile extends RasterLayerType
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case object AsciiFile extends RasterLayerType
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case object Tiled extends RasterLayerType
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case object ConstantRaster extends RasterLayerType
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") case object ArgFile extends RasterLayerType
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") case object AsciiFile extends RasterLayerType
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") case object Tiled extends RasterLayerType
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") case object ConstantRaster extends RasterLayerType
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object RasterLayerType {
   implicit def stringToRasterLayerType(s: String) = {
     s match {

--- a/engine/src/main/scala/geotrellis/engine/RasterLayerType.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayerType.scala
@@ -18,13 +18,15 @@ package geotrellis.engine
 
 import geotrellis._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 abstract class RasterLayerType()
 
-case object ArgFile extends RasterLayerType
-case object AsciiFile extends RasterLayerType
-case object Tiled extends RasterLayerType
-case object ConstantRaster extends RasterLayerType
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case object ArgFile extends RasterLayerType
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case object AsciiFile extends RasterLayerType
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case object Tiled extends RasterLayerType
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case object ConstantRaster extends RasterLayerType
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object RasterLayerType {
   implicit def stringToRasterLayerType(s: String) = {
     s match {

--- a/engine/src/main/scala/geotrellis/engine/RasterSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterSource.scala
@@ -29,6 +29,7 @@ import akka.actor.ActorRef
 import spire.syntax.cfor._
 import scala.collection.mutable
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class RasterSource(val rasterDef: Op[RasterDefinition], val tileOps: Op[Seq[Op[Tile]]])
     extends DataSource[Tile, Tile] {
   type Self = RasterSource
@@ -339,6 +340,7 @@ class RasterSource(val rasterDef: Op[RasterDefinition], val tileOps: Op[Seq[Op[T
 
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object RasterSource {
   def fromPath(path: String): RasterSource =
     fromPath(path, None)

--- a/engine/src/main/scala/geotrellis/engine/RasterSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterSource.scala
@@ -29,7 +29,7 @@ import akka.actor.ActorRef
 import spire.syntax.cfor._
 import scala.collection.mutable
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class RasterSource(val rasterDef: Op[RasterDefinition], val tileOps: Op[Seq[Op[Tile]]])
     extends DataSource[Tile, Tile] {
   type Self = RasterSource
@@ -340,7 +340,7 @@ class RasterSource(val rasterDef: Op[RasterDefinition], val tileOps: Op[Seq[Op[T
 
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object RasterSource {
   def fromPath(path: String): RasterSource =
     fromPath(path, None)

--- a/engine/src/main/scala/geotrellis/engine/RasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterSourceMethods.scala
@@ -6,6 +6,7 @@ package geotrellis.engine
   * wraps RasterSource, that extends your Methods trait. See
   * [[geotrellis.engine.op.local.LocalRasterSourceMethods]]
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait RasterSourceMethods {
   val rasterSource: RasterSource
 }

--- a/engine/src/main/scala/geotrellis/engine/RasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterSourceMethods.scala
@@ -6,7 +6,7 @@ package geotrellis.engine
   * wraps RasterSource, that extends your Methods trait. See
   * [[geotrellis.engine.op.local.LocalRasterSourceMethods]]
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait RasterSourceMethods {
   val rasterSource: RasterSource
 }

--- a/engine/src/main/scala/geotrellis/engine/RasterSourceSeqMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterSourceSeqMethods.scala
@@ -6,5 +6,5 @@ package geotrellis.engine
   * wraps Travesable[RasterSourceSeq], that extends your Methods trait. See
   * [[LocalSeqRasterSourceMethods]] and [[geotrellis.raster.op.local.LocalRasterSourceSeqMethodExtensions]]
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait RasterSourceSeqMethods { val rasterSources: Traversable[RasterSource] }

--- a/engine/src/main/scala/geotrellis/engine/RasterSourceSeqMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterSourceSeqMethods.scala
@@ -6,5 +6,5 @@ package geotrellis.engine
   * wraps Travesable[RasterSourceSeq], that extends your Methods trait. See
   * [[LocalSeqRasterSourceMethods]] and [[geotrellis.raster.op.local.LocalRasterSourceSeqMethodExtensions]]
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait RasterSourceSeqMethods { val rasterSources: Traversable[RasterSource] }
-

--- a/engine/src/main/scala/geotrellis/engine/SeqSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/SeqSource.scala
@@ -2,6 +2,7 @@ package geotrellis.engine
 
 import akka.actor.ActorRef
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class SeqSource[T](elements: Op[Seq[Op[T]]]) extends DataSource[T, Seq[T]] {
   type Self = SeqSource[T]
 

--- a/engine/src/main/scala/geotrellis/engine/SeqSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/SeqSource.scala
@@ -2,7 +2,7 @@ package geotrellis.engine
 
 import akka.actor.ActorRef
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class SeqSource[T](elements: Op[Seq[Op[T]]]) extends DataSource[T, Seq[T]] {
   type Self = SeqSource[T]
 

--- a/engine/src/main/scala/geotrellis/engine/StepOutput.scala
+++ b/engine/src/main/scala/geotrellis/engine/StepOutput.scala
@@ -23,12 +23,13 @@ package geotrellis.engine
  */
 sealed trait StepOutput[+T]
 
-case class Result[+T](value: T) extends StepOutput[T]
-case class StepError(msg: String, trace: String) extends StepOutput[Nothing]
-case class StepRequiresAsync[+T](args: Args, cb: Args => StepOutput[T]) extends StepOutput[T]
-case class AndThen[+T](op: Operation[T]) extends StepOutput[T]
-case class LayerResult[+T](loadFunc: LayerLoader => T) extends StepOutput[T]
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class Result[+T](value: T) extends StepOutput[T]
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class StepError(msg: String, trace: String) extends StepOutput[Nothing]
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class StepRequiresAsync[+T](args: Args, cb: Args => StepOutput[T]) extends StepOutput[T]
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class AndThen[+T](op: Operation[T]) extends StepOutput[T]
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class LayerResult[+T](loadFunc: LayerLoader => T) extends StepOutput[T]
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object StepError {
   def fromException(e: Throwable) = {
     val msg = e.getMessage

--- a/engine/src/main/scala/geotrellis/engine/StepOutput.scala
+++ b/engine/src/main/scala/geotrellis/engine/StepOutput.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,10 +29,10 @@ case class StepRequiresAsync[+T](args: Args, cb: Args => StepOutput[T]) extends 
 case class AndThen[+T](op: Operation[T]) extends StepOutput[T]
 case class LayerResult[+T](loadFunc: LayerLoader => T) extends StepOutput[T]
 
-object StepError { 
-  def fromException(e: Throwable) = { 
+object StepError {
+  def fromException(e: Throwable) = {
     val msg = e.getMessage
-    val trace = e.getStackTrace.map(_.toString).mkString("\n") 
-    StepError(msg, trace) 
-  } 
-} 
+    val trace = e.getStackTrace.map(_.toString).mkString("\n")
+    StepError(msg, trace)
+  }
+}

--- a/engine/src/main/scala/geotrellis/engine/StepOutput.scala
+++ b/engine/src/main/scala/geotrellis/engine/StepOutput.scala
@@ -23,13 +23,13 @@ package geotrellis.engine
  */
 sealed trait StepOutput[+T]
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class Result[+T](value: T) extends StepOutput[T]
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class StepError(msg: String, trace: String) extends StepOutput[Nothing]
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class StepRequiresAsync[+T](args: Args, cb: Args => StepOutput[T]) extends StepOutput[T]
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class AndThen[+T](op: Operation[T]) extends StepOutput[T]
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2") case class LayerResult[+T](loadFunc: LayerLoader => T) extends StepOutput[T]
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") case class Result[+T](value: T) extends StepOutput[T]
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") case class StepError(msg: String, trace: String) extends StepOutput[Nothing]
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") case class StepRequiresAsync[+T](args: Args, cb: Args => StepOutput[T]) extends StepOutput[T]
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") case class AndThen[+T](op: Operation[T]) extends StepOutput[T]
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") case class LayerResult[+T](loadFunc: LayerLoader => T) extends StepOutput[T]
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object StepError {
   def fromException(e: Throwable) = {
     val msg = e.getMessage

--- a/engine/src/main/scala/geotrellis/engine/TileNeighbors.scala
+++ b/engine/src/main/scala/geotrellis/engine/TileNeighbors.scala
@@ -21,6 +21,7 @@ import geotrellis.raster._
 import scala.collection.concurrent.Map
 import scala.collection.mutable
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object TileNeighbors {
   val NONE = new TileNeighbors {
     def n: Option[Op[Tile]] = None
@@ -36,6 +37,7 @@ object TileNeighbors {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait TileNeighbors {
   /** North */
   def n: Option[Op[Tile]]
@@ -61,6 +63,7 @@ trait TileNeighbors {
   *  Tile Neighbors that are represented by a sequence of neighboring tiles,
   *  in the order (n, ne, e, se, s, sw, w, nw)
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class SeqTileNeighbors(seq: Seq[Option[Op[Tile]]]) extends TileNeighbors {
   def n = seq(0)
   def ne = seq(1)

--- a/engine/src/main/scala/geotrellis/engine/TileNeighbors.scala
+++ b/engine/src/main/scala/geotrellis/engine/TileNeighbors.scala
@@ -21,7 +21,7 @@ import geotrellis.raster._
 import scala.collection.concurrent.Map
 import scala.collection.mutable
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object TileNeighbors {
   val NONE = new TileNeighbors {
     def n: Option[Op[Tile]] = None
@@ -37,7 +37,7 @@ object TileNeighbors {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait TileNeighbors {
   /** North */
   def n: Option[Op[Tile]]
@@ -63,7 +63,7 @@ trait TileNeighbors {
   *  Tile Neighbors that are represented by a sequence of neighboring tiles,
   *  in the order (n, ne, e, se, s, sw, w, nw)
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class SeqTileNeighbors(seq: Seq[Option[Op[Tile]]]) extends TileNeighbors {
   def n = seq(0)
   def ne = seq(1)

--- a/engine/src/main/scala/geotrellis/engine/TileSetRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/TileSetRasterLayer.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@ import scala.collection.mutable
 object TileSetRasterLayerBuilder
 extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
-    val tileDir = 
+    val tileDir =
       if(json.hasPath("path")) {
         val f = new File(json.getString("path"))
         if(f.isAbsolute) {
@@ -60,7 +60,7 @@ extends RasterLayerBuilder {
       val rasterExtent = RasterExtent(getExtent(json), cw, ch, cols, rows)
       val layout = TileLayout(layoutCols, layoutRows, pixelCols, pixelRows)
 
-      val info = 
+      val info =
         RasterLayerInfo(
           LayerId(ds, getName(json)),
           getCellType(json),
@@ -78,7 +78,7 @@ extends RasterLayerBuilder {
 }
 
 object TileSetRasterLayer {
-  def tileName(id: LayerId, col: Int, row: Int) = 
+  def tileName(id: LayerId, col: Int, row: Int) =
     s"${id}_${col}_${row}"
 
   def tilePath(path: String, id: LayerId, col: Int, row: Int) =
@@ -135,7 +135,7 @@ extends RasterLayer(info) {
           }
         }
         tile
-      case None => 
+      case None =>
         val loader = getTileLoader()
         val tiles = mutable.ListBuffer[Tile]()
         cfor(0)(_ < tileLayout.layoutRows, _ + 1) { row =>
@@ -148,16 +148,16 @@ extends RasterLayer(info) {
   }
 
   override
-  def getRaster(extent: Extent): Tile = 
+  def getRaster(extent: Extent): Tile =
     CroppedTile(getRaster(None), info.rasterExtent.gridBoundsFor(extent))
 
-  def getTile(col: Int, row: Int, targetExtent: Option[RasterExtent]) = 
+  def getTile(col: Int, row: Int, targetExtent: Option[RasterExtent]) =
     getTileLoader().getTile(col, row, targetExtent)
 
   def getTileLoader() =
     if(isCached)
       new CacheTileLoader(info, tileLayout, getCache)
-    else 
+    else
       new DiskTileLoader(info, tileLayout, tileDirPath)
 
   def cache(c: Cache[String]) = {
@@ -180,7 +180,7 @@ abstract class TileLoader(tileSetInfo: RasterLayerInfo,
     val re = RasterExtent(tileExtents(col, row), tileLayout.tileCols, tileLayout.tileRows)
     if(col < 0 || row < 0 ||
        tileLayout.layoutCols <= col || tileLayout.layoutRows <= row) {
-      val tre = 
+      val tre =
         targetExtent match {
           case Some(x) => x
           case None => re
@@ -202,9 +202,9 @@ extends TileLoader(tileSetInfo, tileLayout) {
   def loadRaster(col: Int, row: Int, re: RasterExtent, targetExtent: Option[RasterExtent]): Tile = {
     val path = TileSetRasterLayer.tilePath(tileDirPath, tileSetInfo.id, col, row)
     targetExtent match {
-      case Some(tre) => 
+      case Some(tre) =>
         ArgReader.read(path, tileSetInfo.cellType, re, tre)
-      case None => 
+      case None =>
         ArgReader.read(path, tileSetInfo.cellType, re.cols, re.rows)
     }
 
@@ -219,9 +219,9 @@ extends TileLoader(info, tileLayout) {
     c.lookup[Array[Byte]](TileSetRasterLayer.tileName(info.id, col, row)) match {
       case Some(bytes) =>
         targetExtent match {
-          case Some(tre) => 
+          case Some(tre) =>
             ArgReader.resampleBytes(bytes, info.cellType, re, tre)
-          case None => 
+          case None =>
             ArrayTile.fromBytes(bytes, info.cellType, re.cols, re.rows)
         }
       case None =>

--- a/engine/src/main/scala/geotrellis/engine/TileSetRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/TileSetRasterLayer.scala
@@ -27,7 +27,7 @@ import java.io.File
 import spire.syntax.cfor._
 import scala.collection.mutable
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object TileSetRasterLayerBuilder
 extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
@@ -78,7 +78,7 @@ extends RasterLayerBuilder {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object TileSetRasterLayer {
   def tileName(id: LayerId, col: Int, row: Int) =
     s"${id}_${col}_${row}"
@@ -87,7 +87,7 @@ object TileSetRasterLayer {
     Filesystem.join(path, s"${id.name}_${col}_${row}.arg")
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class TileSetRasterLayer(info: RasterLayerInfo,
                          val tileDirPath: String,
                          val tileLayout: TileLayout)
@@ -173,7 +173,7 @@ extends RasterLayer(info) {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 abstract class TileLoader(tileSetInfo: RasterLayerInfo,
                           tileLayout: TileLayout) extends Serializable {
   val tileExtents = TileExtents(tileSetInfo.rasterExtent.extent, tileLayout)
@@ -199,7 +199,7 @@ abstract class TileLoader(tileSetInfo: RasterLayerInfo,
   protected def loadRaster(col: Int, row: Int, re: RasterExtent, tre: Option[RasterExtent]): Tile
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class DiskTileLoader(tileSetInfo: RasterLayerInfo,
                      tileLayout: TileLayout,
                      tileDirPath: String)
@@ -216,7 +216,7 @@ extends TileLoader(tileSetInfo, tileLayout) {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class CacheTileLoader(info: RasterLayerInfo,
                       tileLayout: TileLayout,
                       c: Cache[String])

--- a/engine/src/main/scala/geotrellis/engine/TileSetRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/TileSetRasterLayer.scala
@@ -27,6 +27,7 @@ import java.io.File
 import spire.syntax.cfor._
 import scala.collection.mutable
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object TileSetRasterLayerBuilder
 extends RasterLayerBuilder {
   def apply(ds: Option[String], jsonPath: String, json: Config): RasterLayer = {
@@ -77,6 +78,7 @@ extends RasterLayerBuilder {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object TileSetRasterLayer {
   def tileName(id: LayerId, col: Int, row: Int) =
     s"${id}_${col}_${row}"
@@ -85,6 +87,7 @@ object TileSetRasterLayer {
     Filesystem.join(path, s"${id.name}_${col}_${row}.arg")
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class TileSetRasterLayer(info: RasterLayerInfo,
                          val tileDirPath: String,
                          val tileLayout: TileLayout)
@@ -170,6 +173,7 @@ extends RasterLayer(info) {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 abstract class TileLoader(tileSetInfo: RasterLayerInfo,
                           tileLayout: TileLayout) extends Serializable {
   val tileExtents = TileExtents(tileSetInfo.rasterExtent.extent, tileLayout)
@@ -195,6 +199,7 @@ abstract class TileLoader(tileSetInfo: RasterLayerInfo,
   protected def loadRaster(col: Int, row: Int, re: RasterExtent, tre: Option[RasterExtent]): Tile
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class DiskTileLoader(tileSetInfo: RasterLayerInfo,
                      tileLayout: TileLayout,
                      tileDirPath: String)
@@ -211,6 +216,7 @@ extends TileLoader(tileSetInfo, tileLayout) {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class CacheTileLoader(info: RasterLayerInfo,
                       tileLayout: TileLayout,
                       c: Cache[String])

--- a/engine/src/main/scala/geotrellis/engine/ValueSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/ValueSource.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/ValueSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/ValueSource.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.engine
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 class ValueSource[+T](val element:Op[T]) extends OpSource[T] {
   def convergeOp() = element
 
@@ -31,6 +32,7 @@ class ValueSource[+T](val element:Op[T]) extends OpSource[T] {
     ValueSource(f(convergeOp,os.convergeOp))
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object ValueSource {
   def apply[T](element:Op[T]):ValueSource[T] = new ValueSource(element)
  }

--- a/engine/src/main/scala/geotrellis/engine/ValueSource.scala
+++ b/engine/src/main/scala/geotrellis/engine/ValueSource.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.engine
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 class ValueSource[+T](val element:Op[T]) extends OpSource[T] {
   def convergeOp() = element
 
@@ -32,7 +32,7 @@ class ValueSource[+T](val element:Op[T]) extends OpSource[T] {
     ValueSource(f(convergeOp,os.convergeOp))
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object ValueSource {
   def apply[T](element:Op[T]):ValueSource[T] = new ValueSource(element)
  }

--- a/engine/src/main/scala/geotrellis/engine/actors/EngineActor.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/EngineActor.scala
@@ -20,7 +20,7 @@ import geotrellis.engine._
 import akka.actor._
 import akka.routing._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class EngineContext(externalId:String,layerLoader:LayerLoader,engineRef:ActorRef)
 
 /**
@@ -33,7 +33,7 @@ case class EngineContext(externalId:String,layerLoader:LayerLoader,engineRef:Act
  * In the first case, we dispatch the message to a pool of workers). In the second
  * case we will spin up a Step Aggregator actor who will handle the message.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class EngineActor(engine: Engine) extends Actor {
   val fullExternalId = context.system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress.toString
   val externalId = if (fullExternalId.startsWith("akka.tcp://GeoTrellis@"))

--- a/engine/src/main/scala/geotrellis/engine/actors/EngineActor.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/EngineActor.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,14 +29,14 @@ case class EngineContext(externalId:String,layerLoader:LayerLoader,engineRef:Act
  *  1. Requests made by the outside world to run operations.
  *  2. Requests made by other actors to asynchronously evaluate arguments.
  *
- * In the first case, we dispatch the message to a pool of workers). In the second 
+ * In the first case, we dispatch the message to a pool of workers). In the second
  * case we will spin up a Step Aggregator actor who will handle the message.
  */
 case class EngineActor(engine: Engine) extends Actor {
   val fullExternalId = context.system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress.toString
-  val externalId = if (fullExternalId.startsWith("akka.tcp://GeoTrellis@")) 
+  val externalId = if (fullExternalId.startsWith("akka.tcp://GeoTrellis@"))
     fullExternalId.substring(22)
-  else 
+  else
     ""
 
   val engineContext = EngineContext(externalId, engine.layerLoader,self)
@@ -48,20 +48,20 @@ case class EngineActor(engine: Engine) extends Actor {
     case Run(op) =>
       val msgSender = sender
       workerPool ! RunOperation(op, 0, msgSender)
- 
-    case RunOperation(op,pos,client) => 
+
+    case RunOperation(op,pos,client) =>
       op match {
-        case Literal(value) => 
+        case Literal(value) =>
           val hist = History(op,engineContext.externalId).withResult(value)
           client ! PositionedResult(Complete(value, hist.withResult(value).withResult(value)), pos)
-        case RemoteOperation(sendOp, None) => 
+        case RemoteOperation(sendOp, None) =>
           engine.getRouter ! RunOperation(sendOp,pos,client)
-        case RemoteOperation(sendOp, Some(cluster)) => 
+        case RemoteOperation(sendOp, Some(cluster)) =>
           cluster ! RunOperation(sendOp,pos,client)
         case _ =>
           workerPool ! RunOperation(op,pos,client)
       }
-    
+
     case RunCallback(args, pos, cb, client, tracker) =>
       context.actorOf(Props(StepAggregator(engineContext, pos, args, cb, client, tracker)))
 

--- a/engine/src/main/scala/geotrellis/engine/actors/EngineActor.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/EngineActor.scala
@@ -20,6 +20,7 @@ import geotrellis.engine._
 import akka.actor._
 import akka.routing._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class EngineContext(externalId:String,layerLoader:LayerLoader,engineRef:ActorRef)
 
 /**
@@ -32,6 +33,7 @@ case class EngineContext(externalId:String,layerLoader:LayerLoader,engineRef:Act
  * In the first case, we dispatch the message to a pool of workers). In the second
  * case we will spin up a Step Aggregator actor who will handle the message.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class EngineActor(engine: Engine) extends Actor {
   val fullExternalId = context.system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress.toString
   val externalId = if (fullExternalId.startsWith("akka.tcp://GeoTrellis@"))

--- a/engine/src/main/scala/geotrellis/engine/actors/ResultHandler.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/ResultHandler.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ import akka.actor._
 
 /**
  * This class contains functionality to handle results from operations,
- * evaluating StepOutput, constructing OperationResults and sending them 
+ * evaluating StepOutput, constructing OperationResults and sending them
  * back to the client.
  */
 private[actors]

--- a/engine/src/main/scala/geotrellis/engine/actors/StepAggregator.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/StepAggregator.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,8 +23,8 @@ import akka.routing._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-/** 
- * A StepAggregator is responsible for executing 
+/**
+ * A StepAggregator is responsible for executing
  * operations in a list of arguments that are returned
  * from a step in an Operation's execution. Each operation
  * is sent to the engine for asynchronous execution.
@@ -33,11 +33,11 @@ import scala.concurrent.duration._
  * is executed and the results are handled by a ResultHandler.
  */
 private[actors]
-case class StepAggregator[T](engineContext:EngineContext, 
-                             pos:Int, 
+case class StepAggregator[T](engineContext:EngineContext,
+                             pos:Int,
                              args:Args,
-                             cb:Callback[T], 
-                             client:ActorRef, 
+                             cb:Callback[T],
+                             client:ActorRef,
                              history:History)
     extends Actor {
 
@@ -63,7 +63,7 @@ case class StepAggregator[T](engineContext:EngineContext,
       }
     }
 
-    if (isDone) { 
+    if (isDone) {
       finishCallback()
       context.stop(self)
     }
@@ -72,7 +72,7 @@ case class StepAggregator[T](engineContext:EngineContext,
   // This should create a list of all the (non-trivial) child histories we
   // have. This leaves out inlined arguments, who don't have history in any
   // real sense (e.g. they were complete when we received them).
-  def childHistories = 
+  def childHistories =
     results.toList.flatMap {
       case Some(Complete(_, t)) => Some(t)
       case Some(Error(_, t)) => Some(t)
@@ -83,7 +83,7 @@ case class StepAggregator[T](engineContext:EngineContext,
   // If any entry in the results array is null, we're not done.
   def isDone = results.find(_ == None).isEmpty
 
-  def error:Option[Error] = 
+  def error:Option[Error] =
     results.flatten
            .filter { case err:Error => true; case _ => false }
            .headOption
@@ -93,7 +93,7 @@ case class StepAggregator[T](engineContext:EngineContext,
   def getValues = results.toList.map {
     case Some(Complete(value, _)) => value
     case Some(Inlined(value)) => value
-    case r => sys.error("found unexpected result (some(error)) ") 
+    case r => sys.error("found unexpected result (some(error)) ")
   }
 
   // This is called when we have heard back from all our sub-operations and

--- a/engine/src/main/scala/geotrellis/engine/actors/Worker.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/Worker.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@ import scala.concurrent.duration._
 
 /**
  * Workers are responsible for evaluating an operation. However, if the
- * operation in question returns a step result that requires asynchronous callbacks, 
+ * operation in question returns a step result that requires asynchronous callbacks,
  * the work will be off-loaded to a StepAggregator.
  *
  * Thus, in practice workers only ever do work on simple operations.
@@ -34,7 +34,7 @@ import scala.concurrent.duration._
 private[actors]
 case class Worker(val engineContext: EngineContext) extends Actor {
   // Workers themselves don't have direct children. If the operation in
-  // question has a step result requiring child operations be executed 
+  // question has a step result requiring child operations be executed
   // asynchronously, it will be processed by a StepAggregator
   // instead, who will be responsible for constructing the response (including
   // history).
@@ -50,7 +50,7 @@ case class Worker(val engineContext: EngineContext) extends Actor {
       } catch {
         case e:Throwable => {
           val error = StepError.fromException(e)
-          System.err.println("Operation failed, with exception: " + 
+          System.err.println("Operation failed, with exception: " +
             s"${e}\n\nStack trace:\n${error.trace}\n", error.msg,error.trace)
           handler.handleResult(error,history)
         }

--- a/engine/src/main/scala/geotrellis/engine/actors/messages.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/messages.scala
@@ -29,7 +29,7 @@ import akka.actor._
  * External message to compute the given operation and return result to sender.
  * Run child operations using default local dispatcher.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class Run(op:Operation[_])
 
 /********************

--- a/engine/src/main/scala/geotrellis/engine/actors/messages.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/messages.scala
@@ -29,6 +29,7 @@ import akka.actor._
  * External message to compute the given operation and return result to sender.
  * Run child operations using default local dispatcher.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class Run(op:Operation[_])
 
 /********************

--- a/engine/src/main/scala/geotrellis/engine/actors/messages.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/messages.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,25 +32,25 @@ import akka.actor._
 case class Run(op:Operation[_])
 
 /********************
- * Internal messages 
+ * Internal messages
  ********************
  */
 
 /**
  * Internal message to run the provided op and send the result to the client.
  */
-private[actors] case class RunOperation[T](op: Operation[T], 
-                                           pos: Int, 
+private[actors] case class RunOperation[T](op: Operation[T],
+                                           pos: Int,
                                            client: ActorRef)
 
 /**
  * Internal message to compute the provided args (if necessary), invoke the
  * provided callback with the computed args, and send the result to the client.
  */
-private[actors] case class RunCallback[T](args:Args, 
-                                           pos:Int, 
-                                           cb:Callback[T], 
-                                           client:ActorRef, 
+private[actors] case class RunCallback[T](args:Args,
+                                           pos:Int,
+                                           cb:Callback[T],
+                                           client:ActorRef,
                                            history:History)
 
 /**

--- a/engine/src/main/scala/geotrellis/engine/actors/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/package.scala
@@ -1,6 +1,6 @@
 package geotrellis.engine
 
 package object actors {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   type Callback[+T] = (List[Any]) => StepOutput[T]
 }

--- a/engine/src/main/scala/geotrellis/engine/actors/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/actors/package.scala
@@ -1,5 +1,6 @@
 package geotrellis.engine
 
 package object actors {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   type Callback[+T] = (List[Any]) => StepOutput[T]
 }

--- a/engine/src/main/scala/geotrellis/engine/config.scala
+++ b/engine/src/main/scala/geotrellis/engine/config.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/config.scala
+++ b/engine/src/main/scala/geotrellis/engine/config.scala
@@ -18,8 +18,10 @@ package geotrellis.engine
 
 import com.typesafe.config.{ConfigFactory,Config}
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class GeoTrellisConfig(catalogPath:Option[String])
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object GeoTrellisConfig {
   def apply():GeoTrellisConfig = apply(ConfigFactory.load())
 

--- a/engine/src/main/scala/geotrellis/engine/config.scala
+++ b/engine/src/main/scala/geotrellis/engine/config.scala
@@ -18,10 +18,10 @@ package geotrellis.engine
 
 import com.typesafe.config.{ConfigFactory,Config}
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class GeoTrellisConfig(catalogPath:Option[String])
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object GeoTrellisConfig {
   def apply():GeoTrellisConfig = apply(ConfigFactory.load())
 

--- a/engine/src/main/scala/geotrellis/engine/io/LoadFile.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadFile.scala
@@ -22,7 +22,7 @@ import geotrellis.engine._
 /**
  * Load the raster data for a particular extent/resolution from the specified file.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadFile(p: Op[String]) extends Operation[Tile] {
   def _run() = runAsync(List(p))
   val nextSteps: Steps[Tile] = {
@@ -36,7 +36,7 @@ case class LoadFile(p: Op[String]) extends Operation[Tile] {
 /**
  * Load the raster data from the specified file, using the RasterExtent provided.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadFileWithRasterExtent(p: Op[String], e: Op[RasterExtent]) extends Operation[Tile] {
   def _run() = runAsync(List(p, e))
   val nextSteps: Steps[Tile] = {
@@ -47,7 +47,7 @@ case class LoadFileWithRasterExtent(p: Op[String], e: Op[RasterExtent]) extends 
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object LoadFile {
   def apply(p: Op[String], e: Op[RasterExtent]) = LoadFileWithRasterExtent(p, e)
 }

--- a/engine/src/main/scala/geotrellis/engine/io/LoadFile.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadFile.scala
@@ -22,6 +22,7 @@ import geotrellis.engine._
 /**
  * Load the raster data for a particular extent/resolution from the specified file.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadFile(p: Op[String]) extends Operation[Tile] {
   def _run() = runAsync(List(p))
   val nextSteps: Steps[Tile] = {
@@ -35,6 +36,7 @@ case class LoadFile(p: Op[String]) extends Operation[Tile] {
 /**
  * Load the raster data from the specified file, using the RasterExtent provided.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadFileWithRasterExtent(p: Op[String], e: Op[RasterExtent]) extends Operation[Tile] {
   def _run() = runAsync(List(p, e))
   val nextSteps: Steps[Tile] = {
@@ -45,6 +47,7 @@ case class LoadFileWithRasterExtent(p: Op[String], e: Op[RasterExtent]) extends 
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object LoadFile {
   def apply(p: Op[String], e: Op[RasterExtent]) = LoadFileWithRasterExtent(p, e)
 }

--- a/engine/src/main/scala/geotrellis/engine/io/LoadFile.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadFile.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,7 +38,7 @@ case class LoadFile(p: Op[String]) extends Operation[Tile] {
 case class LoadFileWithRasterExtent(p: Op[String], e: Op[RasterExtent]) extends Operation[Tile] {
   def _run() = runAsync(List(p, e))
   val nextSteps: Steps[Tile] = {
-    case (path: String) :: (re: RasterExtent) :: Nil => 
+    case (path: String) :: (re: RasterExtent) :: Nil =>
       LayerResult { layerLoader =>
         layerLoader.getRasterLayerFromPath(path).getRaster(Some(re))
       }

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRaster.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRaster.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.io
 import geotrellis.raster._
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object LoadRaster {
   def apply(n: String): LoadRaster =
     LoadRaster(LayerId(n), None)
@@ -37,6 +38,7 @@ object LoadRaster {
  * Load the raster data for a particular extent/resolution for the
  * raster layer in the catalog with name 'n'
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRaster(layerId: Op[LayerId],
                       r: Op[Option[RasterExtent]]) extends Op[Tile] {
   def _run() = runAsync(List(layerId, r))

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRaster.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRaster.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,14 +34,14 @@ object LoadRaster {
 }
 
 /**
- * Load the raster data for a particular extent/resolution for the 
+ * Load the raster data for a particular extent/resolution for the
  * raster layer in the catalog with name 'n'
  */
 case class LoadRaster(layerId: Op[LayerId],
                       r: Op[Option[RasterExtent]]) extends Op[Tile] {
   def _run() = runAsync(List(layerId, r))
   val nextSteps: Steps[Tile] = {
-    case (layerId: LayerId) :: (re: Option[_]) :: Nil => 
+    case (layerId: LayerId) :: (re: Option[_]) :: Nil =>
       LayerResult { layerLoader =>
         layerLoader.getRasterLayer(layerId)
                    .getRaster(re.asInstanceOf[Option[RasterExtent]])

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRaster.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRaster.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.io
 import geotrellis.raster._
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object LoadRaster {
   def apply(n: String): LoadRaster =
     LoadRaster(LayerId(n), None)
@@ -38,7 +38,7 @@ object LoadRaster {
  * Load the raster data for a particular extent/resolution for the
  * raster layer in the catalog with name 'n'
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRaster(layerId: Op[LayerId],
                       r: Op[Option[RasterExtent]]) extends Op[Tile] {
   def _run() = runAsync(List(layerId, r))

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterDefinition.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterDefinition.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.io
 import geotrellis.engine._
 import geotrellis.raster._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object LoadRasterDefinition {
   def apply(n: String): LoadRasterDefinition =
     LoadRasterDefinition(LayerId(n))
@@ -30,6 +31,7 @@ object LoadRasterDefinition {
 /**
   * Load the [[RasterDefinition]] from the raster layer with the specified name.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRasterDefinition(layerId: Op[LayerId]) extends Op[RasterDefinition] {
   def _run() = runAsync(List(layerId))
   val nextSteps: Steps[RasterDefinition] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterDefinition.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterDefinition.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.io
 import geotrellis.engine._
 import geotrellis.raster._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object LoadRasterDefinition {
   def apply(n: String): LoadRasterDefinition =
     LoadRasterDefinition(LayerId(n))
@@ -31,7 +31,7 @@ object LoadRasterDefinition {
 /**
   * Load the [[RasterDefinition]] from the raster layer with the specified name.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRasterDefinition(layerId: Op[LayerId]) extends Op[RasterDefinition] {
   def _run() = runAsync(List(layerId))
   val nextSteps: Steps[RasterDefinition] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterDefinition.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterDefinition.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,7 +33,7 @@ object LoadRasterDefinition {
 case class LoadRasterDefinition(layerId: Op[LayerId]) extends Op[RasterDefinition] {
   def _run() = runAsync(List(layerId))
   val nextSteps: Steps[RasterDefinition] = {
-    case (layerId: LayerId) :: Nil => 
+    case (layerId: LayerId) :: Nil =>
       LayerResult { layerLoader =>
         val info = layerLoader.getRasterLayer(layerId).info
         RasterDefinition(layerId, info.rasterExtent, info.tileLayout, info.cellType)

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterExtentFromFile.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterExtentFromFile.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterExtentFromFile.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterExtentFromFile.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.io
 import geotrellis.raster._
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object LoadRasterExtent {
   def apply(name: String): LoadRasterExtent =
     LoadRasterExtent(LayerId(name))
@@ -29,6 +30,7 @@ object LoadRasterExtent {
 
 /** Load the [[RasterExtent]] from the raster layer with the specified name.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRasterExtent(layerId: Op[LayerId]) extends Op[RasterExtent] {
   def _run() = runAsync(List(layerId))
   val nextSteps: Steps[RasterExtent] = {
@@ -41,6 +43,7 @@ case class LoadRasterExtent(layerId: Op[LayerId]) extends Op[RasterExtent] {
 
 /** Load the [[RasterExtent]] from the raster in the specified file.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRasterExtentFromFile(path: Op[String]) extends Op[RasterExtent] {
   def _run() = runAsync(List(path))
   val nextSteps: Steps[RasterExtent] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterExtentFromFile.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterExtentFromFile.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.io
 import geotrellis.raster._
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object LoadRasterExtent {
   def apply(name: String): LoadRasterExtent =
     LoadRasterExtent(LayerId(name))
@@ -30,7 +30,7 @@ object LoadRasterExtent {
 
 /** Load the [[RasterExtent]] from the raster layer with the specified name.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRasterExtent(layerId: Op[LayerId]) extends Op[RasterExtent] {
   def _run() = runAsync(List(layerId))
   val nextSteps: Steps[RasterExtent] = {
@@ -43,7 +43,7 @@ case class LoadRasterExtent(layerId: Op[LayerId]) extends Op[RasterExtent] {
 
 /** Load the [[RasterExtent]] from the raster in the specified file.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRasterExtentFromFile(path: Op[String]) extends Op[RasterExtent] {
   def _run() = runAsync(List(path))
   val nextSteps: Steps[RasterExtent] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayer.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayer.scala
@@ -18,6 +18,7 @@ package geotrellis.engine.io
 
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object LoadRasterLayer {
   def apply(n: String): LoadRasterLayer =
     LoadRasterLayer(LayerId(n))
@@ -29,6 +30,7 @@ object LoadRasterLayer {
 /**
   * Load the [[RasterLayer]] from the raster layer with the specified name.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRasterLayer(layerId: Op[LayerId]) extends Op[RasterLayer] {
   def _run() = runAsync(List(layerId))
   val nextSteps: Steps[RasterLayer] = {
@@ -42,6 +44,7 @@ case class LoadRasterLayer(layerId: Op[LayerId]) extends Op[RasterLayer] {
 /**
   * Load the [[RasterLayer]] from the raster layer at the specified path.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRasterLayerFromPath(path: Op[String]) extends Op[RasterLayer] {
   def _run() = runAsync(List(path))
   val nextSteps: Steps[RasterLayer] = {
@@ -55,6 +58,7 @@ case class LoadRasterLayerFromPath(path: Op[String]) extends Op[RasterLayer] {
 /**
   * Load the [[RasterLayer]] from the raster layer at the specified URL.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRasterLayerFromUrl(url: Op[String]) extends Op[RasterLayer] {
   def _run() = runAsync(List(url))
   val nextSteps: Steps[RasterLayer] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayer.scala
@@ -18,7 +18,7 @@ package geotrellis.engine.io
 
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object LoadRasterLayer {
   def apply(n: String): LoadRasterLayer =
     LoadRasterLayer(LayerId(n))
@@ -30,7 +30,7 @@ object LoadRasterLayer {
 /**
   * Load the [[RasterLayer]] from the raster layer with the specified name.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRasterLayer(layerId: Op[LayerId]) extends Op[RasterLayer] {
   def _run() = runAsync(List(layerId))
   val nextSteps: Steps[RasterLayer] = {
@@ -44,7 +44,7 @@ case class LoadRasterLayer(layerId: Op[LayerId]) extends Op[RasterLayer] {
 /**
   * Load the [[RasterLayer]] from the raster layer at the specified path.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRasterLayerFromPath(path: Op[String]) extends Op[RasterLayer] {
   def _run() = runAsync(List(path))
   val nextSteps: Steps[RasterLayer] = {
@@ -58,7 +58,7 @@ case class LoadRasterLayerFromPath(path: Op[String]) extends Op[RasterLayer] {
 /**
   * Load the [[RasterLayer]] from the raster layer at the specified URL.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRasterLayerFromUrl(url: Op[String]) extends Op[RasterLayer] {
   def _run() = runAsync(List(url))
   val nextSteps: Steps[RasterLayer] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayerInfo.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayerInfo.scala
@@ -18,6 +18,7 @@ package geotrellis.engine.io
 
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object LoadRasterLayerInfo {
   def apply(n: String): LoadRasterLayerInfo =
     LoadRasterLayerInfo(LayerId(n))
@@ -29,6 +30,7 @@ object LoadRasterLayerInfo {
 /**
   * Load the [[RasterLayerInfo]] from the raster layer with the specified name.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRasterLayerInfo(layerId: Op[LayerId]) extends Op[RasterLayerInfo] {
   def _run() = runAsync(List(layerId))
   val nextSteps: Steps[RasterLayerInfo] = {
@@ -42,6 +44,7 @@ case class LoadRasterLayerInfo(layerId: Op[LayerId]) extends Op[RasterLayerInfo]
 /**
   * Load the [[RasterLayerInfo]] from the raster layer at the specified path.
   */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRasterLayerInfoFromPath(path: Op[String]) extends Op[RasterLayerInfo] {
   def _run() = runAsync(List(path))
   val nextSteps: Steps[RasterLayerInfo] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayerInfo.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayerInfo.scala
@@ -18,7 +18,7 @@ package geotrellis.engine.io
 
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object LoadRasterLayerInfo {
   def apply(n: String): LoadRasterLayerInfo =
     LoadRasterLayerInfo(LayerId(n))
@@ -30,7 +30,7 @@ object LoadRasterLayerInfo {
 /**
   * Load the [[RasterLayerInfo]] from the raster layer with the specified name.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRasterLayerInfo(layerId: Op[LayerId]) extends Op[RasterLayerInfo] {
   def _run() = runAsync(List(layerId))
   val nextSteps: Steps[RasterLayerInfo] = {
@@ -44,7 +44,7 @@ case class LoadRasterLayerInfo(layerId: Op[LayerId]) extends Op[RasterLayerInfo]
 /**
   * Load the [[RasterLayerInfo]] from the raster layer at the specified path.
   */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRasterLayerInfoFromPath(path: Op[String]) extends Op[RasterLayerInfo] {
   def _run() = runAsync(List(path))
   val nextSteps: Steps[RasterLayerInfo] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayerInfo.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterLayerInfo.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,10 +19,10 @@ package geotrellis.engine.io
 import geotrellis.engine._
 
 object LoadRasterLayerInfo {
-  def apply(n: String): LoadRasterLayerInfo = 
+  def apply(n: String): LoadRasterLayerInfo =
     LoadRasterLayerInfo(LayerId(n))
 
-  def apply(ds: String, n: String): LoadRasterLayerInfo = 
+  def apply(ds: String, n: String): LoadRasterLayerInfo =
     LoadRasterLayerInfo(LayerId(ds, n))
 }
 

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterUrl.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterUrl.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterUrl.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterUrl.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.io
 import geotrellis.raster._
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object LoadRasterUrl {
   def apply(url: Op[String]): LoadRasterUrl = LoadRasterUrl(url, None)
 }
@@ -26,6 +27,7 @@ object LoadRasterUrl {
 /**
  * Load the raster from JSON metadata recieved from a URL
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadRasterUrl(url: Op[String], re: Op[Option[RasterExtent]]) extends Operation[Tile] {
   def _run() = runAsync(List(url, re))
   val nextSteps: Steps[Tile] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadRasterUrl.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadRasterUrl.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.io
 import geotrellis.raster._
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object LoadRasterUrl {
   def apply(url: Op[String]): LoadRasterUrl = LoadRasterUrl(url, None)
 }
@@ -27,7 +27,7 @@ object LoadRasterUrl {
 /**
  * Load the raster from JSON metadata recieved from a URL
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadRasterUrl(url: Op[String], re: Op[Option[RasterExtent]]) extends Operation[Tile] {
   def _run() = runAsync(List(url, re))
   val nextSteps: Steps[Tile] = {

--- a/engine/src/main/scala/geotrellis/engine/io/LoadTile.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadTile.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.io
 import geotrellis.raster._
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object LoadTile {
   def apply(n: String, col: Op[Int], row: Op[Int]): LoadTile =
     LoadTile(LayerId(n), col, row, None)
@@ -37,7 +37,7 @@ object LoadTile {
     LoadTile(layerId, col, row, None)
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class LoadTile(layerId: Op[LayerId],
                     col: Op[Int],
                     row: Op[Int],

--- a/engine/src/main/scala/geotrellis/engine/io/LoadTile.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadTile.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,9 +42,9 @@ case class LoadTile(layerId: Op[LayerId],
                     targetExtent: Op[Option[RasterExtent]]) extends Op[Tile] {
   def _run() = runAsync(List(layerId, col, row, targetExtent))
   val nextSteps: Steps[Tile] = {
-    case (layerId: LayerId) :: 
-         (col: Int) :: 
-         (row: Int) :: 
+    case (layerId: LayerId) ::
+         (col: Int) ::
+         (row: Int) ::
          (te: Option[_]) :: Nil =>
       LayerResult { layerLoader =>
         val layer = layerLoader.getRasterLayer(layerId)

--- a/engine/src/main/scala/geotrellis/engine/io/LoadTile.scala
+++ b/engine/src/main/scala/geotrellis/engine/io/LoadTile.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.io
 import geotrellis.raster._
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object LoadTile {
   def apply(n: String, col: Op[Int], row: Op[Int]): LoadTile =
     LoadTile(LayerId(n), col, row, None)
@@ -36,6 +37,7 @@ object LoadTile {
     LoadTile(layerId, col, row, None)
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class LoadTile(layerId: Op[LayerId],
                     col: Op[Int],
                     row: Op[Int],

--- a/engine/src/main/scala/geotrellis/engine/json/CatalogParser.scala
+++ b/engine/src/main/scala/geotrellis/engine/json/CatalogParser.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable
 // example json is available in the geotrellis.engine.catalog tests. please
 // keep it up-to-date with changes you make here.
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object CatalogParser {
   def error(msg:String) = sys.error(s"Invalid json in catalog: $msg")
 

--- a/engine/src/main/scala/geotrellis/engine/json/CatalogParser.scala
+++ b/engine/src/main/scala/geotrellis/engine/json/CatalogParser.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 // example json is available in the geotrellis.engine.catalog tests. please
 // keep it up-to-date with changes you make here.
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object CatalogParser {
   def error(msg:String) = sys.error(s"Invalid json in catalog: $msg")
 

--- a/engine/src/main/scala/geotrellis/engine/json/CatalogParser.scala
+++ b/engine/src/main/scala/geotrellis/engine/json/CatalogParser.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,7 @@ object CatalogParser {
       }
     if(catalog == "") error("Catalog must have a name field 'catalog' be non-empty")
 
-    val storesList = 
+    val storesList =
       try {
         json.getConfigList("stores")
       } catch {
@@ -67,7 +67,7 @@ object CatalogParser {
           error("'store' property must be a string.")
       }
 
-    val paramsConfig = 
+    val paramsConfig =
       try {
         storeConfig.getConfig("params")
       } catch {
@@ -77,7 +77,7 @@ object CatalogParser {
           error("'param' property must be a json object.")
       }
 
-    val params = 
+    val params =
       paramsConfig.root.keys.map { key =>
         val value =
           try {

--- a/engine/src/main/scala/geotrellis/engine/json/RasterLayerParser.scala
+++ b/engine/src/main/scala/geotrellis/engine/json/RasterLayerParser.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/json/RasterLayerParser.scala
+++ b/engine/src/main/scala/geotrellis/engine/json/RasterLayerParser.scala
@@ -21,7 +21,7 @@ import geotrellis.engine._
 
 import com.typesafe.config.ConfigFactory
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object RasterLayerParser {
   def apply(jsonString:String,path:String = "") = {
     val json = ConfigFactory.parseString(jsonString)

--- a/engine/src/main/scala/geotrellis/engine/json/RasterLayerParser.scala
+++ b/engine/src/main/scala/geotrellis/engine/json/RasterLayerParser.scala
@@ -21,6 +21,7 @@ import geotrellis.engine._
 
 import com.typesafe.config.ConfigFactory
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object RasterLayerParser {
   def apply(jsonString:String,path:String = "") = {
     val json = ConfigFactory.parseString(jsonString)

--- a/engine/src/main/scala/geotrellis/engine/json/Rec.scala
+++ b/engine/src/main/scala/geotrellis/engine/json/Rec.scala
@@ -28,12 +28,12 @@ import java.io.File
  * instance of T. Records are also required to have a name (which will be
  * used when building maps out of lists.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait Rec[T] {
   def name: String
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class CatalogRec(catalog:String,
                       stores:List[DataStoreRec]) extends Rec[Catalog] {
   def create(json:String, source:String) =
@@ -41,7 +41,7 @@ case class CatalogRec(catalog:String,
   def name = catalog
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class DataStoreRec(store:String,
                         params:Map[String, String],
                         catalogPath:String) extends Rec[DataStore] {

--- a/engine/src/main/scala/geotrellis/engine/json/Rec.scala
+++ b/engine/src/main/scala/geotrellis/engine/json/Rec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ trait Rec[T] {
 
 case class CatalogRec(catalog:String,
                       stores:List[DataStoreRec]) extends Rec[Catalog] {
-  def create(json:String, source:String) = 
+  def create(json:String, source:String) =
     Catalog(catalog, stores.map(s => s.name -> s.create).toMap, json, source)
   def name = catalog
 }

--- a/engine/src/main/scala/geotrellis/engine/json/Rec.scala
+++ b/engine/src/main/scala/geotrellis/engine/json/Rec.scala
@@ -28,10 +28,12 @@ import java.io.File
  * instance of T. Records are also required to have a name (which will be
  * used when building maps out of lists.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait Rec[T] {
   def name: String
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class CatalogRec(catalog:String,
                       stores:List[DataStoreRec]) extends Rec[Catalog] {
   def create(json:String, source:String) =
@@ -39,6 +41,7 @@ case class CatalogRec(catalog:String,
   def name = catalog
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class DataStoreRec(store:String,
                         params:Map[String, String],
                         catalogPath:String) extends Rec[DataStore] {

--- a/engine/src/main/scala/geotrellis/engine/logic/AsList.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/AsList.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/logic/AsList.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/AsList.scala
@@ -21,6 +21,7 @@ import geotrellis.engine._
 /**
  * Return the result of the input operation as a List.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class AsList[A](x: Op[A]) extends Op1(x)({
     x => Result(List(x))
 })

--- a/engine/src/main/scala/geotrellis/engine/logic/AsList.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/AsList.scala
@@ -21,7 +21,7 @@ import geotrellis.engine._
 /**
  * Return the result of the input operation as a List.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class AsList[A](x: Op[A]) extends Op1(x)({
     x => Result(List(x))
 })

--- a/engine/src/main/scala/geotrellis/engine/logic/Collect.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/Collect.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,19 +19,19 @@ package geotrellis.engine.logic
 import geotrellis.engine._
 
 case class CollectMap[K, V](map: Op[Map[K, Op[V]]]) extends Op[Map[K, V]] {
-  def _run() = runAsync(List('init, map)) 
+  def _run() = runAsync(List('init, map))
   val nextSteps: Steps[Map[K, V]] = {
-    case 'init :: (m: Map[_, _]) :: Nil => 
+    case 'init :: (m: Map[_, _]) :: Nil =>
       val opMap = m.asInstanceOf[Map[K, Op[V]]]
       val l: List[Op[(K, V)]] = opMap.map { case (k, v) => v.map((k, _)) }.toList
       runAsync('eval :: l)
-    case 'eval :: (l: List[_]) => Result(l.asInstanceOf[List[(K, V)]].toMap) 
+    case 'eval :: (l: List[_]) => Result(l.asInstanceOf[List[(K, V)]].toMap)
     case _ => throw new Exception("unexpected stepresult")
   }
 }
 
 object Collect {
-  def apply[K, V](m: Op[Map[K, Op[V]]]): CollectMap[K, V] = 
+  def apply[K, V](m: Op[Map[K, Op[V]]]): CollectMap[K, V] =
     CollectMap(m)
 }
 
@@ -39,15 +39,15 @@ object Collect {
  * Takes a sequence of operations, and returns a Sequence of the results of those operations.
  */
 case class Collect[A](ops: Op[Seq[Op[A]]]) extends Op[Seq[A]] {
-  def _run() = runAsync(List('init, ops)) 
+  def _run() = runAsync(List('init, ops))
   val nextSteps: Steps[Seq[A]] = {
     case 'init :: (opSeq: Seq[_]) :: Nil => runAsync('eval :: opSeq.toList)
-    case 'eval :: (as: List[_]) => Result(as.asInstanceOf[List[A]].toSeq) 
+    case 'eval :: (as: List[_]) => Result(as.asInstanceOf[List[A]].toSeq)
     case _ => throw new Exception("unexpected stepresult")
   }
 }
 
 object CollectArray {
   @deprecated("Use Collect.", "0.9")
-  def apply[A: Manifest](ops: Array[Op[A]]): Op[Array[A]] = Collect(Literal(ops.toSeq)).map( _.toArray ) 
+  def apply[A: Manifest](ops: Array[Op[A]]): Op[Array[A]] = Collect(Literal(ops.toSeq)).map( _.toArray )
 }

--- a/engine/src/main/scala/geotrellis/engine/logic/Collect.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/Collect.scala
@@ -18,7 +18,7 @@ package geotrellis.engine.logic
 
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class CollectMap[K, V](map: Op[Map[K, Op[V]]]) extends Op[Map[K, V]] {
   def _run() = runAsync(List('init, map))
   val nextSteps: Steps[Map[K, V]] = {
@@ -31,7 +31,7 @@ case class CollectMap[K, V](map: Op[Map[K, Op[V]]]) extends Op[Map[K, V]] {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object Collect {
   def apply[K, V](m: Op[Map[K, Op[V]]]): CollectMap[K, V] =
     CollectMap(m)
@@ -40,7 +40,7 @@ object Collect {
 /**
  * Takes a sequence of operations, and returns a Sequence of the results of those operations.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class Collect[A](ops: Op[Seq[Op[A]]]) extends Op[Seq[A]] {
   def _run() = runAsync(List('init, ops))
   val nextSteps: Steps[Seq[A]] = {
@@ -50,7 +50,7 @@ case class Collect[A](ops: Op[Seq[Op[A]]]) extends Op[Seq[A]] {
   }
 }
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object CollectArray {
   @deprecated("Use Collect.", "0.9")
   def apply[A: Manifest](ops: Array[Op[A]]): Op[Array[A]] = Collect(Literal(ops.toSeq)).map( _.toArray )

--- a/engine/src/main/scala/geotrellis/engine/logic/Collect.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/Collect.scala
@@ -18,6 +18,7 @@ package geotrellis.engine.logic
 
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class CollectMap[K, V](map: Op[Map[K, Op[V]]]) extends Op[Map[K, V]] {
   def _run() = runAsync(List('init, map))
   val nextSteps: Steps[Map[K, V]] = {
@@ -30,6 +31,7 @@ case class CollectMap[K, V](map: Op[Map[K, Op[V]]]) extends Op[Map[K, V]] {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object Collect {
   def apply[K, V](m: Op[Map[K, Op[V]]]): CollectMap[K, V] =
     CollectMap(m)
@@ -38,6 +40,7 @@ object Collect {
 /**
  * Takes a sequence of operations, and returns a Sequence of the results of those operations.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class Collect[A](ops: Op[Seq[Op[A]]]) extends Op[Seq[A]] {
   def _run() = runAsync(List('init, ops))
   val nextSteps: Steps[Seq[A]] = {
@@ -47,6 +50,7 @@ case class Collect[A](ops: Op[Seq[Op[A]]]) extends Op[Seq[A]] {
   }
 }
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object CollectArray {
   @deprecated("Use Collect.", "0.9")
   def apply[A: Manifest](ops: Array[Op[A]]): Op[Array[A]] = Collect(Literal(ops.toSeq)).map( _.toArray )

--- a/engine/src/main/scala/geotrellis/engine/logic/Filter.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/Filter.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,10 +21,10 @@ import geotrellis.engine._
 object Filter {
   def apply[A](ops:Op[Seq[A]], condition:(A) => Boolean) = ops.map(_.filter(condition))
 
-  def apply[A:Manifest](opsOp:Op[Seq[A]], condition:(A) => Op[Boolean]):Op[Seq[A]] = 
+  def apply[A:Manifest](opsOp:Op[Seq[A]], condition:(A) => Op[Boolean]):Op[Seq[A]] =
     opsOp.flatMap (
       (seq) => {
-        seq.foldLeft (Literal(Seq[A]()):Operation[Seq[A]]) { 
+        seq.foldLeft (Literal(Seq[A]()):Operation[Seq[A]]) {
           (sum:Op[Seq[A]],v:A) =>
             for( s <- sum;
                  bool <- condition(v) ) yield {

--- a/engine/src/main/scala/geotrellis/engine/logic/Filter.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/Filter.scala
@@ -18,7 +18,7 @@ package geotrellis.engine.logic
 
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object Filter {
   def apply[A](ops:Op[Seq[A]], condition:(A) => Boolean) = ops.map(_.filter(condition))
 

--- a/engine/src/main/scala/geotrellis/engine/logic/Filter.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/Filter.scala
@@ -18,6 +18,7 @@ package geotrellis.engine.logic
 
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object Filter {
   def apply[A](ops:Op[Seq[A]], condition:(A) => Boolean) = ops.map(_.filter(condition))
 

--- a/engine/src/main/scala/geotrellis/engine/logic/ForEach.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/ForEach.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/logic/ForEach.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/ForEach.scala
@@ -20,7 +20,7 @@ import geotrellis.engine._
 
 import scala.{PartialFunction => PF}
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object ForEach {
   def apply[A, Z:Manifest](a:Op[Array[A]])(f:(A) => Op[Z]) = ForEach1(a)(f)
   def apply[A, B, Z:Manifest](a:Op[Array[A]], b:Op[Array[B]])(f:(A, B) => Op[Z]) = ForEach2(a, b)(f)
@@ -32,7 +32,7 @@ object ForEach {
  * the given function (f) to each item in the array in. The resulting array of
  * Z's is returned.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class ForEach1[A, Z:Manifest](op:Op[Array[A]])(f:(A) => Op[Z]) extends Op[Array[Z]] {
 
   def _run() = runAsync(List(op))
@@ -57,7 +57,7 @@ case class ForEach1[A, Z:Manifest](op:Op[Array[A]])(f:(A) => Op[Z]) extends Op[A
  * the arrays (pairwise by array index) to get a Z value. The resulting array
  * of Z's is returned.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class ForEach2[A, B, Z:Manifest](opA:Op[Array[A]], opB:Op[Array[B]])
                                      (f:(A, B) => Op[Z]) extends Op[Array[Z]] {
 
@@ -85,7 +85,7 @@ case class ForEach2[A, B, Z:Manifest](opA:Op[Array[A]], opB:Op[Array[B]])
  * Then, applies the given function (f) to each (A, B, C) triple in (grouped by
  * array index) to get a Z value. The resulting array of Z's is returned.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class ForEach3[A, B, C, Z:Manifest](opA:Op[Array[A]],
                                          opB:Op[Array[B]],
                                          opC:Op[Array[C]])

--- a/engine/src/main/scala/geotrellis/engine/logic/ForEach.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/ForEach.scala
@@ -20,6 +20,7 @@ import geotrellis.engine._
 
 import scala.{PartialFunction => PF}
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object ForEach {
   def apply[A, Z:Manifest](a:Op[Array[A]])(f:(A) => Op[Z]) = ForEach1(a)(f)
   def apply[A, B, Z:Manifest](a:Op[Array[A]], b:Op[Array[B]])(f:(A, B) => Op[Z]) = ForEach2(a, b)(f)
@@ -31,6 +32,7 @@ object ForEach {
  * the given function (f) to each item in the array in. The resulting array of
  * Z's is returned.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class ForEach1[A, Z:Manifest](op:Op[Array[A]])(f:(A) => Op[Z]) extends Op[Array[Z]] {
 
   def _run() = runAsync(List(op))
@@ -55,6 +57,7 @@ case class ForEach1[A, Z:Manifest](op:Op[Array[A]])(f:(A) => Op[Z]) extends Op[A
  * the arrays (pairwise by array index) to get a Z value. The resulting array
  * of Z's is returned.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class ForEach2[A, B, Z:Manifest](opA:Op[Array[A]], opB:Op[Array[B]])
                                      (f:(A, B) => Op[Z]) extends Op[Array[Z]] {
 
@@ -82,6 +85,7 @@ case class ForEach2[A, B, Z:Manifest](opA:Op[Array[A]], opB:Op[Array[B]])
  * Then, applies the given function (f) to each (A, B, C) triple in (grouped by
  * array index) to get a Z value. The resulting array of Z's is returned.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class ForEach3[A, B, C, Z:Manifest](opA:Op[Array[A]],
                                          opB:Op[Array[B]],
                                          opC:Op[Array[C]])

--- a/engine/src/main/scala/geotrellis/engine/logic/If.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/If.scala
@@ -22,6 +22,7 @@ import geotrellis.engine._
  * Conditionally executes one of two operations; if the Boolean Operation evaluates true, the first
  * Operation executes, otherwise the second Operation executes.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class If[A <: C,B <: C,C:Manifest](bOp: Op[Boolean], trueOp: Op[A], falseOp: Op[B])extends Op[C] {
   def _run() = runAsync('init :: bOp :: Nil)
 

--- a/engine/src/main/scala/geotrellis/engine/logic/If.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/If.scala
@@ -22,7 +22,7 @@ import geotrellis.engine._
  * Conditionally executes one of two operations; if the Boolean Operation evaluates true, the first
  * Operation executes, otherwise the second Operation executes.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class If[A <: C,B <: C,C:Manifest](bOp: Op[Boolean], trueOp: Op[A], falseOp: Op[B])extends Op[C] {
   def _run() = runAsync('init :: bOp :: Nil)
 

--- a/engine/src/main/scala/geotrellis/engine/logic/If.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/If.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,7 @@ case class If[A <: C,B <: C,C:Manifest](bOp: Op[Boolean], trueOp: Op[A], falseOp
 
   val nextSteps: Steps[C] = {
     case 'init :: (b: Boolean) :: Nil => runAsync(
-      List('result, 
+      List('result,
            if (b) trueOp else falseOp))
     case 'result :: c :: Nil => Result(c.asInstanceOf[C])
   }

--- a/engine/src/main/scala/geotrellis/engine/logic/MapOp.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/MapOp.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,14 +21,14 @@ import geotrellis.engine._
 object MapOp {
   /**
    * Invoke a function that takes no arguments.
-   * 
+   *
    * See MapOp0.
    */
   def apply[Z](call:() => Z) = MapOp0(call)
 
   /**
    * Invoke a function that takes one argument.
-   * 
+   *
    * See MapOp1.
    */
   def apply[A,Z](a:Op[A])(call:A => Z) = MapOp1(a)(call)
@@ -38,7 +38,7 @@ object MapOp {
    *
    * See MapOp2.
    */
-  def apply[A,B,Z](a:Op[A], b:Op[B])(call:(A,B) => Z) = 
+  def apply[A,B,Z](a:Op[A], b:Op[B])(call:(A,B) => Z) =
     MapOp2(a,b)(call)
 }
 
@@ -55,7 +55,7 @@ case class MapOp0[Z](call:() => Z) extends Op[Z] {
 /**
  * Invoke a function that takes one argument.
  *
- * Functionally speaking: MapOp an Op[A] into an Op[Z] 
+ * Functionally speaking: MapOp an Op[A] into an Op[Z]
  * using a function from A => Z.
  */
 case class MapOp1[A, Z](a:Op[A])(call:A => Z) extends Op[Z] {
@@ -68,7 +68,7 @@ case class MapOp1[A, Z](a:Op[A])(call:A => Z) extends Op[Z] {
 /**
  * Invoke a function that takes two arguments.
  *
- * Functionally speaking: MapOp an Op[A] and Op[B] into an Op[Z] using a 
+ * Functionally speaking: MapOp an Op[A] and Op[B] into an Op[Z] using a
  * function from (A,B) => Z.
  */
 case class MapOp2[A, B, Z]

--- a/engine/src/main/scala/geotrellis/engine/logic/MapOp.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/MapOp.scala
@@ -18,7 +18,7 @@ package geotrellis.engine.logic
 
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object MapOp {
   /**
    * Invoke a function that takes no arguments.
@@ -46,7 +46,7 @@ object MapOp {
 /**
  * Invoke a function that takes no arguments.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class MapOp0[Z](call:() => Z) extends Op[Z] {
   def _run() = Result(call())
   val nextSteps:Steps[Z] = {
@@ -60,7 +60,7 @@ case class MapOp0[Z](call:() => Z) extends Op[Z] {
  * Functionally speaking: MapOp an Op[A] into an Op[Z]
  * using a function from A => Z.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class MapOp1[A, Z](a:Op[A])(call:A => Z) extends Op[Z] {
   def _run() = runAsync(a :: Nil)
   val nextSteps:Steps[Z] = {
@@ -74,7 +74,7 @@ case class MapOp1[A, Z](a:Op[A])(call:A => Z) extends Op[Z] {
  * Functionally speaking: MapOp an Op[A] and Op[B] into an Op[Z] using a
  * function from (A,B) => Z.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class MapOp2[A, B, Z]
 (a:Op[A], b:Op[B])(call:(A,B) => Z) extends Op[Z] {
   def _run() = runAsync(a :: b :: Nil)

--- a/engine/src/main/scala/geotrellis/engine/logic/MapOp.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/MapOp.scala
@@ -18,6 +18,7 @@ package geotrellis.engine.logic
 
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object MapOp {
   /**
    * Invoke a function that takes no arguments.
@@ -45,6 +46,7 @@ object MapOp {
 /**
  * Invoke a function that takes no arguments.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class MapOp0[Z](call:() => Z) extends Op[Z] {
   def _run() = Result(call())
   val nextSteps:Steps[Z] = {
@@ -58,6 +60,7 @@ case class MapOp0[Z](call:() => Z) extends Op[Z] {
  * Functionally speaking: MapOp an Op[A] into an Op[Z]
  * using a function from A => Z.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class MapOp1[A, Z](a:Op[A])(call:A => Z) extends Op[Z] {
   def _run() = runAsync(a :: Nil)
   val nextSteps:Steps[Z] = {
@@ -71,6 +74,7 @@ case class MapOp1[A, Z](a:Op[A])(call:A => Z) extends Op[Z] {
  * Functionally speaking: MapOp an Op[A] and Op[B] into an Op[Z] using a
  * function from (A,B) => Z.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class MapOp2[A, B, Z]
 (a:Op[A], b:Op[B])(call:(A,B) => Z) extends Op[Z] {
   def _run() = runAsync(a :: b :: Nil)

--- a/engine/src/main/scala/geotrellis/engine/logic/WithResult.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/WithResult.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/logic/WithResult.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/WithResult.scala
@@ -24,7 +24,7 @@ import geotrellis.engine._
  * Functionally speaking, this represents the bind operation
  * on the Operation monad
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class WithResult[A, Z](a:Op[A])(call:A => Op[Z]) extends Op[Z] {
   def _run() = runAsync(a.flatMap(call) :: Nil)
   val nextSteps:Steps[Z] = {

--- a/engine/src/main/scala/geotrellis/engine/logic/WithResult.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/WithResult.scala
@@ -24,6 +24,7 @@ import geotrellis.engine._
  * Functionally speaking, this represents the bind operation
  * on the Operation monad
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class WithResult[A, Z](a:Op[A])(call:A => Op[Z]) extends Op[Z] {
   def _run() = runAsync(a.flatMap(call) :: Nil)
   val nextSteps:Steps[Z] = {

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Apply.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Apply.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Apply.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Apply.scala
@@ -21,7 +21,7 @@ import geotrellis.engine._
 /**
  * This corresponds to Haskell's "apply" (<*>) on Functor.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class Apply[A, Z:Manifest](a:Op[A])(f:Op[A => Z]) extends Op2[A, A => Z, Z](a, f)({
   (a, f) => Result(f(a))
 })

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Apply.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Apply.scala
@@ -21,6 +21,7 @@ import geotrellis.engine._
 /**
  * This corresponds to Haskell's "apply" (<*>) on Functor.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class Apply[A, Z:Manifest](a:Op[A])(f:Op[A => Z]) extends Op2[A, A => Z, Z](a, f)({
   (a, f) => Result(f(a))
 })

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Fmap.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Fmap.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Fmap.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Fmap.scala
@@ -21,6 +21,7 @@ import geotrellis.engine._
 /**
  * This corresponds to Haskell's "fmap" on Functor.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class Fmap[A, Z:Manifest](a:Op[A])(f:A => Z) extends Op1[A, Z](a)({
   a => Result(f(a))
 })

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Fmap.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Fmap.scala
@@ -21,7 +21,7 @@ import geotrellis.engine._
 /**
  * This corresponds to Haskell's "fmap" on Functor.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class Fmap[A, Z:Manifest](a:Op[A])(f:A => Z) extends Op1[A, Z](a)({
   a => Result(f(a))
 })

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Implicits.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Implicits.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Implicits.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Implicits.scala
@@ -30,6 +30,7 @@ import language.implicitConversions
  *
  * engine.run(op) // returns 7
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 object Implicits {
   implicit def applyOperator[A, Z:Manifest](lhs:Op[A => Z]) = new {
     def <*>(rhs:Op[A]) = Apply(rhs)(lhs)

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Implicits.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Implicits.scala
@@ -30,7 +30,7 @@ import language.implicitConversions
  *
  * engine.run(op) // returns 7
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 object Implicits {
   implicit def applyOperator[A, Z:Manifest](lhs:Op[A => Z]) = new {
     def <*>(rhs:Op[A]) = Apply(rhs)(lhs)

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Pure.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Pure.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Pure.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Pure.scala
@@ -21,6 +21,7 @@ import geotrellis.engine._
 /**
  * This corresponds to Haskell's "pure" on Functor.
  */
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 case class Pure[Z:Manifest](z:Z) extends Op0[Z]({
   () => Result(z)
 })

--- a/engine/src/main/scala/geotrellis/engine/logic/applicative/Pure.scala
+++ b/engine/src/main/scala/geotrellis/engine/logic/applicative/Pure.scala
@@ -21,7 +21,7 @@ import geotrellis.engine._
 /**
  * This corresponds to Haskell's "pure" on Functor.
  */
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 case class Pure[Z:Manifest](z:Z) extends Op0[Z]({
   () => Result(z)
 })

--- a/engine/src/main/scala/geotrellis/engine/op/elevation/ElevationRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/elevation/ElevationRasterSourceMethods.scala
@@ -6,6 +6,7 @@ import geotrellis.engine.op.focal._
 import geotrellis.raster.mapalgebra.focal.hillshade._
 import geotrellis.raster.mapalgebra.focal._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait ElevationRasterSourceMethods extends RasterSourceMethods with FocalOperation {
 
   def aspect() =

--- a/engine/src/main/scala/geotrellis/engine/op/elevation/ElevationRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/elevation/ElevationRasterSourceMethods.scala
@@ -6,7 +6,7 @@ import geotrellis.engine.op.focal._
 import geotrellis.raster.mapalgebra.focal.hillshade._
 import geotrellis.raster.mapalgebra.focal._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait ElevationRasterSourceMethods extends RasterSourceMethods with FocalOperation {
 
   def aspect() =

--- a/engine/src/main/scala/geotrellis/engine/op/elevation/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/elevation/package.scala
@@ -3,6 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object elevation {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class ElevationRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends ElevationRasterSourceMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/elevation/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/elevation/package.scala
@@ -3,7 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object elevation {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class ElevationRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends ElevationRasterSourceMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/focal/FocalOperation.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/focal/FocalOperation.scala
@@ -5,6 +5,7 @@ import geotrellis.raster._
 import geotrellis.vector._
 import geotrellis.raster.mapalgebra.focal._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait FocalOperation extends RasterSourceMethods {
 
   def zipWithNeighbors: Op[Seq[(Op[Raster[Tile]], TileNeighbors)]] =

--- a/engine/src/main/scala/geotrellis/engine/op/focal/FocalOperation.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/focal/FocalOperation.scala
@@ -5,7 +5,7 @@ import geotrellis.raster._
 import geotrellis.vector._
 import geotrellis.raster.mapalgebra.focal._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait FocalOperation extends RasterSourceMethods {
 
   def zipWithNeighbors: Op[Seq[(Op[Raster[Tile]], TileNeighbors)]] =

--- a/engine/src/main/scala/geotrellis/engine/op/focal/FocalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/focal/FocalRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/focal/FocalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/focal/FocalRasterSourceMethods.scala
@@ -20,6 +20,7 @@ import geotrellis.engine._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait FocalRasterSourceMethods extends RasterSourceMethods with FocalOperation {
   def focalSum(n: Neighborhood) = focal(n)(Sum.apply)
   def focalMin(n: Neighborhood) = focal(n)(Min.apply)

--- a/engine/src/main/scala/geotrellis/engine/op/focal/FocalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/focal/FocalRasterSourceMethods.scala
@@ -20,7 +20,7 @@ import geotrellis.engine._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait FocalRasterSourceMethods extends RasterSourceMethods with FocalOperation {
   def focalSum(n: Neighborhood) = focal(n)(Sum.apply)
   def focalMin(n: Neighborhood) = focal(n)(Min.apply)

--- a/engine/src/main/scala/geotrellis/engine/op/focal/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/focal/package.scala
@@ -3,7 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object focal {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class FocalRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends FocalRasterSourceMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/focal/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/focal/package.scala
@@ -3,6 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object focal {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class FocalRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends FocalRasterSourceMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/global/GlobalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/global/GlobalRasterSourceMethods.scala
@@ -23,6 +23,7 @@ import geotrellis.raster.regiongroup.RegionGroupOptions
 import geotrellis.raster.viewshed.{ApproxViewshed, Viewshed}
 import geotrellis.vector._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait GlobalRasterSourceMethods extends RasterSourceMethods {
   def costDistance(points: Seq[(Int, Int)]) =
     rasterSource.global(CostDistance(_, points))

--- a/engine/src/main/scala/geotrellis/engine/op/global/GlobalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/global/GlobalRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ import geotrellis.raster.viewshed.{ApproxViewshed, Viewshed}
 import geotrellis.vector._
 
 trait GlobalRasterSourceMethods extends RasterSourceMethods {
-  def costDistance(points: Seq[(Int, Int)]) = 
+  def costDistance(points: Seq[(Int, Int)]) =
     rasterSource.global(CostDistance(_, points))
 
   def rescale(newMin: Int, newMax: Int) =
@@ -33,9 +33,9 @@ trait GlobalRasterSourceMethods extends RasterSourceMethods {
   def rescale(newMin: Double, newMax: Double) =
     rasterSource.global(_.rescale(newMin, newMax))
 
-  def toVector() = 
+  def toVector() =
     rasterSource.converge.mapOp { tileOp =>
-      (tileOp, rasterSource.rasterDefinition).map { (tile, rd) => 
+      (tileOp, rasterSource.rasterDefinition).map { (tile, rd) =>
         tile.toVector(rd.rasterExtent.extent)
       }
     }
@@ -45,14 +45,14 @@ trait GlobalRasterSourceMethods extends RasterSourceMethods {
 
   def viewshed(p: Point, exact: Boolean = false) =
     if(exact)
-      rasterSource.globalOp { r => 
+      rasterSource.globalOp { r =>
         rasterSource.rasterDefinition.map { rd =>
           val (col, row) = rd.rasterExtent.mapToGrid(p.x, p.y)
-          Viewshed(r, col, row) 
+          Viewshed(r, col, row)
         }
       }
     else
-      rasterSource.globalOp { r => 
+      rasterSource.globalOp { r =>
         rasterSource.rasterDefinition.map { rd =>
           val (col, row) = rd.rasterExtent.mapToGrid(p.x, p.y)
           ApproxViewshed(r, col, row)
@@ -61,14 +61,14 @@ trait GlobalRasterSourceMethods extends RasterSourceMethods {
 
   def viewshedOffsets(p: Point, exact: Boolean = false) =
     if(exact)
-      rasterSource.globalOp { r => 
+      rasterSource.globalOp { r =>
         rasterSource.rasterDefinition.map { rd =>
           val (col, row) = rd.rasterExtent.mapToGrid(p.x, p.y)
-          Viewshed.offsets(r, col, row) 
+          Viewshed.offsets(r, col, row)
         }
       }
     else
-      rasterSource.globalOp { r => 
+      rasterSource.globalOp { r =>
         rasterSource.rasterDefinition.map { rd =>
           val (col, row) = rd.rasterExtent.mapToGrid(p.x, p.y)
           ApproxViewshed.offsets(r, col, row)

--- a/engine/src/main/scala/geotrellis/engine/op/global/GlobalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/global/GlobalRasterSourceMethods.scala
@@ -23,7 +23,7 @@ import geotrellis.raster.regiongroup.RegionGroupOptions
 import geotrellis.raster.viewshed.{ApproxViewshed, Viewshed}
 import geotrellis.vector._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait GlobalRasterSourceMethods extends RasterSourceMethods {
   def costDistance(points: Seq[(Int, Int)]) =
     rasterSource.global(CostDistance(_, points))

--- a/engine/src/main/scala/geotrellis/engine/op/global/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/global/package.scala
@@ -3,6 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object global {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class GlobalRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends GlobalRasterSourceMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/global/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/global/package.scala
@@ -3,7 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object global {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class GlobalRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends GlobalRasterSourceMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/hydrology/HydrologyRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/hydrology/HydrologyRasterSourceMethods.scala
@@ -21,7 +21,7 @@ import geotrellis.engine.op.focal.FocalOperation
 import geotrellis.raster.mapalgebra.focal._
 import geotrellis.raster.hydrology._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait HydrologyRasterSourceMethods extends RasterSourceMethods with FocalOperation {
   def accumulation() = rasterSource.globalOp(Accumulation(_))
   def fill(threshold: Double) =

--- a/engine/src/main/scala/geotrellis/engine/op/hydrology/HydrologyRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/hydrology/HydrologyRasterSourceMethods.scala
@@ -21,6 +21,7 @@ import geotrellis.engine.op.focal.FocalOperation
 import geotrellis.raster.mapalgebra.focal._
 import geotrellis.raster.hydrology._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait HydrologyRasterSourceMethods extends RasterSourceMethods with FocalOperation {
   def accumulation() = rasterSource.globalOp(Accumulation(_))
   def fill(threshold: Double) =

--- a/engine/src/main/scala/geotrellis/engine/op/hydrology/HydrologyRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/hydrology/HydrologyRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,9 +23,9 @@ import geotrellis.raster.hydrology._
 
 trait HydrologyRasterSourceMethods extends RasterSourceMethods with FocalOperation {
   def accumulation() = rasterSource.globalOp(Accumulation(_))
-  def fill(threshold: Double) = 
-    focal(Square(1)) { 
-      (r,n,bounds) => Fill(r, n, bounds, threshold) 
+  def fill(threshold: Double) =
+    focal(Square(1)) {
+      (r,n,bounds) => Fill(r, n, bounds, threshold)
     }
   def flowDirection() = rasterSource.globalOp(FlowDirection(_))
 }

--- a/engine/src/main/scala/geotrellis/engine/op/hydrology/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/hydrology/package.scala
@@ -3,6 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object hydrology {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class HydrologyRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends HydrologyRasterSourceMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/hydrology/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/hydrology/package.scala
@@ -3,7 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object hydrology {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class HydrologyRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends HydrologyRasterSourceMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/local/AddRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/AddRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/AddRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/AddRasterSourceMethods.scala
@@ -21,6 +21,7 @@ import geotrellis.raster.mapalgebra.local._
 
 import scala.annotation.tailrec
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait AddRasterSourceMethods extends RasterSourceMethods {
   /** Add a constant Int value to each cell. */
   def localAdd(i: Int): RasterSource = rasterSource.mapTile(Add(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/AddRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/AddRasterSourceMethods.scala
@@ -21,7 +21,7 @@ import geotrellis.raster.mapalgebra.local._
 
 import scala.annotation.tailrec
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait AddRasterSourceMethods extends RasterSourceMethods {
   /** Add a constant Int value to each cell. */
   def localAdd(i: Int): RasterSource = rasterSource.mapTile(Add(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/AndRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/AndRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/AndRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/AndRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait AndRasterSourceMethods extends RasterSourceMethods {
   /** And a constant Int value to each cell. */
   def localAnd(i: Int): RasterSource = rasterSource.mapTile(And(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/AndRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/AndRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait AndRasterSourceMethods extends RasterSourceMethods {
   /** And a constant Int value to each cell. */
   def localAnd(i: Int): RasterSource = rasterSource.mapTile(And(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/ConditionalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/ConditionalRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/ConditionalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/ConditionalRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait ConditionalRasterSourceMethods extends RasterSourceMethods {
   /** Maps all cells matching `cond` to Int `trueValue`.*/
   def localIf(cond: Int => Boolean, trueValue: Int): RasterSource =

--- a/engine/src/main/scala/geotrellis/engine/op/local/ConditionalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/ConditionalRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait ConditionalRasterSourceMethods extends RasterSourceMethods {
   /** Maps all cells matching `cond` to Int `trueValue`.*/
   def localIf(cond: Int => Boolean, trueValue: Int): RasterSource =

--- a/engine/src/main/scala/geotrellis/engine/op/local/DivideRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/DivideRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/DivideRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/DivideRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait DivideRasterSourceMethods extends RasterSourceMethods {
   /** Divide each value of the raster by a constant value.*/
   def localDivide(i: Int): RasterSource = rasterSource.mapTile(Divide(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/DivideRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/DivideRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait DivideRasterSourceMethods extends RasterSourceMethods {
   /** Divide each value of the raster by a constant value.*/
   def localDivide(i: Int): RasterSource = rasterSource.mapTile(Divide(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/EqualRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/EqualRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/EqualRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/EqualRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait EqualRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Tile with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/EqualRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/EqualRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait EqualRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Tile with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/GreaterOrEqualRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/GreaterOrEqualRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait GreaterOrEqualRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/GreaterOrEqualRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/GreaterOrEqualRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait GreaterOrEqualRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/GreaterOrEqualRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/GreaterOrEqualRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,7 @@ trait GreaterOrEqualRasterSourceMethods extends RasterSourceMethods {
    * the corresponding cell value of the input raster is greater than or equal to the input
    * integer, else 0.
    */
-  def localGreaterOrEqual(i: Int): RasterSource = 
+  def localGreaterOrEqual(i: Int): RasterSource =
     rasterSource.mapTile(GreaterOrEqual(_, i))
 
   /**
@@ -33,7 +33,7 @@ trait GreaterOrEqualRasterSourceMethods extends RasterSourceMethods {
    * the corresponding cell value of the input raster is greater than or equal to the input
    * integer, else 0.
    */
-  def localGreaterOrEqualRightAssociative(i: Int): RasterSource = 
+  def localGreaterOrEqualRightAssociative(i: Int): RasterSource =
     rasterSource.mapTile(GreaterOrEqual(i, _))
 
   /**
@@ -62,7 +62,7 @@ trait GreaterOrEqualRasterSourceMethods extends RasterSourceMethods {
    * the corresponding cell value of the input raster is greater than or equal to the input
    * double, else 0.
    */
-  def localGreaterOrEqualRightAssociative(d: Double): RasterSource = 
+  def localGreaterOrEqualRightAssociative(d: Double): RasterSource =
     rasterSource.mapTile(GreaterOrEqual(d, _))
 
   /**
@@ -83,7 +83,7 @@ trait GreaterOrEqualRasterSourceMethods extends RasterSourceMethods {
    * Returns a Raster with data of BitCellType, where cell values equal 1 if
    * the corresponding cell valued of the rasters are greater than or equal to the next raster, else 0.
    */
-  def localGreaterOrEqual(rs: RasterSource): RasterSource = 
+  def localGreaterOrEqual(rs: RasterSource): RasterSource =
     rasterSource.combineTile(rs)(GreaterOrEqual(_, _))
 
   /**

--- a/engine/src/main/scala/geotrellis/engine/op/local/GreaterRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/GreaterRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait GreaterRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/GreaterRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/GreaterRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait GreaterRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/GreaterRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/GreaterRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,7 +42,7 @@ trait GreaterRasterSourceMethods extends RasterSourceMethods {
    * Returns a Raster with data of BitCellType, where cell values equal 1 if
    * the corresponding cell value of the input raster is greater than the input
    * integer, else 0.
-   * 
+   *
    * @note Syntax has double '>' due to '>:' operator being reserved in Scala.
    */
   def >>:(i:Int): RasterSource = localGreaterRightAssociative(i)
@@ -68,7 +68,7 @@ trait GreaterRasterSourceMethods extends RasterSourceMethods {
    * Returns a Raster with data of BitCellType, where cell values equal 1 if
    * the corresponding cell value of the input raster is greater than the input
    * double, else 0.
-   * 
+   *
    * @note Syntax has double '>' due to '>:' operator being reserved in Scala.
    */
   def >>:(d:Double): RasterSource = localGreaterRightAssociative(d)

--- a/engine/src/main/scala/geotrellis/engine/op/local/LessOrEqualRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LessOrEqualRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait LessOrEqualRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/LessOrEqualRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LessOrEqualRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait LessOrEqualRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/LessOrEqualRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LessOrEqualRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,7 +60,7 @@ trait LessOrEqualRasterSourceMethods extends RasterSourceMethods {
    * the corresponding cell value of the input raster is less than or equal to the input
    * double, else 0.
    */
-  def localLessOrEqualRightAssociative(d: Double): RasterSource = 
+  def localLessOrEqualRightAssociative(d: Double): RasterSource =
     rasterSource.mapTile(LessOrEqual(d, _))
 
   /**
@@ -81,7 +81,7 @@ trait LessOrEqualRasterSourceMethods extends RasterSourceMethods {
    * Returns a Raster with data of BitCellType, where cell values equal 1 if
    * the corresponding cell valued of the rasters are less than or equal to the next raster, else 0.
    */
-  def localLessOrEqual(rs:RasterSource): RasterSource = 
+  def localLessOrEqual(rs:RasterSource): RasterSource =
     rasterSource.combineTile(rs)(LessOrEqual(_,_))
 
   /**

--- a/engine/src/main/scala/geotrellis/engine/op/local/LessRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LessRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,7 +45,7 @@ trait LessRasterSourceMethods extends RasterSourceMethods {
    * Returns a Raster with data of BitCellType, where cell values equal 1 if
    * the corresponding cell value of the input raster is less than the input
    * integer, else 0.
-   * 
+   *
    * @note Syntax has double '<' due to '<:' operator being reserved in Scala.
    */
   def <<:(i: Int): RasterSource = localLessRightAssociative(i)
@@ -75,7 +75,7 @@ trait LessRasterSourceMethods extends RasterSourceMethods {
    * Returns a Raster with data of BitCellType, where cell values equal 1 if
    * the corresponding cell value of the input raster is less than the input
    * double, else 0.
-   * 
+   *
    * @note Syntax has double '<' due to '<:' operator being reserved in Scala.
    */
   def <<:(d: Double): RasterSource = localLessRightAssociative(d)

--- a/engine/src/main/scala/geotrellis/engine/op/local/LessRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LessRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait LessRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/LessRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LessRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait LessRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/LocalMapRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LocalMapRasterSourceMethods.scala
@@ -20,7 +20,7 @@ import geotrellis.engine._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait LocalMapRasterSourceMethods extends RasterSourceMethods {
     /** Map the integer values of a each cell to a new integer value. */
   def localMap(f:Int=>Int) =

--- a/engine/src/main/scala/geotrellis/engine/op/local/LocalMapRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LocalMapRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,40 +22,40 @@ import geotrellis.raster.mapalgebra.local._
 
 trait LocalMapRasterSourceMethods extends RasterSourceMethods {
     /** Map the integer values of a each cell to a new integer value. */
-  def localMap(f:Int=>Int) = 
+  def localMap(f:Int=>Int) =
     rasterSource.mapTile { tile =>
        tile.dualMap(f)({ z:Double => i2d(f(d2i(z))) })
     }
 
   /** Map the double values of a each cell to a new double value. */
-  def localMapDouble(f:Double=>Double) = 
+  def localMapDouble(f:Double=>Double) =
     rasterSource.mapTile { tile =>
       tile.dualMap({ z:Int => d2i(f(i2d(z))) })(f)
     }
 
   /** For each cell whose value is not NODATA, map their integer values to a new integer value */
-  def localMapIfSet(f:Int=>Int) = 
+  def localMapIfSet(f:Int=>Int) =
     rasterSource.mapTile { tile =>
       tile.dualMapIfSet(f)({ z:Double => i2d(f(d2i(z))) })
     }
 
   /** For each cell whose value is not Double.NaN, map their double values to a new integer value */
-  def localMapIfSetDouble(f:Double=>Double) = 
+  def localMapIfSetDouble(f:Double=>Double) =
     rasterSource.mapTile { tile =>
       tile.dualMapIfSet({ z:Int => d2i(f(i2d(z))) })(f)
     }
 
   /** Map the values of a each cell to a new value;
-      if the type of the raster is a double type, map using the 
+      if the type of the raster is a double type, map using the
       double function, otherwise map using the integer function. */
   def localDualMap(fInt:Int=>Int)(fDouble:Double=>Double) =
     rasterSource.mapTile { tile =>
       tile.dualMap(fInt)(fDouble)
     }
 
-  /** For each cell whose value is not a NoData, if the type of the raster is a double type, 
+  /** For each cell whose value is not a NoData, if the type of the raster is a double type,
       map using the double function, otherwise map using the integer function. */
-  def localMapIfSetDouble(fInt:Int=>Int)(fDouble:Double=>Double) = 
+  def localMapIfSetDouble(fInt:Int=>Int)(fDouble:Double=>Double) =
     rasterSource.mapTile { tile =>
       tile.dualMapIfSet(fInt)(fDouble)
     }

--- a/engine/src/main/scala/geotrellis/engine/op/local/LocalMapRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LocalMapRasterSourceMethods.scala
@@ -20,6 +20,7 @@ import geotrellis.engine._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait LocalMapRasterSourceMethods extends RasterSourceMethods {
     /** Map the integer values of a each cell to a new integer value. */
   def localMap(f:Int=>Int) =

--- a/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceMethods.scala
@@ -22,6 +22,7 @@ import geotrellis.raster.mapalgebra.local._
 import geotrellis.raster.rasterize.Rasterizer
 import geotrellis.vector.Geometry
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait LocalRasterSourceMethods
   extends RasterSourceMethods
      with LocalMapRasterSourceMethods

--- a/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,7 +62,7 @@ trait LocalRasterSourceMethods
 
   def localCombineDouble[That](rs: RasterSource)
                               (f: (Double, Double)=>Double): RasterSource = {
-    val tileOps = 
+    val tileOps =
       (rasterSource.tiles, rs.tiles).map { (ts1, ts2) =>
         for((t1, t2) <- ts1.zip(ts2)) yield {
           (t1, t2).map { (r1, r2) =>
@@ -126,27 +126,27 @@ trait LocalRasterSourceMethods
   def localUndefined(): RasterSource = rasterSource.mapTile(Undefined(_), "Undefined")
 
   /** Masks this raster based on cell values of the second raster. See [[Mask]]. */
-  def localMask(rs: RasterSource, readMask: Int, writeMask: Int): RasterSource = 
+  def localMask(rs: RasterSource, readMask: Int, writeMask: Int): RasterSource =
     rasterSource.combineTile(rs, "localMask")(Mask(_, _, readMask, writeMask))
 
   /** InverseMasks this raster based on cell values of the second raster. See [[InverseMask]]. */
-  def localInverseMask(rs: RasterSource, readMask: Int, writeMask: Int): RasterSource = 
+  def localInverseMask(rs: RasterSource, readMask: Int, writeMask: Int): RasterSource =
     rasterSource.combineTile(rs, "localMask")(InverseMask(_, _, readMask, writeMask))
 
   /** Takes the mean of the values of each cell in the set of rasters. */
-  def localMean(rss: Seq[RasterSource]): RasterSource = 
+  def localMean(rss: Seq[RasterSource]): RasterSource =
     rasterSource.combineTile(rss, "Mean")(Mean(_))
 
   /** Takes the mean of the values of each cell in the set of rasters. */
-  def localMean(rss: RasterSource*)(implicit d: DI): RasterSource = 
+  def localMean(rss: RasterSource*)(implicit d: DI): RasterSource =
     localMean(rss)
 
  /** Gives the count of unique values at each location in a set of Rasters.*/
-  def localVariety(rss: Seq[RasterSource]): RasterSource = 
+  def localVariety(rss: Seq[RasterSource]): RasterSource =
     rasterSource.combineTile(rss, "Variety")(Variety(_))
 
  /** Gives the count of unique values at each location in a set of Rasters.*/
-  def localVariety(rss: RasterSource*)(implicit d: DI): RasterSource = 
+  def localVariety(rss: RasterSource*)(implicit d: DI): RasterSource =
     localVariety(rss)
 
   /** Takes the sine of each raster cell value. */
@@ -177,7 +177,7 @@ trait LocalRasterSourceMethods
   def localAtan(): RasterSource = rasterSource.mapTile(Atan(_), "Atan")
 
   /** Takes the arc tangent 2 of each raster cell value. */
-  def localAtan2(rs: RasterSource): RasterSource = 
+  def localAtan2(rs: RasterSource): RasterSource =
     rasterSource.combineTile(rs, "Atan2")(Atan2(_, _))
 
   /** Assigns to each cell the value within the given rasters that is the nth min */

--- a/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceMethods.scala
@@ -22,7 +22,7 @@ import geotrellis.raster.mapalgebra.local._
 import geotrellis.raster.rasterize.Rasterizer
 import geotrellis.vector.Geometry
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait LocalRasterSourceMethods
   extends RasterSourceMethods
      with LocalMapRasterSourceMethods

--- a/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceSeqMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceSeqMethods.scala
@@ -9,7 +9,7 @@ trait LocalRasterSourceSeqMethods extends RasterSourceSeqMethods {
 
   def applyOp(f: Seq[Op[Tile]]=>Op[Tile]) =
     RasterSource(
-      rasterDefinition, 
+      rasterDefinition,
       rasterSources
         .toSeq
         .map(_.tiles)
@@ -17,7 +17,7 @@ trait LocalRasterSourceSeqMethods extends RasterSourceSeqMethods {
     )
 
   // /** Adds all the rasters in the sequence */
-  def localAdd(): RasterSource = 
+  def localAdd(): RasterSource =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => Add(tiles) }
     }
@@ -26,7 +26,7 @@ trait LocalRasterSourceSeqMethods extends RasterSourceSeqMethods {
   def difference() = localSubtract
 
   /** Takes the difference of the rasters in the sequence from left to right */
-  def localSubtract() = 
+  def localSubtract() =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => Subtract(tiles) }
     }
@@ -35,49 +35,49 @@ trait LocalRasterSourceSeqMethods extends RasterSourceSeqMethods {
   def product() = localMultiply
 
   /** Takes the product of the rasters in the sequence */
-  def localMultiply() = 
+  def localMultiply() =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => Multiply(tiles) }
     }
 
   /** Divides the rasters in the sequence from left to right */
-  def localDivide() = 
+  def localDivide() =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => Divide(tiles) }
     }
 
   /** Takes the max of each cell value */
-  def max() = 
+  def max() =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => Max(tiles) }
     }
 
   /** Takes the min of each cell value */
-  def min() = 
+  def min() =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => Min(tiles) }
     }
 
   /** Takes the logical And of each cell value */
-  def and() = 
+  def and() =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => And(tiles) }
     }
 
   /** Takes the logical Or of each cell value */
-  def or() = 
+  def or() =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => Or(tiles) }
     }
 
   /** Takes the logical Xor of each cell value */
-  def xor() = 
+  def xor() =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => Xor(tiles) }
     }
 
   /** Raises each cell value to the power of the next raster, from left to right */
-  def exponentiate() = 
+  def exponentiate() =
     applyOp { tileOps =>
       logic.Collect(tileOps).map { tiles: Seq[Tile] => Pow(tiles) }
     }

--- a/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceSeqMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceSeqMethods.scala
@@ -4,6 +4,7 @@ import geotrellis.engine._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait LocalRasterSourceSeqMethods extends RasterSourceSeqMethods {
   val rasterDefinition = rasterSources.head.rasterDefinition
 

--- a/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceSeqMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/LocalRasterSourceSeqMethods.scala
@@ -4,7 +4,7 @@ import geotrellis.engine._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait LocalRasterSourceSeqMethods extends RasterSourceSeqMethods {
   val rasterDefinition = rasterSources.head.rasterDefinition
 

--- a/engine/src/main/scala/geotrellis/engine/op/local/MajorityRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MajorityRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/MajorityRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MajorityRasterSourceMethods.scala
@@ -22,7 +22,7 @@ import geotrellis.raster.mapalgebra.local._
 import spire.syntax.cfor._
 import scala.collection.mutable
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait MajorityRasterSourceMethods extends RasterSourceMethods {
 
   /** Assigns to each cell the value within the given rasters that is the most numerous. */

--- a/engine/src/main/scala/geotrellis/engine/op/local/MajorityRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MajorityRasterSourceMethods.scala
@@ -22,6 +22,7 @@ import geotrellis.raster.mapalgebra.local._
 import spire.syntax.cfor._
 import scala.collection.mutable
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait MajorityRasterSourceMethods extends RasterSourceMethods {
 
   /** Assigns to each cell the value within the given rasters that is the most numerous. */

--- a/engine/src/main/scala/geotrellis/engine/op/local/MaxRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MaxRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/MaxRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MaxRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait MaxRasterSourceMethods extends RasterSourceMethods {
   /** Max a constant Int value to each cell. */
   def localMax(i: Int): RasterSource = rasterSource.mapTile(Max(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/MaxRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MaxRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait MaxRasterSourceMethods extends RasterSourceMethods {
   /** Max a constant Int value to each cell. */
   def localMax(i: Int): RasterSource = rasterSource.mapTile(Max(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/MinRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MinRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/MinRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MinRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait MinRasterSourceMethods extends RasterSourceMethods {
   /** Min a constant Int value to each cell. */
   def localMin(i: Int): RasterSource = rasterSource.mapTile(Min(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/MinRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MinRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait MinRasterSourceMethods extends RasterSourceMethods {
   /** Min a constant Int value to each cell. */
   def localMin(i: Int): RasterSource = rasterSource.mapTile(Min(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/MinorityRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MinorityRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,18 +24,18 @@ import scala.collection.mutable
 
 trait MinorityRasterSourceMethods extends RasterSourceMethods {
   /** Assigns to each cell the value within the given rasters that is the least numerous. */
-  def localMinority(rss: Seq[RasterSource]): RasterSource = 
+  def localMinority(rss: Seq[RasterSource]): RasterSource =
     rasterSource.combineTile(rss, "Minority")(Minority(_))
 
   /** Assigns to each cell the value within the given rasters that is the least numerous. */
-  def localMinority(rss: RasterSource*)(implicit d: DI): RasterSource = 
+  def localMinority(rss: RasterSource*)(implicit d: DI): RasterSource =
     localMinority(rss)
 
   /** Assigns to each cell the value within the given rasters that is the nth least numerous. */
-  def localMinority(n: Int, rss: Seq[RasterSource]): RasterSource = 
+  def localMinority(n: Int, rss: Seq[RasterSource]): RasterSource =
     rasterSource.combineTile(rss, "Minority")(Minority(n, _))
 
   /** Assigns to each cell the value within the given rasters that is the nth least numerous. */
-  def localMinority(n: Int, rss: RasterSource*)(implicit d: DI): RasterSource = 
+  def localMinority(n: Int, rss: RasterSource*)(implicit d: DI): RasterSource =
     localMinority(n, rss)
 }

--- a/engine/src/main/scala/geotrellis/engine/op/local/MinorityRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MinorityRasterSourceMethods.scala
@@ -22,7 +22,7 @@ import geotrellis.raster.mapalgebra.local._
 import spire.syntax.cfor._
 import scala.collection.mutable
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait MinorityRasterSourceMethods extends RasterSourceMethods {
   /** Assigns to each cell the value within the given rasters that is the least numerous. */
   def localMinority(rss: Seq[RasterSource]): RasterSource =

--- a/engine/src/main/scala/geotrellis/engine/op/local/MinorityRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MinorityRasterSourceMethods.scala
@@ -22,6 +22,7 @@ import geotrellis.raster.mapalgebra.local._
 import spire.syntax.cfor._
 import scala.collection.mutable
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait MinorityRasterSourceMethods extends RasterSourceMethods {
   /** Assigns to each cell the value within the given rasters that is the least numerous. */
   def localMinority(rss: Seq[RasterSource]): RasterSource =

--- a/engine/src/main/scala/geotrellis/engine/op/local/MultiplyRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MultiplyRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/MultiplyRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MultiplyRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait MultiplyRasterSourceMethods extends RasterSourceMethods {
   /** Multiply a constant value from each cell.*/
   def localMultiply(i: Int): RasterSource = rasterSource.mapTile(Multiply(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/MultiplyRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/MultiplyRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait MultiplyRasterSourceMethods extends RasterSourceMethods {
   /** Multiply a constant value from each cell.*/
   def localMultiply(i: Int): RasterSource = rasterSource.mapTile(Multiply(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/OrRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/OrRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/OrRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/OrRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait OrRasterSourceMethods extends RasterSourceMethods {
   /** Or a constant Int value to each cell. */
   def localOr(i: Int): RasterSource = rasterSource.mapTile(Or(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/OrRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/OrRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait OrRasterSourceMethods extends RasterSourceMethods {
   /** Or a constant Int value to each cell. */
   def localOr(i: Int): RasterSource = rasterSource.mapTile(Or(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/PowRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/PowRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/PowRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/PowRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait PowRasterSourceMethods extends RasterSourceMethods {
   /** Pow each value of the raster by a constant value.*/
   def localPow(i: Int): RasterSource = rasterSource.mapTile(Pow(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/PowRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/PowRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait PowRasterSourceMethods extends RasterSourceMethods {
   /** Pow each value of the raster by a constant value.*/
   def localPow(i: Int): RasterSource = rasterSource.mapTile(Pow(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/SubtractRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/SubtractRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/SubtractRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/SubtractRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait SubtractRasterSourceMethods extends RasterSourceMethods {
   /** Subtract a constant value from each cell.*/
   def localSubtract(i: Int): RasterSource = rasterSource.mapTile(Subtract(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/SubtractRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/SubtractRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait SubtractRasterSourceMethods extends RasterSourceMethods {
   /** Subtract a constant value from each cell.*/
   def localSubtract(i: Int): RasterSource = rasterSource.mapTile(Subtract(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/UnequalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/UnequalRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/UnequalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/UnequalRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait UnequalRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/UnequalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/UnequalRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait UnequalRasterSourceMethods extends RasterSourceMethods {
   /**
    * Returns a Raster with data of BitCellType, where cell values equal 1 if

--- a/engine/src/main/scala/geotrellis/engine/op/local/XorRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/XorRasterSourceMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/op/local/XorRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/XorRasterSourceMethods.scala
@@ -19,7 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait XorRasterSourceMethods extends RasterSourceMethods {
   /** Xor a constant Int value to each cell. */
   def localXor(i: Int): RasterSource = rasterSource.mapTile(Xor(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/XorRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/XorRasterSourceMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.engine.op.local
 import geotrellis.engine._
 import geotrellis.raster.mapalgebra.local._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait XorRasterSourceMethods extends RasterSourceMethods {
   /** Xor a constant Int value to each cell. */
   def localXor(i: Int): RasterSource = rasterSource.mapTile(Xor(_, i))

--- a/engine/src/main/scala/geotrellis/engine/op/local/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/package.scala
@@ -3,9 +3,11 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object local {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class LocalRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends LocalRasterSourceMethods
 
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class LocalRasterSourceSeqExtensions(val rasterSources: Traversable[RasterSource])
       extends LocalRasterSourceSeqMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/local/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/local/package.scala
@@ -3,11 +3,11 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object local {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class LocalRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends LocalRasterSourceMethods
 
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class LocalRasterSourceSeqExtensions(val rasterSources: Traversable[RasterSource])
       extends LocalRasterSourceSeqMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/ZonalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/ZonalRasterSourceMethods.scala
@@ -25,6 +25,7 @@ import spire.syntax.cfor._
 
 import scala.collection.mutable
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait ZonalRasterSourceMethods extends RasterSourceMethods {
   /**
    * Given a raster, return a histogram summary of the cells within each zone.

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/ZonalRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/ZonalRasterSourceMethods.scala
@@ -25,7 +25,7 @@ import spire.syntax.cfor._
 
 import scala.collection.mutable
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait ZonalRasterSourceMethods extends RasterSourceMethods {
   /**
    * Given a raster, return a histogram summary of the cells within each zone.

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/package.scala
@@ -3,7 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object zonal {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class ZonalRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends ZonalRasterSourceMethods { }
 }

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/package.scala
@@ -3,6 +3,7 @@ package geotrellis.engine.op
 import geotrellis.engine._
 
 package object zonal {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class ZonalRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends ZonalRasterSourceMethods { }
 }

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/summary/ZonalSummaryRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/summary/ZonalSummaryRasterSourceMethods.scala
@@ -26,6 +26,7 @@ import geotrellis.vector._
 import scala.collection.mutable
 import spire.syntax.cfor._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait ZonalSummaryRasterSourceMethods extends RasterSourceMethods {
   def mapIntersecting[B, That](p: Polygon)
                               (handler: TilePolygonalSummaryHandler[B]): DataSource[B, _] =

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/summary/ZonalSummaryRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/summary/ZonalSummaryRasterSourceMethods.scala
@@ -26,7 +26,7 @@ import geotrellis.vector._
 import scala.collection.mutable
 import spire.syntax.cfor._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait ZonalSummaryRasterSourceMethods extends RasterSourceMethods {
   def mapIntersecting[B, That](p: Polygon)
                               (handler: TilePolygonalSummaryHandler[B]): DataSource[B, _] =

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/summary/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/summary/package.scala
@@ -3,6 +3,6 @@ package geotrellis.engine.op.zonal
 import geotrellis.engine._
 
 package object summary {
-  implicit class ZonalSummaryRasterSourceMethodExtensions(val rasterSource: RasterSource) 
+  implicit class ZonalSummaryRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends ZonalSummaryRasterSourceMethods { }
 }

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/summary/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/summary/package.scala
@@ -3,7 +3,7 @@ package geotrellis.engine.op.zonal
 import geotrellis.engine._
 
 package object summary {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class ZonalSummaryRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends ZonalSummaryRasterSourceMethods { }
 }

--- a/engine/src/main/scala/geotrellis/engine/op/zonal/summary/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/op/zonal/summary/package.scala
@@ -3,6 +3,7 @@ package geotrellis.engine.op.zonal
 import geotrellis.engine._
 
 package object summary {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class ZonalSummaryRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends ZonalSummaryRasterSourceMethods { }
 }

--- a/engine/src/main/scala/geotrellis/engine/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/package.scala
@@ -24,10 +24,10 @@ import language.experimental.macros
 package object engine {
   implicit lazy val engine = GeoTrellis.engine
 
-  type Args = List[Any]
-  type Op[+A] = Operation[A]
-  type DI = DummyImplicit
-  type Steps[T] = PartialFunction[Any, StepOutput[T]]
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2") type Args = List[Any]
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2") type Op[+A] = Operation[A]
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2") type DI = DummyImplicit
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2") type Steps[T] = PartialFunction[Any, StepOutput[T]]
 
   /**
    * Syntax for converting tuples of operations
@@ -35,16 +35,19 @@ package object engine {
    * this is similiar to a for comprehension, but the
    * operations will be executed in parallel.
    */
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class OpMap2[A, B](t: (Op[A], Op[B])) {
     def map[T](f: (A, B)=>T) = Op(f).apply(t._1, t._2)
     def flatMap[T](f: (A, B)=>Op[T]) = Op(f).apply(t._1, t._2)
   }
 
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class OpMap3[A, B, C](t: (Op[A], Op[B], Op[C])) {
     def map[T](f: (A, B, C)=>T) = Op(f).apply(t._1, t._2, t._3)
     def flatMap[T](f: (A, B, C)=>Op[T]) = Op(f).apply(t._1, t._2, t._3)
   }
 
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class OpMap4[A, B, C, D](t: (Op[A], Op[B], Op[C], Op[D])) {
     def map[T](f: (A, B, C, D)=>T) = Op(f).apply(t._1, t._2, t._3, t._4)
     def flatMap[T](f: (A, B, C, D)=>Op[T]) = Op(f).apply(t._1, t._2, t._3, t._4)
@@ -55,23 +58,28 @@ package object engine {
    * have methods to work with the results of those
    * operations executed in parallel
    */
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class OpMapSeq[A](seq: Seq[Op[A]]) {
     def mapOps[T](f: (Seq[A]=>T)) = logic.Collect(Literal(seq)).map(f)
     def flaMapOps[T](f: (Seq[A]=>Op[T])) = logic.Collect(Literal(seq)).flatMap(f)
   }
 
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class OpMapArray[A](seq: Array[Op[A]]) {
     def mapOps[T](f: (Seq[A]=>T)) = logic.Collect(Literal(seq.toSeq)).map(f)
     def flaMapOps[T](f: (Seq[A]=>Op[T])) = logic.Collect(Literal(seq.toSeq)).flatMap(f)
   }
 
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class OpSeqToCollect[T](seq: Op[Seq[Op[T]]]) {
     def collect() = logic.Collect(seq)
   }
 
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit def dataSourceSeqToSeqSource[T](iterable: Iterable[OpSource[T]]): SeqSource[T] =
     DataSource.fromSources(iterable.toSeq)
 
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class DataSourceSeqWrapper[T](dss: Seq[OpSource[T]]) {
     def collectSources(): SeqSource[T] = DataSource.fromSources(dss)
   }

--- a/engine/src/main/scala/geotrellis/engine/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/package.scala
@@ -24,10 +24,10 @@ import language.experimental.macros
 package object engine {
   implicit lazy val engine = GeoTrellis.engine
 
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2") type Args = List[Any]
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2") type Op[+A] = Operation[A]
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2") type DI = DummyImplicit
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2") type Steps[T] = PartialFunction[Any, StepOutput[T]]
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") type Args = List[Any]
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") type Op[+A] = Operation[A]
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") type DI = DummyImplicit
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10") type Steps[T] = PartialFunction[Any, StepOutput[T]]
 
   /**
    * Syntax for converting tuples of operations
@@ -35,19 +35,19 @@ package object engine {
    * this is similiar to a for comprehension, but the
    * operations will be executed in parallel.
    */
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class OpMap2[A, B](t: (Op[A], Op[B])) {
     def map[T](f: (A, B)=>T) = Op(f).apply(t._1, t._2)
     def flatMap[T](f: (A, B)=>Op[T]) = Op(f).apply(t._1, t._2)
   }
 
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class OpMap3[A, B, C](t: (Op[A], Op[B], Op[C])) {
     def map[T](f: (A, B, C)=>T) = Op(f).apply(t._1, t._2, t._3)
     def flatMap[T](f: (A, B, C)=>Op[T]) = Op(f).apply(t._1, t._2, t._3)
   }
 
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class OpMap4[A, B, C, D](t: (Op[A], Op[B], Op[C], Op[D])) {
     def map[T](f: (A, B, C, D)=>T) = Op(f).apply(t._1, t._2, t._3, t._4)
     def flatMap[T](f: (A, B, C, D)=>Op[T]) = Op(f).apply(t._1, t._2, t._3, t._4)
@@ -58,28 +58,28 @@ package object engine {
    * have methods to work with the results of those
    * operations executed in parallel
    */
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class OpMapSeq[A](seq: Seq[Op[A]]) {
     def mapOps[T](f: (Seq[A]=>T)) = logic.Collect(Literal(seq)).map(f)
     def flaMapOps[T](f: (Seq[A]=>Op[T])) = logic.Collect(Literal(seq)).flatMap(f)
   }
 
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class OpMapArray[A](seq: Array[Op[A]]) {
     def mapOps[T](f: (Seq[A]=>T)) = logic.Collect(Literal(seq.toSeq)).map(f)
     def flaMapOps[T](f: (Seq[A]=>Op[T])) = logic.Collect(Literal(seq.toSeq)).flatMap(f)
   }
 
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class OpSeqToCollect[T](seq: Op[Seq[Op[T]]]) {
     def collect() = logic.Collect(seq)
   }
 
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit def dataSourceSeqToSeqSource[T](iterable: Iterable[OpSource[T]]): SeqSource[T] =
     DataSource.fromSources(iterable.toSeq)
 
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class DataSourceSeqWrapper[T](dss: Seq[OpSource[T]]) {
     def collectSources(): SeqSource[T] = DataSource.fromSources(dss)
   }

--- a/engine/src/main/scala/geotrellis/engine/render/RasterSourceColorMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RasterSourceColorMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/render/RasterSourceColorMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RasterSourceColorMethods.scala
@@ -20,6 +20,7 @@ import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait RasterSourceColorMethods extends RasterSourceMethods {
   def color(breaksToColors: Map[Int, Int]): RasterSource =
     color(breaksToColors, ColorMapOptions.Default)

--- a/engine/src/main/scala/geotrellis/engine/render/RasterSourceColorMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RasterSourceColorMethods.scala
@@ -20,7 +20,7 @@ import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait RasterSourceColorMethods extends RasterSourceMethods {
   def color(breaksToColors: Map[Int, Int]): RasterSource =
     color(breaksToColors, ColorMapOptions.Default)

--- a/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourceJpgMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourceJpgMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourceJpgMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourceJpgMethods.scala
@@ -20,6 +20,7 @@ import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait RenderRasterSourceJpgMethods extends RasterSourceMethods {
   /** Generate a PNG from a raster of RGBA integer values.
     *

--- a/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourceJpgMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourceJpgMethods.scala
@@ -20,7 +20,7 @@ import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait RenderRasterSourceJpgMethods extends RasterSourceMethods {
   /** Generate a PNG from a raster of RGBA integer values.
     *

--- a/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourcePngMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourcePngMethods.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourcePngMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourcePngMethods.scala
@@ -20,6 +20,7 @@ import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.engine._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait RenderRasterSourcePngMethods extends RasterSourceMethods {
   /** Generate a PNG from a raster of RGBA integer values.
     *

--- a/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourcePngMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/RenderRasterSourcePngMethods.scala
@@ -20,7 +20,7 @@ import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.engine._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait RenderRasterSourcePngMethods extends RasterSourceMethods {
   /** Generate a PNG from a raster of RGBA integer values.
     *

--- a/engine/src/main/scala/geotrellis/engine/render/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/package.scala
@@ -3,7 +3,7 @@ package geotrellis.engine
 import geotrellis.engine._
 
 package object render {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class RenderRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends RenderRasterSourcePngMethods with RenderRasterSourceJpgMethods with RasterSourceColorMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/render/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/package.scala
@@ -3,6 +3,7 @@ package geotrellis.engine
 import geotrellis.engine._
 
 package object render {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class RenderRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends RenderRasterSourcePngMethods with RenderRasterSourceJpgMethods with RasterSourceColorMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/render/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/render/package.scala
@@ -3,6 +3,6 @@ package geotrellis.engine
 import geotrellis.engine._
 
 package object render {
-  implicit class RenderRasterSourceMethodExtensions(val rasterSource: RasterSource) 
+  implicit class RenderRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends RenderRasterSourcePngMethods with RenderRasterSourceJpgMethods with RasterSourceColorMethods
 }

--- a/engine/src/main/scala/geotrellis/engine/stats/StatsRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/stats/StatsRasterSourceMethods.scala
@@ -21,7 +21,7 @@ import geotrellis.raster._
 import geotrellis.raster.histogram._
 import geotrellis.raster.summary._
 
-@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+@deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
 trait StatsRasterSourceMethods extends RasterSourceMethods {
   private def convergeHistograms(histograms: Seq[Histogram[Int]]): Histogram[Int] = FastMapHistogram.fromHistograms(histograms)
 

--- a/engine/src/main/scala/geotrellis/engine/stats/StatsRasterSourceMethods.scala
+++ b/engine/src/main/scala/geotrellis/engine/stats/StatsRasterSourceMethods.scala
@@ -21,6 +21,7 @@ import geotrellis.raster._
 import geotrellis.raster.histogram._
 import geotrellis.raster.summary._
 
+@deprecated("geotrellis-engine has been deprecated", "7b92cb2")
 trait StatsRasterSourceMethods extends RasterSourceMethods {
   private def convergeHistograms(histograms: Seq[Histogram[Int]]): Histogram[Int] = FastMapHistogram.fromHistograms(histograms)
 

--- a/engine/src/main/scala/geotrellis/engine/stats/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/stats/package.scala
@@ -3,6 +3,6 @@ package geotrellis.engine
 import geotrellis.engine._
 
 package object stats {
-  implicit class StatsRasterSourceMethodExtensions(val rasterSource: RasterSource) 
+  implicit class StatsRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends StatsRasterSourceMethods { }
 }

--- a/engine/src/main/scala/geotrellis/engine/stats/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/stats/package.scala
@@ -3,7 +3,7 @@ package geotrellis.engine
 import geotrellis.engine._
 
 package object stats {
-  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
+  @deprecated("geotrellis-engine has been deprecated", "Geotrellis Version 0.10")
   implicit class StatsRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends StatsRasterSourceMethods { }
 }

--- a/engine/src/main/scala/geotrellis/engine/stats/package.scala
+++ b/engine/src/main/scala/geotrellis/engine/stats/package.scala
@@ -3,6 +3,7 @@ package geotrellis.engine
 import geotrellis.engine._
 
 package object stats {
+  @deprecated("geotrellis-engine has been deprecated", "7b92cb2")
   implicit class StatsRasterSourceMethodExtensions(val rasterSource: RasterSource)
       extends StatsRasterSourceMethods { }
 }


### PR DESCRIPTION
All of the publicly-accessible classes, traits, and objects in this project have been marked as deprecated.

As regards in-the-wild code examples that use this project, I have not been able to find any thus far.  There do not appear to be any projects in the `geotrellis` repository that use `geotrellis-engine`, and cursory googling did not reveal any.

### Still Need To ###
   - [x] Do a better survey of known code that might be effected by this change