### PR TITLE
Create geotrellis-util Subproject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ lazy val admin = Project("admin", file("admin")).
   settings(commonSettings: _*)
 
 lazy val spark = Project("spark", file("spark")).
-  dependsOn(raster).
+  dependsOn(util, raster).
   settings(commonSettings: _*)
 
 lazy val sparkTestkit: Project = Project("spark-testkit", file("spark-testkit")).

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val proj4 = Project("proj4", file("proj4")).
   settings(commonSettings: _*)
 
 lazy val raster = Project("raster", file("raster")).
-  dependsOn(macros, vector).
+  dependsOn(util, macros, vector).
   settings(commonSettings: _*)
 
 lazy val rasterTest = Project("raster-test", file("raster-test")).
@@ -149,6 +149,9 @@ lazy val dev = Project("dev", file("dev")).
 
 lazy val demo = Project("demo", file("demo")).
   dependsOn(jetty).
+  settings(commonSettings: _*)
+
+lazy val util = Project("util", file("util")).
   settings(commonSettings: _*)
 
 lazy val vectorBenchmark: Project = Project("vector-benchmark", file("vector-benchmark")).

--- a/engine/src/main/scala/geotrellis/engine/ArgFileRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ArgFileRasterLayer.scala
@@ -17,8 +17,8 @@
 package geotrellis.engine
 
 import geotrellis.raster._
-import geotrellis.raster.io.Filesystem
 import geotrellis.raster.io.arg.ArgReader
+import geotrellis.util.Filesystem
 
 import com.typesafe.config.Config
 

--- a/engine/src/main/scala/geotrellis/engine/ArgUrlRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/ArgUrlRasterLayer.scala
@@ -18,7 +18,7 @@ package geotrellis.engine
 
 import geotrellis.raster._
 import geotrellis.raster.io.arg.ArgReader
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 
 import akka.actor.ActorSystem
 import akka.io.IO

--- a/engine/src/main/scala/geotrellis/engine/AsciiRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/AsciiRasterLayer.scala
@@ -21,6 +21,7 @@ import geotrellis.raster.io._
 import geotrellis.raster.io.ascii._
 import geotrellis.engine._
 import geotrellis.vector.Extent
+import geotrellis.util.Filesystem
 
 import java.io.{File, BufferedReader}
 import com.typesafe.config.Config

--- a/engine/src/main/scala/geotrellis/engine/Catalog.scala
+++ b/engine/src/main/scala/geotrellis/engine/Catalog.scala
@@ -18,7 +18,7 @@ package geotrellis.engine
 
 import geotrellis.raster._
 import geotrellis.engine._
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 
 import com.typesafe.config.Config
 
@@ -26,6 +26,7 @@ import java.io.File
 
 import scala.collection.mutable
 import scala.util._
+
 
 // example json is available in the geotrellis.engine.catalog tests. please
 // keep it up-to-date with changes you make here.

--- a/engine/src/main/scala/geotrellis/engine/RasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/RasterLayer.scala
@@ -19,7 +19,7 @@ package geotrellis.engine
 import geotrellis._
 import geotrellis.raster._
 import geotrellis.vector.Extent
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 
 import scala.concurrent._
 import scala.concurrent.Future
@@ -36,6 +36,7 @@ import spray.http._
 import spray.client.pipelining._
 
 import java.io.File
