### PR TITLE
Add scaladoc generation on building of master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ _SUCCESS
 *.swo
 *.sublime-*
 .vagrant
+
+lib
+index.html
+index.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,5 @@ deploy:
       scala: "2.11.5"
 
 after_deploy:
+  - bash .travis/scaladocs.sh
   - rm -f "${HOME}/.bintray/.credentials"

--- a/.travis/scaladocs.sh
+++ b/.travis/scaladocs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+if [ "$TRAVIS_BRANCH" != "master" ]
+then
+  echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
+  exit 0
+fi
+
+rev=$(git rev-parse --short HEAD)
+
+cd stage/_book
+
+# Build docs
+./sbt "++2.11.5 unidoc"
+
+# Set up git
+git config --global user.email "azaveadev@azavea.com"
+git config --global user.name "azaveaci"
+
+# Inside scaladocs from hereon
+git clone https://github.com/geotrellis/scaladocs.git
+rm -rf scaladocs/latest
+mv target/scala-2.11/unidoc scaladocs/latest
+cd scaladocs
+git remote add originAuth https://$CI_GH_TOKEN@github.com/geotrellis/scaladocs.git
+
+git add -A .
+git commit -m "rebuild scaladocs at ${rev}"
+git push -q originAuth HEAD:gh-pages

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import Dependencies._
+import UnidocKeys._
 
 lazy val commonSettings = Seq(
   version := Version.geotrellis,
@@ -16,6 +17,7 @@ lazy val commonSettings = Seq(
     "-language:higherKinds",
     "-language:postfixOps",
     "-language:existentials",
+    "-language:experimental.macros",
     "-feature"),
   publishMavenStyle := true,
   publishArtifact in Test := false,
@@ -27,6 +29,8 @@ lazy val commonSettings = Seq(
   bintrayPackageLabels := Info.tags,
 
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.7.1" cross CrossVersion.binary),
+
+  addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
 
   pomExtra := (
     <scm>
@@ -50,7 +54,9 @@ lazy val commonSettings = Seq(
 
 lazy val root = Project("geotrellis", file(".")).
   dependsOn(raster, vector, proj4, spark).
+  settings(commonSettings: _*).
   settings(
+    scalacOptions in (ScalaUnidoc, unidoc) += "-Ymacro-expand:none",
     initialCommands in console :=
       """
       import geotrellis.raster._
@@ -58,6 +64,7 @@ lazy val root = Project("geotrellis", file(".")).
       import geotrellis.proj4._
       """
   )
+  .settings(unidocSettings: _*)
 
 lazy val macros = Project("macros", file("macros")).
   settings(commonSettings: _*)

--- a/package.html
+++ b/package.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html >
+<html>
+        <head>
+          <title>root - _root_</title>
+          <meta name="description" content="root - root " />
+          <meta name="keywords" content="root root " />
+          <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+          
+      <link href="lib/template.css" media="screen" type="text/css" rel="stylesheet" />
+      <link href="lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
+      <script type="text/javascript" src="lib/jquery.js" id="jquery-js"></script>
+      <script type="text/javascript" src="lib/jquery-ui.js"></script>
+      <script type="text/javascript" src="lib/template.js"></script>
+      <script type="text/javascript" src="lib/tools.tooltip.js"></script>
+      
+      <script type="text/javascript">
+         if(top === self) {
+            var url = 'index.html';
+            var hash = 'package';
+            var anchor = window.location.hash;
+            var anchor_opt = '';
+            if (anchor.length >= 1)
+              anchor_opt = '@' + anchor.substring(1);
+            window.location.href = url + '#' + hash + anchor_opt;
+         }
+   	  </script>
+    
+        </head>
+        <body class="value">
+      <div id="definition">
+        <img alt="Package" src="lib/package_big.png" />
+        
+        <h1>root package</h1><span class="permalink">
+      <a href="index.html#package" title="Permalink" target="_top">
+        <img src="lib/permalink.png" alt="Permalink" />
+      </a>
+    </span>
+      </div>
+
+      <h4 id="signature" class="signature">
+      <span class="modifier_kind">
+        <span class="modifier"></span>
+        <span class="kind">package</span>
+      </span>
+      <span class="symbol">
+        <span class="name">root</span>
+      </span>
+      </h4>
+      
+          <div id="comment" class="fullcommenttop"></div>
+        
+
+      <div id="mbrsel">
+        <div id="textfilter"><span class="pre"></span><span class="input"><input id="mbrsel-input" type="text" accesskey="/" /></span><span class="post"></span></div>
+        
+        
+        <div id="visbl">
+            <span class="filtertype">Visibility</span>
+            <ol><li class="public in"><span>Public</span></li><li class="all out"><span>All</span></li></ol>
+          </div>
+      </div>
+
+      <div id="template">
+        <div id="allMembers">
+        
+
+        
+
+        
+
+        
+
+        
+
+        
+        </div>
+
+        <div id="inheritedMembers">
+        
+        
+        </div>
+
+        <div id="groupedMembers">
+        
+        </div>
+
+      </div>
+
+      <div id="tooltip"></div>
+
+      <div id="footer">  </div>
+
+
+    </body>
+      </html>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,8 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
 
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
+
 addSbtPlugin("com.eed3si9n" % "sbt-dirty-money" % "0.1.0")
 
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")


### PR DESCRIPTION
This PR adds automated building of scaladocs. Two steps remain:

1. setting up CI_GH_TOKEN on travis for the azaveadev github account
2. cleaning up the output to exclude akka and some other third party libs that get pulled in