### PR TITLE
Raster RDD Filter Methods

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
+++ b/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
@@ -19,9 +19,9 @@ sealed trait Bounds[+A] extends Product with Serializable {
   def intersects[B >: A](other: KeyBounds[B])(implicit b: Boundable[B]): Boolean =
     intersect(other).nonEmpty
 
-  def get: KeyBounds[A] 
+  def get: KeyBounds[A]
 
-  def getOrElse[B >: A](default: => KeyBounds[B]): KeyBounds[B] = 
+  def getOrElse[B >: A](default: => KeyBounds[B]): KeyBounds[B] =
     if (isEmpty) default else this.get
 }
 

--- a/spark/src/main/scala/geotrellis/spark/io/RDDFilter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/RDDFilter.scala
@@ -114,16 +114,17 @@ object Intersects {
   }
 
   /** Define Intersects filter for Polygon */
-  implicit def forPolygon[K: SpatialComponent: Boundable, M] =
+  implicit def forPolygon[K: SpatialComponent: Boundable, M: (? => {def mapTransform: MapKeyTransform})] =
     new RDDFilter[K, Intersects.type, MultiPolygon, M] {
       def apply(metadata: M, kb: KeyBounds[K], polygon: MultiPolygon) = {
         val extent = polygon.envelope
-        val keyext = metadata.asInstanceOf[RasterMetaData].mapTransform(kb.minKey)
-        val bounds = metadata.asInstanceOf[RasterMetaData].mapTransform(extent)
+        val keyext = metadata.mapTransform(kb.minKey)
+        val bounds = metadata.mapTransform(extent)
         val options = Options(includePartial=true, sampleType=PixelIsArea)
+
         /*
-         * Construct a rasterExtent that fits tightly around the
-         * candidate tiles (the candidate keys).  IT IS ASSUMED THAT
+         * Construct  a  rasterExtent  that fits  tightly  around  the
+         * candidate tiles  (the candidate keys).  IT  IS ASSUMED THAT
          * ALL TILES HAVE THE SAME LENGTH AND HEIGHT.
          */
         val xmin = math.floor(extent.min.x / keyext.width) * keyext.width

--- a/spark/src/main/scala/geotrellis/spark/io/filter/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/filter/Implicits.scala
@@ -1,0 +1,15 @@
+package geotrellis.spark.filter
+
+import geotrellis.spark._
+
+import org.apache.spark.rdd._
+
+import scala.reflect.ClassTag
+
+
+object Implicits extends Implicits
+
+trait Implicits {
+  implicit class withRasterRDDFilterMethods[K: Boundable : ClassTag, V: ClassTag, M](val self: RDD[(K, V)] with Metadata[M])
+      extends RasterRDDFilterMethods[K, V, M]
+}

--- a/spark/src/main/scala/geotrellis/spark/io/filter/RasterRDDFilterMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/filter/RasterRDDFilterMethods.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.filter
+
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.util.MethodExtensions
+
+import org.apache.spark.rdd._
+
+
+abstract class RasterRDDFilterMethods[K: Boundable, V, M] extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
+  type FilterChainArg = (M, List[KeyBounds[K]])
+
+  /**
+    * A method that takes a sequence of [[KeyBounds]] objects and
+    * returns an [[BoundedRDDQuery]] which filters out all keys in the
+    * RDD not contained in the union of the given KeyBounds.
+    *
+    * @param  keybounds A sequence of KeyBounds[K] objects
+    * @return           An RDDQuery that filters out keys in the RDD not found in keybounds
+    */
+  def filterByKeyBounds(keybounds: Seq[KeyBounds[K]]): BoundRDDQuery[K, M, RDD[(K, V)] with Metadata[M]] = {
+    val rdd = self.filter({ case (k, _) => keybounds.exists({ kb => kb.includes(k) }) })
+    val metadata = self.metadata
+    val fn: RDDQuery[K, M] => RDD[(K, V)] with Metadata[M] = { _ => ContextRDD(rdd, metadata) }
+
+    new BoundRDDQuery[K, M, RDD[(K, V)] with Metadata[M]](new RDDQuery, fn)
+  }
+
+  /**
+    * A method that takes a single [[KeyBounds]] object and returns an
+    * [[BoundedRDDQuery]] which filters out all keys in the RDD not
+    * contained in the given KeyBounds.
+    *
+    * @param  keybounds A KeyBounds[K] object
+    * @return           An RDDQuery that filters out keys in the RDD not found in kb
+    */
+  def filterByKeyBounds(kb: KeyBounds[K]): BoundRDDQuery[K, M, RDD[(K, V)] with Metadata[M]] =
+    filterByKeyBounds(List(kb))
+}

--- a/spark/src/main/scala/geotrellis/spark/io/filter/RasterRDDFilterMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/filter/RasterRDDFilterMethods.scala
@@ -24,32 +24,29 @@ import org.apache.spark.rdd._
 
 
 abstract class RasterRDDFilterMethods[K: Boundable, V, M] extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
-  type FilterChainArg = (M, List[KeyBounds[K]])
-
   /**
     * A method that takes a sequence of [[KeyBounds]] objects and
-    * returns an [[BoundedRDDQuery]] which filters out all keys in the
-    * RDD not contained in the union of the given KeyBounds.
+    * returns a [[RasterRDD]] in-which all keys in the original RDD
+    * which are not contained in the union of the given KeyBounds have
+    * been filtered-out.
     *
     * @param  keybounds A sequence of KeyBounds[K] objects
-    * @return           An RDDQuery that filters out keys in the RDD not found in keybounds
+    * @return           A filtered RasterRDD
     */
-  def filterByKeyBounds(keybounds: Seq[KeyBounds[K]]): BoundRDDQuery[K, M, RDD[(K, V)] with Metadata[M]] = {
+  def filterByKeyBounds(keybounds: Seq[KeyBounds[K]]): RDD[(K, V)] with Metadata[M] = {
     val rdd = self.filter({ case (k, _) => keybounds.exists({ kb => kb.includes(k) }) })
     val metadata = self.metadata
-    val fn: RDDQuery[K, M] => RDD[(K, V)] with Metadata[M] = { _ => ContextRDD(rdd, metadata) }
-
-    new BoundRDDQuery[K, M, RDD[(K, V)] with Metadata[M]](new RDDQuery, fn)
+    ContextRDD(rdd, metadata)
   }
 
   /**
-    * A method that takes a single [[KeyBounds]] object and returns an
-    * [[BoundedRDDQuery]] which filters out all keys in the RDD not
-    * contained in the given KeyBounds.
+    * A method that takes a single [[KeyBounds]] objects and returns a
+    * [[RasterRDD]] in-which all keys in the original RDD which are
+    * not contained in the KeyBounds have been filtered-out.
     *
-    * @param  keybounds A KeyBounds[K] object
-    * @return           An RDDQuery that filters out keys in the RDD not found in kb
+    * @param  keybounds A sequence of KeyBounds[K] objects
+    * @return           A filtered RasterRDD
     */
-  def filterByKeyBounds(kb: KeyBounds[K]): BoundRDDQuery[K, M, RDD[(K, V)] with Metadata[M]] =
+  def filterByKeyBounds(kb: KeyBounds[K]): RDD[(K, V)] with Metadata[M] =
     filterByKeyBounds(List(kb))
 }

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -23,6 +23,8 @@ import geotrellis.proj4._
 import geotrellis.spark.tiling._
 import geotrellis.spark.ingest._
 import geotrellis.spark.crop._
+import geotrellis.spark.filter._
+
 import org.apache.spark.Partitioner
 import org.apache.spark.rdd._
 
@@ -127,6 +129,9 @@ package object spark
         }
       }, preservesPartitioning = true)
   }
