### PR TITLE
WIP: Input src in etl and ingest objects

### DIFF
--- a/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
@@ -81,27 +81,11 @@ case class Etl(args: Seq[String], @transient modules: Seq[TypedModule] = Etl.def
     tuple
   }
 
-  def collectMetadata[I: ProjectedExtentComponent, V <: CellGrid](rdd: RDD[(I, V)])(implicit sc: SparkContext): (Int, M) = {
-    val crs = conf.crs()
-    val targetCellType = conf.cellType.get
-
+  def collectMetadata[I: ProjectedExtentComponent, V <: CellGrid](rdd: RDD[(I, V)])(implicit sc: SparkContext): (Int, M) =
     scheme match {
-      case Left(layoutScheme) =>
-        val (zoom, rmd) = RasterMetaData.fromRdd(rdd, crs, layoutScheme) { key => key.projectedExtent.extent }
-        targetCellType match {
-          case None => zoom -> rmd
-          case Some(ct) => zoom -> rmd.copy(cellType = ct)
-        }
-
-      case Right(layoutDefinition) =>
-        0 -> RasterMetaData(
-          crs = crs,
-          cellType = targetCellType.get,
-          extent = layoutDefinition.extent,
-          layout = layoutDefinition
-        )
+      case Left(layoutScheme: LayoutScheme) => RasterMetaData.fromRdd(rdd, layoutScheme)
+      case Right(layoutDefinition) => 0 -> RasterMetaData.fromRdd(rdd, layoutDefinition)
     }
-  }
 
   def save[
     K: SpatialComponent: TypeTag,

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
@@ -106,7 +106,7 @@ case class Etl(args: Seq[String], @transient modules: Seq[TypedModule] = Etl.def
 
       scheme match {
         case Left(s) =>
-          if (conf.pyramid() && zoom > 1) {
+          if (conf.pyramid() && zoom >= 1) {
             val (nextLevel, nextRdd) = Pyramid.up(rdd, s, zoom)
             savePyramid(nextLevel, nextRdd)
           }

--- a/spark/src/main/scala/geotrellis/spark/ingest/Ingest.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/Ingest.scala
@@ -65,8 +65,7 @@ object Ingest {
     )
     (sink: (RasterRDD[K], Int) => Unit): Unit =
   {
-    val (_, rasterMetaData) =
-      RasterMetaData.fromRdd(sourceTiles, destCRS, layoutScheme)(_.projectedExtent.extent)
+    val (_, rasterMetaData) = RasterMetaData.fromRdd(sourceTiles, layoutScheme)
     val tiledRdd = sourceTiles.tileToLayout(rasterMetaData, resampleMethod).cache()
     val contextRdd = new ContextRDD(tiledRdd, rasterMetaData)
     val (zoom, rasterRdd) = bufferSize.fold(contextRdd.reproject(destCRS, layoutScheme))(contextRdd.reproject(destCRS, layoutScheme, _))

--- a/spark/src/main/scala/geotrellis/spark/ingest/MultiBandIngest.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/MultiBandIngest.scala
@@ -23,8 +23,7 @@ object MultiBandIngest {
     bufferSize: Option[Int] = None)
     (sink: (MultiBandRasterRDD[K], Int) => Unit): Unit =
   {
-    val (_, rasterMetaData) =
-      RasterMetaData.fromRdd(sourceTiles, destCRS, layoutScheme)(_.projectedExtent.extent)
+    val (_, rasterMetaData) = RasterMetaData.fromRdd(sourceTiles, layoutScheme)
     val tiledRdd = sourceTiles.tileToLayout(rasterMetaData, resampleMethod).cache()
     val contextRdd = new ContextRDD(tiledRdd, rasterMetaData)
     val (zoom, rasterRdd) = bufferSize.fold(contextRdd.reproject(destCRS, layoutScheme))(contextRdd.reproject(destCRS, layoutScheme, _))


### PR DESCRIPTION
Currently input crs forces to be equal dest crs. 

- [x] fix inputs crs in Etl and in Ingest objects
- [x] test it on tiles in different projections
  - [x] webmerc (chatta demo)
  - [x] sinus (modis, MOD13Q1: ingested `2015 001 18 03`)
  - [x] utm (lc8: ingested `LC82010352015188LGN00_B2.TIF`)
  - [ ] latlng 