### PR TITLE
Make Spurious Failure Less Likely

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
@@ -84,7 +84,7 @@ class StreamingHistogramSpec extends FunSpec with Matchers {
 
       Iterator.continually(list1)
         .flatten.take(list1.length * 10000)
-        .foreach({ i => h.countItem(i + r.nextDouble / 1000.0) })
+        .foreach({ i => h.countItem(i + (3.0 + r.nextGaussian) / 60000.0) })
 
       h.getMedian.toInt should equal (9)
       h.getMedian should equal (h.generateStatistics.median)
@@ -98,7 +98,6 @@ class StreamingHistogramSpec extends FunSpec with Matchers {
       list2.foreach({ i => h.countItem(i) })
 
       val mean = h.getMean()
-      println(s"$mean")
       abs(mean - 18194.14285714286) should be < 1e-7
       mean should equal (h.generateStatistics.mean)
     }
@@ -120,10 +119,10 @@ class StreamingHistogramSpec extends FunSpec with Matchers {
 
       Iterator.continually(list2)
         .flatten.take(list2.length * 10000)
-        .foreach({ i => h.countItem(i + r.nextDouble / 100000.0) })
+        .foreach({ i => h.countItem(i + r.nextGaussian / 10000.0) })
 
       val mean = h.getMean()
-      abs(mean - 18194.14285714286) should be < 1e-5
+      abs(mean - 18194.14285714286) should be < 1e-4
       mean should equal (h.generateStatistics.mean)
     }
   }

--- a/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
@@ -82,11 +82,17 @@ class StreamingHistogramSpec extends FunSpec with Matchers {
     it("getMedian should work when n is large with unique elements") {
       val h = StreamingHistogram()
 
+      /* Here  the list of values  is used repeatedly, but  with small
+       * perturbations to  make the values  unique (to make  sure that
+       * the maximum number of buckets  is exceeded so that the median
+       * can be tested under  those circumstances).  The perturbations
+       * should be  positive numbers  with magnitude somewhere  in the
+       * neighborhood of 1e-4.*/
       Iterator.continually(list1)
         .flatten.take(list1.length * 10000)
         .foreach({ i => h.countItem(i + (3.0 + r.nextGaussian) / 60000.0) })
 
-      h.getMedian.toInt should equal (9)
+      math.round(h.getMedian).toInt should equal (9)
       h.getMedian should equal (h.generateStatistics.median)
     }
   }
@@ -117,6 +123,13 @@ class StreamingHistogramSpec extends FunSpec with Matchers {
     it("getMean should work when n is large with unique elements") {
       val h = StreamingHistogram()
 
+      /* The  list of values is  used repeatedly here, but  with small
+       * perturbations.   The motivation  for  those  is similar  that
+       * stated above for the median case.  The difference of the mean
+       * of the perturbed list and the mean of the unperturbed list is
+       * a random variable with mean zero and standard deviation 1e-6,
+       * so this test "should never fail" unless the histogram code is
+       * faulty. */
       Iterator.continually(list2)
         .flatten.take(list2.length * 10000)
         .foreach({ i => h.countItem(i + r.nextGaussian / 10000.0) })


### PR DESCRIPTION
This *should* make a spurious failure in the `StreamingHistogramSpec` tests very unlikely.