+
 
 /**
  * Represents a Raster Layer that can give detailed information

--- a/engine/src/main/scala/geotrellis/engine/TileSetRasterLayer.scala
+++ b/engine/src/main/scala/geotrellis/engine/TileSetRasterLayer.scala
@@ -18,8 +18,8 @@ package geotrellis.engine
 
 import geotrellis.raster._
 import geotrellis.vector.Extent
-import geotrellis.raster.io.Filesystem
 import geotrellis.raster.io.arg.ArgReader
+import geotrellis.util.Filesystem
 
 import com.typesafe.config.Config
 import java.io.File

--- a/raster-test/src/test/scala/geotrellis/raster/io/FilesystemSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/FilesystemSpec.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.raster.io
 
+import geotrellis.util.Filesystem
 import org.scalatest._
 
 class FilesystemSpec extends FunSpec

--- a/raster-test/src/test/scala/geotrellis/raster/io/FilesystemSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/FilesystemSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@ package geotrellis.raster.io
 
 import org.scalatest._
 
-class FilesystemSpec extends FunSpec 
+class FilesystemSpec extends FunSpec
                         with Matchers {
   describe("Filesystem") {
     it("should give the same array for slurp and mapToByteArray for whole array") {

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable
 import spire.syntax.cfor._
 
 object GridBounds {
-  def apply(r: CellGrid): GridBounds = 
+  def apply(r: CellGrid): GridBounds =
     GridBounds(0, 0, r.cols-1, r.rows-1)
 
   def envelope(keys: Iterable[Product2[Int, Int]]): GridBounds = {
@@ -100,7 +100,7 @@ case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
     val arr = Array.ofDim[(Int, Int)](width*height)
     cfor(0)(_ < height, _ + 1) { row =>
       cfor(0)(_ < width, _ + 1) { col =>
-        arr(row * width + col) = 
+        arr(row * width + col) =
           (col + colMin, row + rowMin)
       }
     }

--- a/raster/src/main/scala/geotrellis/raster/costdistance/CostDistanceMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/costdistance/CostDistanceMethods.scala
@@ -1,6 +1,8 @@
 package geotrellis.raster.costdistance
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 trait CostDistanceMethods extends MethodExtensions[Tile] {
   def costDistance(points: Seq[(Int, Int)]): Tile =

--- a/raster/src/main/scala/geotrellis/raster/crop/CropMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/crop/CropMethods.scala
@@ -2,6 +2,8 @@ package geotrellis.raster.crop
 
 import geotrellis.vector._
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 trait CropMethods[T] extends MethodExtensions[T] {
   import Crop.Options

--- a/raster/src/main/scala/geotrellis/raster/hydrology/HydrologyMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/hydrology/HydrologyMethods.scala
@@ -1,7 +1,9 @@
 package geotrellis.raster.hydrology
 
 import geotrellis.raster.mapalgebra.focal.Square
-import geotrellis.raster.{Tile, MethodExtensions}
+import geotrellis.raster.Tile
+import geotrellis.util.MethodExtensions
+
 
 trait HydrologyMethods extends MethodExtensions[Tile] {
   def accumulation(): Tile = Accumulation(self)

--- a/raster/src/main/scala/geotrellis/raster/io/Filesystem.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/Filesystem.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ object Filesystem {
     val buffer = channel.map(READ_ONLY, 0, size)
     channel.close()
     fis.close()
-    
+
     // read 256K at a time out of the buffer into our array
     var i = 0
     val data = Array.ofDim[Byte](size)
@@ -47,7 +47,7 @@ object Filesystem {
   def mapToByteArray(path: String, data: Array[Byte], startIndex: Int, size: Int): Unit = {
     val f = new File(path)
     val fis = new FileInputStream(f)
-    val buffer = 
+    val buffer =
       try {
         val channel = fis.getChannel
         channel.map(READ_ONLY, startIndex, size)

--- a/raster/src/main/scala/geotrellis/raster/io/arg/ArgReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/arg/ArgReader.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/raster/src/main/scala/geotrellis/raster/io/arg/ArgReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/arg/ArgReader.scala
@@ -18,14 +18,15 @@ package geotrellis.raster.io.arg
 
 import geotrellis.raster._
 import geotrellis.raster.resample._
-import geotrellis.raster.io.Filesystem
 import geotrellis.vector.Extent
+import geotrellis.util.Filesystem
 
 import com.typesafe.config.ConfigFactory
 
 import java.io.File
 import java.nio.ByteBuffer
 import java.lang.IllegalArgumentException
+
 
 object ArgReader {
   /** Reads an arg from the json metadata file. */

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
@@ -50,7 +50,7 @@ object GeoTiffReader {
   /* Read a single band GeoTIFF file.
    * If there is more than one band in the GeoTiff, read the first band only.
    */
-  def readSingleBand(path: String, decompress: Boolean): SingleBandGeoTiff = 
+  def readSingleBand(path: String, decompress: Boolean): SingleBandGeoTiff =
     readSingleBand(Filesystem.slurp(path), decompress)
 
   /* Read a single band GeoTIFF file.
@@ -96,7 +96,7 @@ object GeoTiffReader {
 
   /* Read a multi band GeoTIFF file.
    */
-  def readMultiBand(path: String, decompress: Boolean): MultiBandGeoTiff = 
+  def readMultiBand(path: String, decompress: Boolean): MultiBandGeoTiff =
     readMultiBand(Filesystem.slurp(path), decompress)
 
   /* Read a multi band GeoTIFF file.

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
@@ -17,13 +17,13 @@
 package geotrellis.raster.io.geotiff.reader
 
 import geotrellis.raster._
-import geotrellis.raster.io.Filesystem
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.compression._
 import geotrellis.raster.io.geotiff.utils._
 import geotrellis.raster.io.geotiff.tags._
 import geotrellis.vector.Extent
 import geotrellis.proj4.CRS
+import geotrellis.util.Filesystem
 
 import monocle.syntax._
 
@@ -31,6 +31,7 @@ import scala.io._
 import scala.collection.mutable
 import java.nio.{ByteBuffer, ByteOrder}
 import spire.syntax.cfor._
+
 
 class MalformedGeoTiffException(msg: String) extends RuntimeException(msg)
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -1,16 +1,17 @@
 package geotrellis.raster.io.geotiff.reader
 
-import geotrellis.raster.io.Filesystem
 import geotrellis.raster.io.geotiff.tags._
 import geotrellis.raster.io.geotiff.tags.codes._
 import TagCodes._
 import TiffFieldType._
+import geotrellis.util.Filesystem
 
 import geotrellis.raster.io.geotiff.utils._
 import spire.syntax.cfor._
 import monocle.syntax._
 
 import java.nio.{ ByteBuffer, ByteOrder }
+
 
 object TiffTagsReader {
   def read(path: String): TiffTags = read(Filesystem.slurp(path))

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/FocalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/FocalMethods.scala
@@ -1,6 +1,8 @@
 package geotrellis.raster.mapalgebra.focal
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 trait FocalMethods extends MethodExtensions[Tile] {
 

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/HillshadeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/HillshadeMethods.scala
@@ -2,6 +2,8 @@ package geotrellis.raster.mapalgebra.focal.hillshade
 
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
+import geotrellis.util.MethodExtensions
+
 
 trait HillshadeMethods extends MethodExtensions[Tile] {
   /**

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Add.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Add.scala
@@ -17,8 +17,10 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
 
 import scala.annotation.tailrec
+
 
 /**
  * Operation to add values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/And.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/And.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Operation to And values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Divide.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Divide.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Divides values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Equal.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Equal.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Determines if values are equal. Sets to 1 if true, else 0.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Greater.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Greater.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Determines if values are greater than other values. Sets to 1 if true, else 0.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/GreaterOrEqual.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/GreaterOrEqual.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Determines if values are greater than or equal to other values. Sets to 1 if true, else 0.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Less.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Less.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Determines if values are less than other values. Sets to 1 if true, else 0.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/LessOrEqual.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/LessOrEqual.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Determines if values are less than or equal to other values. Sets to 1 if true, else 0.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/LocalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/LocalMethods.scala
@@ -17,6 +17,11 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.raster.rasterize.Rasterizer
+import geotrellis.raster.rasterize.Rasterize.Options
+import geotrellis.vector.{Geometry, Extent}
+import geotrellis.util.MethodExtensions
+
 
 trait LocalMethods extends MethodExtensions[Tile]
                       with AddMethods

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Majority.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Majority.scala
@@ -17,9 +17,11 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
 
 import spire.syntax.cfor._
 import scala.collection.mutable
+
 
 object Majority extends Serializable {
   def apply(r: Tile*): Tile = apply(0, r)

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Max.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Max.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Gets maximum values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Min.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Min.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Gets minimum values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Minority.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Minority.scala
@@ -17,9 +17,11 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
 
 import spire.syntax.cfor._
 import scala.collection.mutable
+
 
 object Minority extends Serializable {
   def apply(r: Tile*): Tile =

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Multiply.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Multiply.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Multiplies values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Or.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Or.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Or's cell values of rasters or Int values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Pow.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Pow.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Pows values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Subtract.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Subtract.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Subtracts values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Unequal.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Unequal.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Determines if values are equal. Sets to 1 if true, else 0.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Xor.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Xor.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Xor's cell values of rasters or Int values.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/conditional.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/conditional.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster.mapalgebra.local
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /**
  * Maps all cells matching `cond` to Int `trueValue`.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/zonal/ZonalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/zonal/ZonalMethods.scala
@@ -3,6 +3,8 @@ package geotrellis.raster.mapalgebra.zonal
 import geotrellis.raster._
 import geotrellis.raster.summary._
 import geotrellis.raster.histogram._
+import geotrellis.util.MethodExtensions
+
 
 trait ZonalMethods extends MethodExtensions[Tile] {
   def zonalHistogramInt(zones: Tile): Map[Int, Histogram[Int]] =

--- a/raster/src/main/scala/geotrellis/raster/mask/TileMaskMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/mask/TileMaskMethods.scala
@@ -5,6 +5,7 @@ import geotrellis.raster.mapalgebra.local.{Mask, InverseMask}
 import geotrellis.raster.rasterize.Rasterizer
 import geotrellis.raster.rasterize.Rasterize.Options
 import geotrellis.vector.{Geometry, Extent}
+import geotrellis.util.MethodExtensions
 
 
 trait TileMaskMethods extends MethodExtensions[Tile] {

--- a/raster/src/main/scala/geotrellis/raster/merge/RasterMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/RasterMergeMethods.scala
@@ -3,6 +3,8 @@ package geotrellis.raster.merge
 import geotrellis.raster._
 import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
 import geotrellis.vector.Extent
+import geotrellis.util.MethodExtensions
+
 
 class RasterMergeMethods[T <: CellGrid: ? => TileMergeMethods[T]](val self: Raster[T]) extends MethodExtensions[Raster[T]] {
   def merge(other: Raster[T], method: ResampleMethod): Raster[T] =

--- a/raster/src/main/scala/geotrellis/raster/merge/TileMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileMergeMethods.scala
@@ -3,6 +3,8 @@ package geotrellis.raster.merge
 import geotrellis.raster._
 import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
 import geotrellis.vector.Extent
+import geotrellis.util.MethodExtensions
+
 
 trait TileMergeMethods[T] extends MethodExtensions[T] {
   def merge(other: T): T

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -20,6 +20,7 @@ import geotrellis.vector.Point
 import geotrellis.macros.{ NoDataMacros, TypeConversionMacros }
 import geotrellis.vector.{Geometry, Feature}
 import geotrellis.raster.rasterize._
+import geotrellis.util.MethodExtensions
 
 
 package object raster

--- a/raster/src/main/scala/geotrellis/raster/prototype/TilePrototypeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/prototype/TilePrototypeMethods.scala
@@ -1,6 +1,8 @@
 package geotrellis.raster.prototype
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 /** Methods that allow us to create a similar tile type from an already existing tile. */
 trait TilePrototypeMethods[T <: CellGrid] extends MethodExtensions[T] {

--- a/raster/src/main/scala/geotrellis/raster/rasterize/FeatureRasterizeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/FeatureRasterizeMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.raster.rasterize
 import geotrellis.raster._
 import geotrellis.raster.rasterize.Rasterize.Options
 import geotrellis.vector.{Geometry,Feature}
+import geotrellis.util.MethodExtensions
 
 
 trait FeatureIntRasterizeMethods[+G <: Geometry, T <: Feature[G,Int]] extends MethodExtensions[T] {

--- a/raster/src/main/scala/geotrellis/raster/rasterize/GeometryRasterizeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/GeometryRasterizeMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.raster.rasterize
 import geotrellis.raster._
 import geotrellis.raster.rasterize.Rasterize.Options
 import geotrellis.vector.Geometry
+import geotrellis.util.MethodExtensions
 
 
 trait GeometryRasterizeMethods[T <: Geometry] extends MethodExtensions[T] {

--- a/raster/src/main/scala/geotrellis/raster/rasterize/RasterExtentRasterizeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/RasterExtentRasterizeMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.raster.rasterize
 import geotrellis.raster._
 import geotrellis.raster.rasterize.Rasterize.Options
 import geotrellis.vector.Geometry
+import geotrellis.util.MethodExtensions
 
 
 trait RasterExtentRasterizeMethods[T <: RasterExtent] extends MethodExtensions[T] {

--- a/raster/src/main/scala/geotrellis/raster/rasterize/SingleBandRasterRasterizeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/SingleBandRasterRasterizeMethods.scala
@@ -19,6 +19,8 @@ package geotrellis.raster.rasterize
 import geotrellis.raster._
 import geotrellis.raster.rasterize.Rasterize.Options
 import geotrellis.vector.Geometry
+import geotrellis.util.MethodExtensions
+
 
 trait SingleBandRasterRasterizeMethods[T <: Tile, S <: Raster[T]] extends MethodExtensions[Raster[T]] {
   def foreachCell(

--- a/raster/src/main/scala/geotrellis/raster/rasterize/TileRasterizeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/TileRasterizeMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.raster.rasterize
 import geotrellis.raster._
 import geotrellis.raster.rasterize.Rasterize.Options
 import geotrellis.vector.{Geometry,Extent}
+import geotrellis.util.MethodExtensions
 
 
 trait TileRasterizeMethods[T <: Tile] extends MethodExtensions[T] {

--- a/raster/src/main/scala/geotrellis/raster/regiongroup/RegionGroupMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/regiongroup/RegionGroupMethods.scala
@@ -1,6 +1,8 @@
 package geotrellis.raster.regiongroup
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 trait RegionGroupMethods extends MethodExtensions[Tile] {
   def regionGroup: RegionGroupResult =

--- a/raster/src/main/scala/geotrellis/raster/render/ColorMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorMethods.scala
@@ -4,10 +4,12 @@ import geotrellis.raster._
 import geotrellis.raster.render.png._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.raster.summary._
+import geotrellis.util.MethodExtensions
 
 import java.awt.image.BufferedImage
 
 import spire.syntax.cfor._
+
 
 trait ColorMethods extends MethodExtensions[Tile] {
   def color(breaksToColors: Map[Int, Int]): Tile =

--- a/raster/src/main/scala/geotrellis/raster/render/JpgRenderMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/JpgRenderMethods.scala
@@ -4,6 +4,8 @@ import geotrellis.raster._
 import geotrellis.raster.render.jpg._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.raster.summary._
+import geotrellis.util.MethodExtensions
+
 
 trait JpgRenderMethods extends MethodExtensions[Tile] {
   /** Generate a JPG from a raster of RGBA integer values.

--- a/raster/src/main/scala/geotrellis/raster/render/PngRenderMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/PngRenderMethods.scala
@@ -4,6 +4,8 @@ import geotrellis.raster._
 import geotrellis.raster.render.png._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.raster.summary._
+import geotrellis.util.MethodExtensions
+
 
 trait PngRenderMethods extends MethodExtensions[Tile] {
   /** Generate a PNG from a raster of RGBA integer values.

--- a/raster/src/main/scala/geotrellis/raster/reproject/ProjectedRasterReprojectMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/ProjectedRasterReprojectMethods.scala
@@ -7,7 +7,8 @@ import geotrellis.proj4._
 
 import spire.syntax.cfor._
 
-class ProjectedRasterReprojectMethods[T <: CellGrid](val self: ProjectedRaster[T])(implicit ev: Raster[T] => RasterReprojectMethods[Raster[T]]) 
+
+class ProjectedRasterReprojectMethods[T <: CellGrid](val self: ProjectedRaster[T])(implicit ev: Raster[T] => RasterReprojectMethods[Raster[T]])
     extends MethodExtensions[ProjectedRaster[T]] {
   import Reproject.Options
 

--- a/raster/src/main/scala/geotrellis/raster/reproject/ProjectedRasterReprojectMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/ProjectedRasterReprojectMethods.scala
@@ -4,6 +4,7 @@ import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.vector.Extent
 import geotrellis.proj4._
+import geotrellis.util.MethodExtensions
 
 import spire.syntax.cfor._
 

--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterReprojectMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterReprojectMethods.scala
@@ -4,6 +4,8 @@ import geotrellis.raster._
 import geotrellis.proj4._
 import geotrellis.raster.resample.ResampleMethod
 import geotrellis.vector.Extent
+import geotrellis.util.MethodExtensions
+
 
 trait RasterReprojectMethods[+T <: Raster[_]] extends MethodExtensions[T] {
   import Reproject.Options

--- a/raster/src/main/scala/geotrellis/raster/reproject/TileReprojectMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/TileReprojectMethods.scala
@@ -4,6 +4,8 @@ import geotrellis.raster._
 import geotrellis.proj4._
 import geotrellis.raster.resample.ResampleMethod
 import geotrellis.vector.Extent
+import geotrellis.util.MethodExtensions
+
 
 trait TileReprojectMethods[T <: CellGrid] extends MethodExtensions[T] {
   import Reproject.Options

--- a/raster/src/main/scala/geotrellis/raster/resample/RasterResampleMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/RasterResampleMethods.scala
@@ -2,6 +2,8 @@ package geotrellis.raster.resample
 
 import geotrellis.raster._
 import geotrellis.vector.Extent
+import geotrellis.util.MethodExtensions
+
 
 trait RasterResampleMethods[+T <: Raster[_]] extends MethodExtensions[T] {
   def resample(target: RasterExtent, method: ResampleMethod): T

--- a/raster/src/main/scala/geotrellis/raster/resample/ResampleMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/ResampleMethods.scala
@@ -2,8 +2,10 @@ package geotrellis.raster.resample
 
 import geotrellis.raster._
 import geotrellis.vector.Extent
+import geotrellis.util.MethodExtensions
 
 import spire.syntax.cfor._
+
 
 trait ResampleMethods[T <: CellGrid] extends MethodExtensions[T] {
   def resample(extent: Extent, targetExtent: RasterExtent, method: ResampleMethod): T

--- a/raster/src/main/scala/geotrellis/raster/resample/TileResampleMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/TileResampleMethods.scala
@@ -2,6 +2,8 @@ package geotrellis.raster.resample
 
 import geotrellis.raster._
 import geotrellis.vector._
+import geotrellis.util.MethodExtensions
+
 
 trait TileResampleMethods[T <: CellGrid] extends MethodExtensions[T] {
   def resample(extent: Extent, target: RasterExtent, method: ResampleMethod): T

--- a/raster/src/main/scala/geotrellis/raster/summary/SummaryMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/SummaryMethods.scala
@@ -2,6 +2,8 @@ package geotrellis.raster.summary
 
 import geotrellis.raster._
 import geotrellis.raster.histogram._
+import geotrellis.util.MethodExtensions
+
 
 trait SummaryMethods extends MethodExtensions[Tile] {
   /**

--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/PolygonalSummaryMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/PolygonalSummaryMethods.scala
@@ -3,6 +3,8 @@ package geotrellis.raster.summary.polygonal
 import geotrellis.raster._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.vector._
+import geotrellis.util.MethodExtensions
+
 
 trait PolygonalSummaryMethods extends MethodExtensions[Tile] {
   def polygonalSummary[T](extent: Extent, polygon: Polygon, handler: TilePolygonalSummaryHandler[T]): T = {

--- a/raster/src/main/scala/geotrellis/raster/vectorize/VectorizeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/vectorize/VectorizeMethods.scala
@@ -2,6 +2,8 @@ package geotrellis.raster.vectorize
 
 import geotrellis.raster._
 import geotrellis.vector._
+import geotrellis.util.MethodExtensions
+
 
 trait VectorizeMethods extends MethodExtensions[Tile] {
   def toVector(extent: Extent, regionConnectivity: Connectivity = FourNeighbors): List[PolygonFeature[Int]] =

--- a/raster/src/main/scala/geotrellis/raster/viewshed/ViewshedMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/viewshed/ViewshedMethods.scala
@@ -1,6 +1,8 @@
 package geotrellis.raster.viewshed
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 
 trait ViewshedMethods extends MethodExtensions[Tile] {
   def viewshed(col: Int, row: Int, exact: Boolean = false): Tile =

--- a/spark/src/main/scala/geotrellis/spark/MultiBandRasterRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/MultiBandRasterRDDMethods.scala
@@ -1,8 +1,10 @@
 package geotrellis.spark
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
 import org.apache.spark.rdd._
 import scala.reflect.ClassTag
+
 
 abstract class MultiBandRasterRDDMethods[K: ClassTag] extends MethodExtensions[MultiBandRasterRDD[K]] {
   def convert(cellType: CellType): MultiBandRasterRDD[K] =

--- a/spark/src/main/scala/geotrellis/spark/RasterRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/RasterRDDMethods.scala
@@ -1,8 +1,10 @@
 package geotrellis.spark
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
 import org.apache.spark.rdd._
 import scala.reflect.ClassTag
+
 
 abstract class RasterRDDMethods[K: ClassTag] extends MethodExtensions[RasterRDD[K]] {
   def convert(cellType: CellType) =

--- a/spark/src/main/scala/geotrellis/spark/RasterRDDSeqMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/RasterRDDSeqMethods.scala
@@ -1,8 +1,10 @@
 package geotrellis.spark
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
 import scala.reflect.ClassTag
 import org.apache.spark.rdd.RDD
+
 
 trait RasterRDDSeqMethods[K] extends MethodExtensions[Traversable[RDD[(K, Tile)]]] {
   implicit val keyClassTag: ClassTag[K]

--- a/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
@@ -4,10 +4,13 @@ import geotrellis.raster._
 import geotrellis.raster.stitch._
 import geotrellis.raster.crop._
 import geotrellis.spark._
+import geotrellis.util.MethodExtensions
+import geotrellis.util.MethodExtensions
 
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
+
 
 class BufferTilesMethods[
   K: SpatialComponent: ClassTag,

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
@@ -13,7 +13,7 @@ import java.io._
 
 /**
  * Stores and retrieves layer attributes from the file system.
- * 
+ *
  * @param catalogPath      The directory of the base catalog
  */
 class FileAttributeStore(val catalogPath: String) extends AttributeStore[JsonFormat] {
@@ -32,7 +32,7 @@ class FileAttributeStore(val catalogPath: String) extends AttributeStore[JsonFor
         val att = f.getName.split(SEP).last.replace(".json", "")
         (att.substring(0, att.length - 5), f)
       }
-  
+
   def read[T: Format](file: File): (LayerId, T) =
     Filesystem.readText(file)
       .parseJson
@@ -68,7 +68,7 @@ class FileAttributeStore(val catalogPath: String) extends AttributeStore[JsonFor
       .isEmpty
 
   def delete(layerId: LayerId, attributeName: String): Unit = {
-    val layerFiles = 
+    val layerFiles =
       attributeDirectory
         .listFiles(new WildcardFileFilter(s"${layerId.name}${SEP}${layerId.zoom}${SEP}*.json"): FileFilter)
     if(layerFiles.isEmpty) throw new LayerNotFoundError(layerId)
@@ -79,7 +79,7 @@ class FileAttributeStore(val catalogPath: String) extends AttributeStore[JsonFor
   }
 
   def delete(layerId: LayerId): Unit = {
-    val layerFiles = 
+    val layerFiles =
       attributeDirectory
         .listFiles(new WildcardFileFilter(s"${layerId.name}${SEP}${layerId.zoom}${SEP}*.json"): FileFilter)
     if(layerFiles.isEmpty) throw new LayerNotFoundError(layerId)

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
@@ -3,13 +3,14 @@ package geotrellis.spark.io.file
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.json._
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 
 import org.apache.commons.io.filefilter.WildcardFileFilter
 import spray.json._
 import DefaultJsonProtocol._
 
 import java.io._
+
 
 /**
  * Stores and retrieves layer attributes from the file system.

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerCopier.scala
@@ -5,7 +5,7 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 import AttributeStore.Fields
 
 import spray.json.JsonFormat
@@ -13,6 +13,7 @@ import org.apache.avro.Schema
 
 import scala.reflect.ClassTag
 import java.io.File
+
 
 object FileLayerCopier {
   def apply[K: JsonFormat: ClassTag, V: ClassTag, M: JsonFormat](sourceAttributeStore: FileAttributeStore, targetAttributeStore: FileAttributeStore): LayerCopier[LayerId] =

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerDeleter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerDeleter.scala
@@ -22,7 +22,7 @@ object FileLayerDeleter {
         val (header, metadata, keyBounds, keyIndex, writerSchema) = try {
           attributeStore.readLayerAttributes[FileLayerHeader, M, KeyBounds[K], KeyIndex[K], Schema](layerId)
         } catch {
-          case e: AttributeNotFoundError => 
+          case e: AttributeNotFoundError =>
             throw new LayerNotFoundError(layerId).initCause(e)
         }
 

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerDeleter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerDeleter.scala
@@ -5,7 +5,7 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 import AttributeStore.Fields
 
 import spray.json.JsonFormat
@@ -13,6 +13,7 @@ import org.apache.avro.Schema
 
 import scala.reflect.ClassTag
 import java.io.File
+
 
 object FileLayerDeleter {
   def apply[K: JsonFormat: ClassTag, V: ClassTag, M: JsonFormat](attributeStore: FileAttributeStore): LayerDeleter[LayerId] =

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerMover.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerMover.scala
@@ -5,7 +5,7 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 import AttributeStore.Fields
 
 import spray.json.JsonFormat
@@ -13,6 +13,7 @@ import org.apache.avro.Schema
 
 import scala.reflect.ClassTag
 import java.io.File
+
 
 object FileLayerMover {
   def apply[K: JsonFormat: ClassTag, V: ClassTag, M: JsonFormat](sourceAttributeStore: FileAttributeStore, targetAttributeStore: FileAttributeStore): LayerMover[LayerId] =

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerReindexer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerReindexer.scala
@@ -5,7 +5,7 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 import AttributeStore.Fields
 
 import org.apache.spark.SparkContext
@@ -14,6 +14,7 @@ import org.apache.avro.Schema
 
 import scala.reflect.ClassTag
 import java.io.File
+
 
 object FileLayerReindexer {
   def apply[

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerWriter.scala
@@ -6,9 +6,8 @@ import geotrellis.spark.io.json._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.avro.codecs._
 import geotrellis.spark.io.index._
-
 import geotrellis.raster._
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 
 import org.apache.avro.Schema
 import org.apache.spark.SparkContext
@@ -20,6 +19,7 @@ import com.typesafe.scalalogging.slf4j._
 import AttributeStore.Fields
 
 import java.io.File
+
 
 /**
   * Handles writing Raster RDDs and their metadata to a filesystem.

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
@@ -6,7 +6,7 @@ import geotrellis.spark.io.index.{MergeQueue, KeyIndex, IndexRanges}
 import geotrellis.spark.io.avro.{AvroEncoder, AvroRecordCodec}
 import geotrellis.spark.utils.KryoWrapper
 import geotrellis.spark.utils.cache.Cache
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 
 import org.apache.avro.Schema
 import org.apache.commons.io.IOUtils
@@ -17,6 +17,7 @@ import spire.syntax.cfor._
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import java.io.File
+
 
 class FileRDDReader[K: Boundable: AvroRecordCodec: ClassTag, V: AvroRecordCodec: ClassTag](implicit sc: SparkContext) {
 

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
@@ -39,7 +39,7 @@ class FileRDDReader[K: Boundable: AvroRecordCodec: ClassTag, V: AvroRecordCodec:
     val includeKey = (key: K) => KeyBounds.includeKey(queryKeyBounds, key)(boundable)
     val _recordCodec = KeyValueRecordCodec[K, V]
     val kwWriterSchema = KryoWrapper(writerSchema) //Avro Schema is not Serializable
-  
+
     sc.parallelize(bins, bins.size)
       .mapPartitions { partition: Iterator[Seq[(Long, Long)]] =>
         val resultPartition = mutable.ListBuffer[(K, V)]()

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileRDDWriter.scala
@@ -1,13 +1,14 @@
 package geotrellis.spark.io.file
 
-import geotrellis.raster.io.Filesystem
 import geotrellis.spark.io.avro.{AvroRecordCodec, AvroEncoder}
 import geotrellis.spark.io.avro.codecs.KeyValueRecordCodec
+import geotrellis.util.Filesystem
 
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
 import java.io.File
+
 
 class FileRDDWriter [K: AvroRecordCodec: ClassTag, V: AvroRecordCodec: ClassTag]() {
 

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileTileReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileTileReader.scala
@@ -7,7 +7,7 @@ import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.avro.codecs._
-import geotrellis.raster.io.Filesystem
+import geotrellis.util.Filesystem
 
 import org.apache.avro.Schema
 import spray.json._
@@ -15,6 +15,7 @@ import spray.json.DefaultJsonProtocol._
 
 import java.io.File
 import scala.reflect.ClassTag
+
 
 class FileTileReader[K: AvroRecordCodec: JsonFormat: ClassTag, V: AvroRecordCodec](
   val attributeStore: AttributeStore[JsonFormat],

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/package.scala
@@ -5,6 +5,7 @@ import geotrellis.spark.utils._
 import geotrellis.spark.io.hadoop.formats._
 import geotrellis.spark.io.avro.codecs._
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
 import org.apache.spark._
 import org.apache.spark.rdd._
 import org.apache.spark.SparkContext._
@@ -14,6 +15,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.hadoop.mapreduce._
 
 import scala.reflect._
+
 
 package object hadoop {
   implicit def stringToPath(path: String): Path = new Path(path)

--- a/spark/src/main/scala/geotrellis/spark/io/slippy/FileSlippyTileReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/slippy/FileSlippyTileReader.scala
@@ -2,11 +2,11 @@ package geotrellis.spark.io.slippy
 
 import geotrellis.vector._
 import geotrellis.raster._
-import geotrellis.raster.io.Filesystem
 import geotrellis.raster.io.geotiff._
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.hadoop.formats._
+import geotrellis.util.Filesystem
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter._
@@ -19,6 +19,7 @@ import org.apache.hadoop.fs.Path
 
 import java.io._
 import scala.collection.JavaConversions._
+
 
 class FileSlippyTileReader[T](uri: String, extensions: Seq[String] = Seq())(fromBytes: (SpatialKey, Array[Byte]) => T) extends SlippyTileReader[T] {
   import SlippyTileReader.TilePath

--- a/spark/src/main/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriter.scala
@@ -2,11 +2,11 @@ package geotrellis.spark.io.slippy
 
 import geotrellis.vector._
 import geotrellis.raster._
-import geotrellis.raster.io.Filesystem
 import geotrellis.raster.io.geotiff._
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.hadoop.formats._
+import geotrellis.util.Filesystem
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter._
@@ -19,6 +19,7 @@ import org.apache.hadoop.fs.Path
 
 import java.io.File
 import scala.collection.JavaConversions._
+
 
 class HadoopSlippyTileWriter[T](uri: String, extension: String)(getBytes: (SpatialKey, T) => Array[Byte])(implicit sc: SparkContext) extends SlippyTileWriter[T] {
   def setupWrite(zoom: Int, rdd: RDD[(SpatialKey, T)]): RDD[(SpatialKey, T)] = {

--- a/spark/src/main/scala/geotrellis/spark/io/slippy/S3SlippyTileReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/slippy/S3SlippyTileReader.scala
@@ -2,16 +2,17 @@ package geotrellis.spark.io.slippy
 
 import geotrellis.vector._
 import geotrellis.raster._
-import geotrellis.raster.io.Filesystem
 import geotrellis.raster.io.geotiff._
 import geotrellis.spark._
 import geotrellis.spark.io.s3._
+import geotrellis.util.Filesystem
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter._
 import org.apache.spark._
 import org.apache.spark.rdd._
 import java.io.File
+
 
 class S3SlippyTileReader[T](uri: String)(fromBytes: (SpatialKey, Array[Byte]) => T) extends SlippyTileReader[T] {
   import SlippyTileReader.TilePath

--- a/spark/src/main/scala/geotrellis/spark/io/slippy/SlippyTileReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/slippy/SlippyTileReader.scala
@@ -2,12 +2,12 @@ package geotrellis.spark.io.slippy
 
 import geotrellis.vector._
 import geotrellis.raster._
-import geotrellis.raster.io.Filesystem
 import geotrellis.raster.io.geotiff._
 import geotrellis.spark._
 import geotrellis.spark.io.s3._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.hadoop.formats._
+import geotrellis.util.Filesystem
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter._
@@ -20,6 +20,7 @@ import org.apache.hadoop.fs.Path
 
 import java.io.File
 import scala.collection.JavaConversions._
+
 
 trait SlippyTileReader[T] {
   def read(zoom: Int)(implicit sc: SparkContext): RDD[(SpatialKey, T)]

--- a/spark/src/main/scala/geotrellis/spark/io/slippy/SlippyTileWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/slippy/SlippyTileWriter.scala
@@ -2,12 +2,12 @@ package geotrellis.spark.io.slippy
 
 import geotrellis.vector._
 import geotrellis.raster._
-import geotrellis.raster.io.Filesystem
 import geotrellis.raster.io.geotiff._
 import geotrellis.spark._
 import geotrellis.spark.io.s3._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.hadoop.formats._
+import geotrellis.util.Filesystem
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter._
@@ -20,6 +20,7 @@ import org.apache.hadoop.fs.Path
 
 import java.io.File
 import scala.collection.JavaConversions._
+
 
 trait SlippyTileWriter[T] {
   def setupWrite(zoom: Int, rdd: RDD[(SpatialKey, T)]): RDD[(SpatialKey, T)]

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/CombineMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/CombineMethods.scala
@@ -1,9 +1,13 @@
 package geotrellis.spark.mapalgebra
 
 import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 import org.apache.spark.Partitioner
 import org.apache.spark.rdd.RDD
+
 import scala.reflect.ClassTag
+
 
 abstract class CombineMethods[K: ClassTag, V: ClassTag] extends MethodExtensions[RDD[(K, V)]] {
   def combineValues[R: ClassTag](other: RDD[(K, V)])(f: (V, V) => R): RDD[(K, R)] = combineValues(other, None)(f)

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/Implicits.scala
@@ -1,9 +1,13 @@
 package geotrellis.spark.mapalgebra
 
+import geotrellis.raster._
+import geotrellis.util.MethodExtensions
+
 import org.apache.spark.Partitioner
 import org.apache.spark.rdd.RDD
-import geotrellis.raster._
+
 import scala.reflect.ClassTag
+
 
 object Implicits extends Implicits
 

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/Implicits.scala
@@ -23,7 +23,7 @@ trait Implicits {
 
   implicit class withMapValuesOptionMethods[K: ClassTag, V: ClassTag](val self: RDD[(K, (V, Option[V]))]) extends MethodExtensions[RDD[(K, (V, Option[V]))]] {
     def updateValues(f: (V, V) => V): RDD[(K, V)] =
-      self.mapValues { case (v1, ov2) => 
+      self.mapValues { case (v1, ov2) =>
         ov2 match {
           case Some(v2) => f(v1, v2)
           case None => v1

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/TileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/TileRDDMethods.scala
@@ -1,8 +1,10 @@
 package geotrellis.spark.mapalgebra
 
 import scala.reflect.ClassTag
-import geotrellis.raster.{MethodExtensions, Tile}
+import geotrellis.raster.Tile
+import geotrellis.util.MethodExtensions
 import org.apache.spark.rdd.RDD
+
 
 trait TileRDDMethods[K] extends MethodExtensions[RDD[(K, Tile)]] {
   implicit val keyClassTag: ClassTag[K]

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalOperation.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalOperation.scala
@@ -5,6 +5,7 @@ import geotrellis.spark.buffer._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
 import geotrellis.vector._
+import geotrellis.util.MethodExtensions
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext._
@@ -14,6 +15,7 @@ import spire.syntax.cfor._
 import annotation.tailrec
 import scala.reflect.ClassTag
 import scala.collection.mutable.ArrayBuffer
+
 
 object FocalOperation {
   private def mapOverBufferedTiles[K: SpatialComponent: ClassTag](bufferedTiles: RDD[(K, BufferedTile[Tile])], neighborhood: Neighborhood)

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalRasterRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalRasterRDDMethods.scala
@@ -3,6 +3,8 @@ package geotrellis.spark.mapalgebra.focal
 import geotrellis.spark._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
+import geotrellis.util.MethodExtensions
+
 
 trait FocalRasterRDDMethods[K] extends FocalOperation[K] {
 

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/local/LocalTileRDDSeqMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/local/LocalTileRDDSeqMethods.scala
@@ -4,10 +4,13 @@ import geotrellis.spark._
 import geotrellis.spark.mapalgebra._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.local._
+import geotrellis.util.MethodExtensions
+
 import org.apache.spark.Partitioner
 import org.apache.spark.rdd.RDD
+
 import scala.reflect._
-import org.apache.spark.rdd.RDD
+
 
 abstract class LocalTileRDDSeqMethods[K: ClassTag] extends MethodExtensions[Traversable[RDD[(K, Tile)]]] {
   private def r(f: Traversable[Tile] => (Tile), partitioner: Option[Partitioner]): RDD[(K, Tile)] =

--- a/spark/src/main/scala/geotrellis/spark/mask/RasterRDDMaskMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mask/RasterRDDMaskMethods.scala
@@ -5,6 +5,7 @@ import geotrellis.raster.rasterize.Rasterize.Options
 import geotrellis.spark._
 import geotrellis.spark.RasterRDD
 import geotrellis.vector._
+import geotrellis.util.MethodExtensions
 import scala.reflect.ClassTag
 
 

--- a/spark/src/main/scala/geotrellis/spark/merge/RddLayoutMergeMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/RddLayoutMergeMethods.scala
@@ -1,14 +1,16 @@
 package geotrellis.spark.merge
 
-import scala.reflect.ClassTag
-
-import org.apache.spark.rdd.RDD
-
 import geotrellis.raster._
 import geotrellis.raster.merge._
 import geotrellis.raster.prototype._
 import geotrellis.spark._
 import geotrellis.spark.tiling.LayoutDefinition
+import geotrellis.util.MethodExtensions
+
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
 
 // TODO: Handle metadata lens abstraction for layout definition.
 class RDDLayoutMergeMethods[

--- a/spark/src/main/scala/geotrellis/spark/merge/RddLayoutMergeMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/RddLayoutMergeMethods.scala
@@ -21,7 +21,7 @@ class RDDLayoutMergeMethods[
    val thisLayout = self.metadata.layout
    val thatLayout = other.metadata.layout
 
-   val cutRdd = 
+   val cutRdd =
        other
          .flatMap { case (k: K, tile: V) =>
            val extent = thatLayout.mapTransform(k)

--- a/spark/src/main/scala/geotrellis/spark/merge/TileRDDMergeMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/TileRDDMergeMethods.scala
@@ -2,11 +2,13 @@ package geotrellis.spark.merge
 
 import geotrellis.raster._
 import geotrellis.raster.merge._
+import geotrellis.util.MethodExtensions
 
 import org.apache.spark._
 import org.apache.spark.rdd._
 
 import scala.reflect.ClassTag
+
 
 class TileRDDMergeMethods[K: ClassTag, V: ClassTag: ? => TileMergeMethods[V]](val self: RDD[(K, V)]) extends MethodExtensions[RDD[(K, V)]] {
   def merge(other: RDD[(K, V)]): RDD[(K, V)] =

--- a/spark/src/main/scala/geotrellis/spark/partitioner/SpatialJoinMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/partitioner/SpatialJoinMethods.scala
@@ -3,8 +3,10 @@ package geotrellis.spark.partitioner
 import geotrellis.raster._
 import geotrellis.spark._
 import org.apache.spark.rdd._
+import geotrellis.util.MethodExtensions
 
 import scala.reflect._
+
 
 abstract class SpatialJoinMethods[
   K: Boundable: PartitionerIndex: ClassTag,

--- a/spark/src/main/scala/geotrellis/spark/reproject/ProjectedExtentComponentReprojectMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/ProjectedExtentComponentReprojectMethods.scala
@@ -6,8 +6,10 @@ import geotrellis.spark._
 import geotrellis.spark.ingest._
 import geotrellis.vector._
 import geotrellis.proj4._
+import geotrellis.util.MethodExtensions
 
 import org.apache.spark.rdd._
+
 
 class ProjectedExtentComponentReprojectMethods[K: ProjectedExtentComponent, V <: CellGrid: (? => TileReprojectMethods[V])](val self: RDD[(K, V)])
     extends MethodExtensions[RDD[(K, V)]] {

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReprojectMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReprojectMethods.scala
@@ -10,10 +10,12 @@ import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.spark.ingest._
 import geotrellis.proj4._
+import geotrellis.util.MethodExtensions
 
 import org.apache.spark.rdd._
 
 import scala.reflect.ClassTag
+
 
 class TileRDDReprojectMethods[
   K: SpatialComponent: ClassTag,

--- a/spark/src/main/scala/geotrellis/spark/stitch/StitchRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/stitch/StitchRDDMethods.scala
@@ -5,7 +5,10 @@ import geotrellis.raster.stitch.Stitcher
 import geotrellis.vector.Extent
 import geotrellis.spark._
 import geotrellis.spark.tiling.MapKeyTransform
+import geotrellis.util.MethodExtensions
+
 import org.apache.spark.rdd.RDD
+
 
 object TileLayoutStitcher {
   /**

--- a/spark/src/main/scala/geotrellis/spark/summary/polygonal/PolygonalSummaryRasterRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/summary/polygonal/PolygonalSummaryRasterRDDMethods.scala
@@ -5,10 +5,12 @@ import geotrellis.raster.histogram._
 import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.vector._
+import geotrellis.util.MethodExtensions
 import org.apache.spark.Partitioner
 
 import org.apache.spark.rdd._
 import reflect.ClassTag
+
 
 abstract class PolygonalSummaryRasterRDDMethods[K: ClassTag] extends MethodExtensions[RasterRDD[K]] {
   import Implicits._

--- a/spark/src/main/scala/geotrellis/spark/tiling/TilerKeyMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/TilerKeyMethods.scala
@@ -1,8 +1,9 @@
 package geotrellis.spark.tiling
 
 import geotrellis.spark._
-import geotrellis.raster.MethodExtensions
 import geotrellis.vector._
+import geotrellis.util.MethodExtensions
+
 
 trait TilerKeyMethods[K1, K2] extends MethodExtensions[K1] {
   def extent: Extent

--- a/spark/src/main/scala/geotrellis/spark/tiling/TilerMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/TilerMethods.scala
@@ -6,9 +6,12 @@ import geotrellis.raster.merge._
 import geotrellis.raster.prototype._
 import geotrellis.raster.resample._
 import geotrellis.spark._
+import geotrellis.util.MethodExtensions
+
 import org.apache.spark.rdd._
 
 import scala.reflect.ClassTag
+
 
 class TilerMethods[K, V <: CellGrid: ClassTag: ? => TileMergeMethods[V]: ? => TilePrototypeMethods[V]](val self: RDD[(K, V)]) extends MethodExtensions[RDD[(K, V)]] {
   import Tiler.Options

--- a/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormatSpec.scala
@@ -2,17 +2,18 @@ package geotrellis.spark.io.s3
 
 import geotrellis.proj4.LatLng
 import geotrellis.raster._
-import geotrellis.raster.io.Filesystem
 import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.ingest._
+import geotrellis.util.Filesystem
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.task._
 import org.joda.time.format._
 import org.scalatest._
+
 
 class TemporalGeoTiffS3InputFormatSpec extends FunSpec with Matchers with TestEnvironment {
   val layoutScheme = ZoomedLayoutScheme(LatLng)

--- a/util/src/main/scala/geotrellis/util/Filesystem.scala
+++ b/util/src/main/scala/geotrellis/util/Filesystem.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package geotrellis.raster.io
+package geotrellis.util
 
 import java.nio.file._
 import java.nio.charset.StandardCharsets

--- a/util/src/main/scala/geotrellis/util/MethodExtensions.scala
+++ b/util/src/main/scala/geotrellis/util/MethodExtensions.scala
@@ -1,4 +1,4 @@
-package geotrellis.raster
+package geotrellis.util
 
 trait MethodExtensions[+T] extends Serializable {
   def self: T

--- a/vector/src/main/scala/geotrellis/vector/Dimension.scala
+++ b/vector/src/main/scala/geotrellis/vector/Dimension.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,10 +23,10 @@ sealed trait Dimensions { private[vector] val jtsGeom: jts.Geometry }
 trait AtLeastOneDimension extends Dimensions
 trait AtMostOneDimension extends Dimensions
 
-trait ZeroDimensions extends Dimensions 
+trait ZeroDimensions extends Dimensions
                         with AtMostOneDimension
 
-trait OneDimension extends Dimensions 
+trait OneDimension extends Dimensions
                        with AtMostOneDimension
                        with AtLeastOneDimension
 


### PR DESCRIPTION
A new subproject called `geotrellis-util` has been created.  It contains the files formerly-known as:
   * `raster/MethodExtensions.scala`
   * `raster/io/Filesystem.scala`

Another possible candidate is:
   * ~~`raster/PixelSampleType.scala` (doubtful)~~

The methodology for identify candidates was to run the command `grep -L 'import geotrellis' --include='*.scala' -r .` to identify files that do not make use of any imported objects/classes/methods, then to manually look through that list.  That pattern is exhibited by both `MethodExtensions.scala` and `Filesystem.scala` and seems like a reasonable criterion for identifying other candidates because it identifies files that are possibly project-agnostic.

### Still Need To ###
   - [x] Get yea or nay on `raster/PixelSampleType.scala`
   - [x] Possibly identify other candidates