### PR TITLE
Supply build.sbt File for geotrellis-util

### DIFF
--- a/util/build.sbt
+++ b/util/build.sbt
@@ -1,0 +1,3 @@
+import Dependencies._
+
+name := "geotrellis-util"


### PR DESCRIPTION
This change supplies a `build.sbt` file for the `geotrellis-util` project.