### PR TITLE
Subsetted combine and map Methods

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/ArrayMultiBandTileSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/ArrayMultiBandTileSpec.scala
@@ -1,0 +1,78 @@
+import geotrellis.raster._
+
+import geotrellis.raster.testkit._
+
+import org.scalatest._
+
+class ArrayMultiBandTileSpec extends FunSpec {
+
+  val mbt1 =
+    ArrayMultiBandTile(
+      ArrayTile(Array.ofDim[Int](15*10).fill(1), 15, 10),
+      ArrayTile(Array.ofDim[Int](15*10).fill(2), 15, 10),
+      ArrayTile(Array.ofDim[Int](15*10).fill(3), 15, 10))
+
+  val mbt2 =
+    ArrayMultiBandTile(
+      ArrayTile(Array.ofDim[Double](15*10).fill(1.5), 15, 10),
+      ArrayTile(Array.ofDim[Double](15*10).fill(2.5), 15, 10),
+      ArrayTile(Array.ofDim[Double](15*10).fill(5.0), 15, 10))
+
+  describe("ArrayMultiBandTile subset combine methods") {
+
+    it("should work correctly on integer-valued tiles") {
+      val actual = mbt1.combine(List(0,1))({ seq: Seq[Int] => seq.sum }).toArray
+      val expected = mbt1.band(2).toArray
+
+      (actual.zip(expected)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected")
+      })
+    }
+
+    it("should work correctly on double-valued tiles") {
+      val actual = mbt2.combineDouble(List(0,1))({ seq: Seq[Double] => seq.sum + 1.0 }).toArray
+      val expected = mbt2.band(2).toArray
+
+      (actual.zip(expected)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected")
+      })
+    }
+  }
+
+  describe("ArrayMultiBandTile subset map methods") {
+
+    it("should work correctly on integer-valued tiles") {
+      val actual = mbt1.map(List(0,2))({ (band, z) => band + z })
+      val expected = ArrayMultiBandTile(
+        ArrayTile(Array.ofDim[Int](15*10).fill(1), 15, 10),
+        ArrayTile(Array.ofDim[Int](15*10).fill(2), 15, 10),
+        ArrayTile(Array.ofDim[Int](15*10).fill(5), 15, 10))
+
+      (0 until 3).foreach({ b =>
+        val actualArray = actual.band(b).toArray
+        val expectedArray = expected.band(b).toArray
+
+        actualArray.zip(expectedArray).foreach({ pair =>
+          assert(pair._1 == pair._2, s"actual should equal expected in band $b")
+        })
+      })
+    }
+
+    it("should work correctly on double-valued tiles") {
+      val actual = mbt2.mapDouble(List(0,2))({ (band, z) => band + 2.0 * z })
+      val expected = ArrayMultiBandTile(
+        ArrayTile(Array.ofDim[Double](15*10).fill(3.0), 15, 10),
+        ArrayTile(Array.ofDim[Double](15*10).fill(2.5), 15, 10),
+        ArrayTile(Array.ofDim[Double](15*10).fill(12.0), 15, 10))
+
+      (0 until 3).foreach({ b =>
+        val actualArray = actual.band(b).toArray
+        val expectedArray = expected.band(b).toArray
+
+        actualArray.zip(expectedArray).foreach({ pair =>
+          assert(pair._1 == pair._2, s"actual should equal expected in band $b")
+        })
+      })
+    }
+  }
+}

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTileSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTileSpec.scala
@@ -16,7 +16,7 @@ class GeoTiffMultiBandTileSpec extends FunSpec
     with Matchers
     with BeforeAndAfterAll
     with RasterMatchers
-    with GeoTiffTestUtils 
+    with GeoTiffTestUtils
     with TileBuilders {
 
   override def afterAll = purge

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTileSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTileSpec.scala
@@ -110,7 +110,87 @@ class GeoTiffMultiBandTileSpec extends FunSpec
     }
   }
 