+
+  implicit class withRasterRDDFilterMethods[K: Boundable : ClassTag, V: ClassTag, M](val self: RDD[(K, V)] with Metadata[M])
+      extends RasterRDDFilterMethods[K, V, M]
 
   /** Keeps with the convention while still using simple tups, nice */
   implicit class TileTuple[K](tup: (K, Tile)) {

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -52,6 +52,7 @@ package object spark
     with mapalgebra.focal.hillshade.Implicits
     with partitioner.Implicits
     with crop.Implicits
+    with filter.Implicits
     with Serializable // required for java serialization, even though it's mixed in
 {
 
@@ -129,9 +130,6 @@ package object spark
         }
       }, preservesPartitioning = true)
   }
-
-  implicit class withRasterRDDFilterMethods[K: Boundable : ClassTag, V: ClassTag, M](val self: RDD[(K, V)] with Metadata[M])
-      extends RasterRDDFilterMethods[K, V, M]
 
   /** Keeps with the convention while still using simple tups, nice */
   implicit class TileTuple[K](tup: (K, Tile)) {

--- a/spark/src/test/scala/geotrellis/spark/RasterRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterRDDFilterMethodsSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.filter
+
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.filter._
+import geotrellis.raster.io.geotiff.SingleBandGeoTiff
+
+import org.scalatest.FunSpec
+
+
+class RasterRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
+
+  describe("RasterRDD Crop Methods") {
+    val path = "raster-test/data/aspect.tif"
+    val gt = SingleBandGeoTiff(path)
+    val originalRaster = gt.raster.resample(500, 500)
+    val (_, rdd) = createRasterRDD(originalRaster, 5, 5, gt.crs)
+    val allKeys = KeyBounds(SpatialKey(0,0), SpatialKey(4,4))
+    val someKeys = KeyBounds(SpatialKey(1,1), SpatialKey(3,3))
+    val moreKeys = KeyBounds(SpatialKey(4,4), SpatialKey(4,4))
+    val noKeys = KeyBounds(SpatialKey(5,5), SpatialKey(6,6))
+
+    it("should correctly filter by a covering range") {
+      val query = rdd.filterByKeyBounds(List(allKeys))
+      query.toRDD.count should be (25)
+    }
+
+    it("should correctly filter by an intersecting range") {
+      val query = rdd.filterByKeyBounds(List(someKeys))
+      query.toRDD.count should be (9)
+    }
+
+    it("should correctly filter by an intersecting range given as a singleton") {
+      val query = rdd.filterByKeyBounds(someKeys)
+      query.toRDD.count should be (9)
+    }
+
+    it("should correctly filter by a non-intersecting range") {
+      val query = rdd.filterByKeyBounds(List(noKeys))
+      query.toRDD.count should be (0)
+    }
+
+    it("should correctly filter by multiple ranges") {
+      val query = rdd.filterByKeyBounds(List(someKeys, moreKeys, noKeys))
+      query.toRDD.count should be (10)
+    }
+  }
+}
+

