### PR TITLE
BufferTiles Fix

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/buffer/BufferTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/BufferTiles.scala
@@ -25,8 +25,8 @@ object BufferTiles {
   case object TopLeft extends Direction
 
   def collectWithNeighbors[K: SpatialComponent, V <: CellGrid: (? => CropMethods[V])](
-    key: K, 
-    tile: V, 
+    key: K,
+    tile: V,
     includeKey: SpatialKey => Boolean,
     getBufferSizes: SpatialKey => BufferSizes
   ): Seq[(K, (Direction, V))] = {
@@ -123,12 +123,12 @@ object BufferTiles {
   }
 
   /** Buffer the tiles of type V by a constant buffer size.
-    * 
+    *
     * This function will return each of the tiles with a buffer added to them by the contributions of adjacent, abutting tiles.
-    * 
+    *
     * @tparam         K                 The key of this tile set RDD, requiring a spatial component.
     * @tparam         V                 The tile type, requires a Stitcher[V] and implicit conversion to CropMethods[V]
-    * 
+    *
     * @param          rdd               The keyed tile rdd.
     * @param          bufferSize        Number of pixels to buffer the tile with. The tile will only be buffered by this amount on
     *                                   any side if there is an adjacent, abutting tile to contribute the border pixels.
@@ -140,12 +140,12 @@ object BufferTiles {
     apply(rdd, bufferSize, GridBounds(Int.MinValue, Int.MinValue, Int.MaxValue, Int.MaxValue))
 
   /** Buffer the tiles of type V by a constant buffer size.
-    * 
+    *
     * This function will return each of the tiles with a buffer added to them by the contributions of adjacent, abutting tiles.
-    * 
+    *
     * @tparam         K                 The key of this tile set RDD, requiring a spatial component.
     * @tparam         V                 The tile type, requires a Stitcher[V] and implicit conversion to CropMethods[V]
-    * 
+    *
     * @param          rdd               The keyed tile rdd.
     * @param          bufferSize        Number of pixels to buffer the tile with. The tile will only be buffered by this amount on
     *                                   any side if there is an adjacent, abutting tile to contribute the border pixels.
@@ -160,7 +160,7 @@ object BufferTiles {
     val bufferSizes = BufferSizes(bufferSize, bufferSize, bufferSize, bufferSize)
     val tilesAndSlivers =
       rdd
-        .flatMap { case (key, tile) => 
+        .flatMap { case (key, tile) =>
           collectWithNeighbors(key, tile, { key => layerBounds.contains(key.col, key.row) }, { key => bufferSizes })
         }
 
@@ -174,12 +174,12 @@ object BufferTiles {
   }
 
   /** Buffer the tiles of type V by a dynamic buffer size.
-    * 
+    *
     * This function will return each of the tiles with a buffer added to them by the contributions of adjacent, abutting tiles.
-    * 
+    *
     * @tparam         K                 The key of this tile set RDD, requiring a spatial component.
     * @tparam         V                 The tile type, requires a Stitcher[V] and implicit conversion to CropMethods[V]
-    * 
+    *
     * @param          rdd               The keyed tile rdd.
     * @param          getBufferSize     A function which returns the BufferSizes that should be used for a tile at this Key.
     */
@@ -193,19 +193,19 @@ object BufferTiles {
           partition.map { case (key, _) => (key, getBufferSizes(key)) }
         }, preservesPartitioning = true)
         .persist(StorageLevel.MEMORY_ONLY)
- 
+
     val result = apply(rdd, bufferSizesPerKey)
     bufferSizesPerKey.unpersist(blocking = false)
     result
   }
 
   /** Buffer the tiles of type V by a dynamic buffer size.
-    * 
+    *
     * This function will return each of the tiles with a buffer added to them by the contributions of adjacent, abutting tiles.
-    * 
+    *
     * @tparam         K                        The key of this tile set RDD, requiring a spatial component.
     * @tparam         V                        The tile type, requires a Stitcher[V] and implicit conversion to CropMethods[V]
-    * 
+    *
     * @param          rdd                      The keyed tile rdd.
     * @param          bufferSizesPerKey        An RDD that holds the BufferSizes to use for each key.
     */
@@ -234,7 +234,7 @@ object BufferTiles {
 
           }
 
-      val grouped = 
+      val grouped =
         rdd.partitioner match {
           case Some(partitioner) => contributingKeys.groupByKey(partitioner)
           case None => contributingKeys.groupByKey
@@ -247,7 +247,7 @@ object BufferTiles {
     val tilesAndSlivers =
       rdd
         .join(surroundingBufferSizes)
-        .flatMap { case (key, (tile, bufferSizesMap)) => 
+        .flatMap { case (key, (tile, bufferSizesMap)) =>
           collectWithNeighbors(key, tile, bufferSizesMap.contains _, bufferSizesMap)
         }
 

--- a/spark/src/main/scala/geotrellis/spark/buffer/BufferTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/BufferTiles.scala
@@ -90,6 +90,10 @@ object BufferTiles {
                   case Right       => acc.copy(right = slice.cols)
                   case Top         => acc.copy(top = slice.rows)
                   case Bottom      => acc.copy(bottom = slice.rows)
+                  case BottomRight => acc.copy(bottom = slice.rows, right = slice.cols)
+                  case BottomLeft  => acc.copy(bottom = slice.rows, left = slice.cols)
+                  case TopRight    => acc.copy(top = slice.rows, right = slice.cols)
+                  case TopRight    => acc.copy(top = slice.rows, right = slice.cols)
                   case _           => acc
                 }
               }

--- a/spark/src/test/scala/geotrellis/spark/buffer/BufferTilesSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/buffer/BufferTilesSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.buffer
+
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.raster.io.geotiff.SingleBandGeoTiff
+
+import org.scalatest.FunSpec
+
+
+class BufferTilesSpec extends FunSpec with TestEnvironment {
+
+  describe("The BufferTiles functionality") {
+    val path = "raster-test/data/aspect.tif"
+    val gt = SingleBandGeoTiff(path)
+    val originalRaster = gt.raster.resample(500, 500)
+    val (_, wholeRdd) = createRasterRDD(originalRaster, 5, 5, gt.crs)
+    val metadata = wholeRdd.metadata
+
+    it("should work when the RDD is a diagonal strip") {
+      val partialRdd = ContextRDD(wholeRdd.filter({ case (k, _) => k.col == k.row }), metadata)
+      BufferTiles(partialRdd, 1).count
+    }
+
+    it("should work when the RDD is a square minus the main diagonal") {
+      val partialRdd = ContextRDD(wholeRdd.filter({ case (k, _) => k.col != k.row }), metadata)
+      BufferTiles(partialRdd, 1).count
+    }
+
+    it("should work when the RDD is the other diagonal strip") {
+      val partialRdd = ContextRDD(wholeRdd.filter({ case (k, _) => k.col == (4- k.row) }), metadata)
+      BufferTiles(partialRdd, 1).count
+    }
+
+    it("should work when the RDD is a square minus the other diagonal") {
+      val partialRdd = ContextRDD(wholeRdd.filter({ case (k, _) => k.col != (4- k.row) }), metadata)
+      BufferTiles(partialRdd, 1).count
+    }
+  }
+}


### PR DESCRIPTION
These changes (attempt to) fix a bug in the `BufferTile` functionality.  That bug would cause exceptions when trying to process certain non-rectangular RDDs.