-  describe("MutliBand subset methods") {
+  describe("MultiBand subset combine methods") {
+
+    it("should work correctly on integer-valued tiles") {
+      val tiles = MultiBandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
+      val band0 = tiles.band(0).toArray
+      val band2 = tiles.band(2).toArray
+      val actual = tiles.combine(List(0,2))({ seq: Seq[Int] => seq.sum }).toArray
+      val expected = band0.zip(band2).map({ pair => pair._1 + pair._2 })
+
+      (actual.zip(expected)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected")
+      })
+    }
+
+    it("should work correctly on double-valued tiles") {
+      val original =
+        ArrayMultiBandTile(
+          ArrayTile(Array.ofDim[Float](150*140).fill(1.5f), 150, 140),
+          ArrayTile(Array.ofDim[Float](150*140).fill(2.5f), 150, 140),
+          ArrayTile(Array.ofDim[Float](150*140).fill(3.5f), 150, 140))
+      val tiles = GeoTiffMultiBandTile(original)
+      val band0 = tiles.band(0).toArrayDouble
+      val band2 = tiles.band(2).toArrayDouble
+      val actual = tiles.combineDouble(List(0,2))({ seq: Seq[Double] => seq.sum }).toArray
+      val expected = band0.zip(band2).map({ pair => pair._1 + pair._2 })
+
+      (actual.zip(expected)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected")
+      })
+    }
+  }
+
+  describe("MultiBand subset map methods") {
+
+    it("should work correctly on integer-valued tiles") {
+      val tiles = MultiBandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
+      val actual = tiles.map(List(0,2))({ (band,z) => z + band + 3 })
+      val expectedBand0 = tiles.band(0).map({ z => z + 0 + 3 }).toArray
+      val expectedBand1 = tiles.band(1).toArray
+      val expectedBand2 = tiles.band(2).map({ z => z + 2 + 3 }).toArray
+
+      (actual.band(0).toArray.zip(expectedBand0)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected in band 0")
+      })
+
+      (actual.band(1).toArray.zip(expectedBand1)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected in band 1")
+      })
+
+      (actual.band(2).toArray.zip(expectedBand2)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected in band 2")
+      })
+    }
+
+    it("should work correctly on double-valued tiles") {
+      val original =
+        ArrayMultiBandTile(
+          ArrayTile(Array.ofDim[Float](150*140).fill(1.5f), 150, 140),
+          ArrayTile(Array.ofDim[Float](150*140).fill(2.5f), 150, 140),
+          ArrayTile(Array.ofDim[Float](150*140).fill(3.5f), 150, 140))
+      val tiles = GeoTiffMultiBandTile(original)
+      val actual = tiles.mapDouble(List(0,2))({ (band,z) => z + band + 3.5 })
+      val expectedBand0 = tiles.band(0).mapDouble({ z => z + 0 + 3.5 }).toArrayDouble
+      val expectedBand1 = tiles.band(1).toArrayDouble
+      val expectedBand2 = tiles.band(2).mapDouble({ z => z + 2 + 3.5 }).toArrayDouble
+
+      (actual.band(0).toArrayDouble.zip(expectedBand0)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected in band 0")
+      })
+
+      (actual.band(1).toArrayDouble.zip(expectedBand1)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected in band 1")
+      })
+
+      (actual.band(2).toArrayDouble.zip(expectedBand2)).foreach({ pair =>
+        assert(pair._1 == pair._2, "actual should equal expected in band 2")
+      })
+    }
+  }
+
+  describe("MultiBand subset methods") {
 
     it("subset should be inexpensive") {
       val tile0 = MultiBandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
@@ -138,6 +138,46 @@ class ArrayMultiBandTile(bands: Array[Tile]) extends MultiBandTile {
     band(b0) foreachDouble f
   }
 
+  /**
+    * Combine a subset of the bands of a tile into a new
+    * integer-valued multiband tile using the function f.
+    *
+    * @param    subset   A sequence containing the subset of bands that are of interest.
+    * @param    f        A function to combine the bands.
+    */
+  def combine(subset: Seq[Int])(f: Seq[Int] => Int): Tile = {
+    subset.foreach({ b => require(0 <= b && b < bandCount, "All elements of subset must be present") })
+
+    val result = ArrayTile.empty(cellType, cols, rows)
+    cfor(0)(_ < rows, _ + 1) { row =>
+      cfor(0)(_ < cols, _ + 1) { col =>
+        val data = subset.map({ b => band(b).get(col, row) })
+        result.set(col, row, f(data))
+      }
+    }
+    result
+  }
+
+  /**
+    * Combine a subset of the bands of a tile into a new double-valued
+    * multiband tile using the function f.
+    *
+    * @param    subset   A sequence containing the subset of bands that are of interest.
+    * @param    f        A function to combine the bands.
+    */
+  def combineDouble(subset: Seq[Int])(f: Seq[Double] => Double): Tile = {
+    subset.foreach({ b => require(0 <= b && b < bandCount, "All elements of subset must be present") })
+
+    val result = ArrayTile.empty(cellType, cols, rows)
+    cfor(0)(_ < rows, _ + 1) { row =>
+      cfor(0)(_ < cols, _ + 1) { col =>
+        val data = subset.map({ b => band(b).getDouble(col, row) })
+        result.setDouble(col, row, f(data))
+      }
+    }
+    result
+  }
+
   /** Combine each int band value for each cell.
     * This method will be inherently slower than calling a method with explicitly stated bands,
     * so if you have as many or fewer bands to combine than an explicit method call, use that.

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
@@ -55,6 +55,60 @@ class ArrayMultiBandTile(bands: Array[Tile]) extends MultiBandTile {
     ArrayMultiBandTile(newBands)
   }
 
+  /**
+    * Map over a subset of the bands of a multiband tile to create a
+    * new integer-valued multiband tile.
+    *
+    * @param    subset   A sequence containing the subset of bands that are of interest.
+    * @param    f        A function to map over the bands.
+    */
+  def map(subset: Seq[Int])(f: (Int, Int) => Int): MultiBandTile = {
+    val newBands = Array.ofDim[Tile](bandCount)
+    val set = subset.toSet
+
+    subset.foreach({ b =>
+      require(0 <= b && b < bandCount, "All elements of subset must be present")
+    })
+
+    (0 until bandCount).foreach({ b =>
+      if (set.contains(b))
+        newBands(b) = band(b).map({ z => f(b, z) })
+      else if (cellType.isFloatingPoint)
+        newBands(b) = band(b).map({ z => z })
+      else
+        newBands(b) = band(b)
+    })
+
+    ArrayMultiBandTile(newBands)
+  }
+
+  /**
+    * Map over a subset of the bands of a multiband tile to create a
+    * new double-valued multiband tile.
+    *
+    * @param    subset   A sequence containing the subset of bands that are of interest.
+    * @param    f        A function to map over the bands.
+    */
+  def mapDouble(subset: Seq[Int])(f: (Int, Double) => Double): MultiBandTile = {
+    val newBands = Array.ofDim[Tile](bandCount)
+    val set = subset.toSet
+
+    subset.foreach({ b =>
+      require(0 <= b && b < bandCount, "All elements of subset must be present")
+    })
+
+    (0 until bandCount).foreach({ b =>
+      if (set.contains(b))
+        newBands(b) = band(b).mapDouble({ z => f(b, z) })
+      else if (cellType.isFloatingPoint)
+        newBands(b) = band(b)
+      else
+        newBands(b) = band(b).mapDouble({ z => z })
+    })
+
+    ArrayMultiBandTile(newBands)
+  }
+
   /** Map each band's int value.
     * @param       f       Function that takes in a band number and a value, and returns the mapped value for that cell value.
     */

--- a/raster/src/main/scala/geotrellis/raster/MultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/MultiBandTile.scala
@@ -17,6 +17,24 @@ trait MultiBandTile extends CellGrid with MacroCombinableMultiBandTile[Tile] {
 
   def convert(newCellType: CellType): MultiBandTile
 
+  /**
+    * Map over a subset of the bands of a multiband tile to create a
+    * new integer-valued multiband tile.
+    *
+    * @param    subset   A sequence containing the subset of bands that are of interest.
+    * @param    f        A function to map over the bands.
+    */
+  def map(subset: Seq[Int])(f: (Int, Int) => Int): MultiBandTile
+
+  /**
+    * Map over a subset of the bands of a multiband tile to create a
+    * new double-valued multiband tile.
+    *
+    * @param    subset   A sequence containing the subset of bands that are of interest.
+    * @param    f        A function to map over the bands.
+    */
+  def mapDouble(subset: Seq[Int])(f: (Int, Double) => Double): MultiBandTile
+
   /** Map each band's int value.
     * @param       f       Function that takes in a band number and a value, and returns the mapped value for that cell value.
     */

--- a/raster/src/main/scala/geotrellis/raster/MultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/MultiBandTile.scala
@@ -60,6 +60,24 @@ trait MultiBandTile extends CellGrid with MacroCombinableMultiBandTile[Tile] {
     */
   def foreachDouble(b0: Int)(f: Double => Unit): Unit
 
+  /**
+    * Combine a subset of the bands of a tile into a new
+    * integer-valued multiband tile using the function f.
+    *
+    * @param    subset   A sequence containing the subset of bands that are of interest.
+    * @param    f        A function to combine the bands.
+    */
+  def combine(subset: Seq[Int])(f: Seq[Int] => Int): Tile
+
+  /**
+    * Combine a subset of the bands of a tile into a new double-valued
+    * multiband tile using the function f.
+    *
+    * @param    subset   A sequence containing the subset of bands that are of interest.
+    * @param    f        A function to combine the bands.
+    */
+  def combineDouble(subset: Seq[Int])(f: Seq[Double] => Double): Tile
+
   /** Combine each int band value for each cell.
     * This method will be inherently slower than calling a method with explicitly stated bands,
     * so if you have as many or fewer bands to combine than an explicit method call, use that.

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTile.scala
@@ -446,6 +446,36 @@ abstract class GeoTiffMultiBandTile(
     }
   }
 
+  /**
+    * Piggy-back on the other combine method to support combing a
+    * subset of the bands.
+    */
+  def combine(subset: Seq[Int])(f: Seq[Int] => Int): Tile = {
+    subset.foreach({ b => require(0 <= b && b < bandCount, "All elements of subset must be present") })
+
+    val fn = { array: Array[Int] =>
+      val data = subset.map({ i => array(i) })
+      f(data)
+    }
+
+    combine(fn)
+  }
+
+  /**
+    * Piggy-back on the other combineDouble method to support
+    * combining a subset of the bands.
+    */
+  def combineDouble(subset: Seq[Int])(f: Seq[Double] => Double): Tile = {
+    subset.foreach({ b => require(0 <= b && b < bandCount, "All elements of subset must be present") })
+
+    val fn = { array: Array[Double] =>
+      val data = subset.map({ i => array(i) })
+      f(data)
+    }
+
+    combineDouble(fn)
+  }
+
   override
   def combine(f: Array[Int] => Int): Tile =
     _combine(_.initValueHolder)({ segmentCombiner => segmentCombiner.placeValue _ })({ segmentCombiner =>
@@ -518,14 +548,14 @@ abstract class GeoTiffMultiBandTile(
     )
   }
 
-  def combine(b0: Int,b1: Int)(f: (Int, Int) => Int): Tile =
+  def combine(b0: Int, b1: Int)(f: (Int, Int) => Int): Tile =
     _combine(b0: Int, b1: Int) { segmentCombiner =>
       { (targetIndex: Int, s1: GeoTiffSegment, i1: Int, s2: GeoTiffSegment, i2: Int) =>
         segmentCombiner.set(targetIndex, s1, i1, s2, i2)(f)
       }
     }
 
-  def combineDouble(b0: Int,b1: Int)(f: (Double, Double) => Double): Tile =
+  def combineDouble(b0: Int, b1: Int)(f: (Double, Double) => Double): Tile =
     _combine(b0: Int, b1: Int) { segmentCombiner =>
       { (targetIndex: Int, s1: GeoTiffSegment, i1: Int, s2: GeoTiffSegment, i2: Int) =>
         segmentCombiner.setDouble(targetIndex, s1, i1, s2, i2)(f)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTile.scala
@@ -239,6 +239,34 @@ abstract class GeoTiffMultiBandTile(
     )
   }
 
+  /**
+    * Piggy-back on the other map method to support mapping a subset
+    * of the bands.
+    */
+  def map(subset: Seq[Int])(f: (Int, Int) => Int): MultiBandTile = {
+    val set = subset.toSet
+    val fn = { (bandIndex: Int, z: Int) =>
+      if (set.contains(bandIndex)) f(bandIndex, z)
+      else z
+    }
+
+    map(fn)
+  }
+
+  /**
+    * Piggy-back on the other map method to support mapping a subset
+    * of the bands.
+    */
+  def mapDouble(subset: Seq[Int])(f: (Int, Double) => Double): MultiBandTile = {
+    val set = subset.toSet
+    val fn = { (bandIndex: Int, z: Double) =>
+      if (set.contains(bandIndex)) f(bandIndex, z)
+      else z
+    }
+
+    mapDouble(fn)
+  }
+
   def map(b0: Int)(f: Int => Int): MultiBandTile =
     if(hasPixelInterleave) {
       mapSegments { (segment, _) =>

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
@@ -56,7 +56,7 @@ object GeoTiffTile {
     val compressor = options.compression.createCompressor(segmentCount)
 
     val compressedBytes = Array.ofDim[Array[Byte]](segmentCount)
-    val segmentTiles = 
+    val segmentTiles =
       options.storageMethod match {
         case _: Tiled => CompositeTile.split(tile, segmentLayout.tileLayout)
         case _: Striped => CompositeTile.split(tile, segmentLayout.tileLayout, extend = false)
@@ -339,7 +339,7 @@ abstract class GeoTiffTile(
         }
     }
 
-  def toArray(): Array[Int] = 
+  def toArray(): Array[Int] =
     toArrayTile.toArray
 
   def toArrayDouble(): Array[Double] =

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffTile.scala
@@ -14,7 +14,7 @@ class UInt32GeoTiffTile(
   def mutable: MutableArrayTile = {
     val arr = Array.ofDim[Float](cols * rows)
     cfor(0)(_ < segmentCount, _ + 1) { segmentIndex =>
-      val segment = 
+      val segment =
         getSegment(segmentIndex)
       val segmentTransform = segmentLayout.getSegmentTransform(segmentIndex)
       cfor(0)(_ < segment.size, _ + 1) { i =>


### PR DESCRIPTION
Subsetted versions of the `combine` and `map` methods are provided for all `MultiBandTile` derived types.  These are "subsetted" in the sense that they allow combining (respectively mapping) over a subset of the bands of a `MultiBandTile`.