--- a/spark/src/test/scala/geotrellis/spark/RasterRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterRDDFilterMethodsSpec.scala
@@ -38,28 +38,27 @@ class RasterRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
 
     it("should correctly filter by a covering range") {
       val query = rdd.filterByKeyBounds(List(allKeys))
-      query.toRDD.count should be (25)
+      query.count should be (25)
     }
 
     it("should correctly filter by an intersecting range") {
       val query = rdd.filterByKeyBounds(List(someKeys))
-      query.toRDD.count should be (9)
+      query.count should be (9)
     }
 
     it("should correctly filter by an intersecting range given as a singleton") {
       val query = rdd.filterByKeyBounds(someKeys)
-      query.toRDD.count should be (9)
+      query.count should be (9)
     }
 
     it("should correctly filter by a non-intersecting range") {
       val query = rdd.filterByKeyBounds(List(noKeys))
-      query.toRDD.count should be (0)
+      query.count should be (0)
     }
 
     it("should correctly filter by multiple ranges") {
       val query = rdd.filterByKeyBounds(List(someKeys, moreKeys, noKeys))
-      query.toRDD.count should be (10)
+      query.count should be (10)
     }
   }
 }
-


### PR DESCRIPTION
These changes add a `filterByKeyBounds` method to the `RasterRDD` type that allows the same to be filtered by one or more `KeyBounds`.

~~The `.filterByKeyBounds(...)` method returns a `BoundedRDDQuery` instead of an `RDDQuery` because the former has a `toRDD` method and the latter does not.~~

### Still Need To ###
   - [x] ~~Confirm that this covers the requirement ".filter method which returns an RDDQuery, whose .toRDD method will produce the filtered RDD"~~