### PR TITLE
Provide an At RDD Filter

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/RDDFilter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/RDDFilter.scala
@@ -162,6 +162,24 @@ object Intersects {
     }
 }
 
+object At {
+  def apply[T](at: T) = RDDFilter.Value[At.type, T](at)
+
+  /** Define At filter for a DateTime */
+  implicit def forDateTime[K: TemporalComponent : Boundable, M] =
+    new RDDFilter[K, At.type, DateTime, M] {
+      def apply(metadata: M, kb: KeyBounds[K], at: DateTime) = {
+        val queryBounds = KeyBounds(
+          kb.minKey updateTemporalComponent TemporalKey(at),
+          kb.maxKey updateTemporalComponent TemporalKey(at))
+        (queryBounds intersect kb) match {
+          case kb: KeyBounds[K] => List(kb)
+          case EmptyBounds => Nil
+        }
+      }
+    }
+}
+
 object Between {
   def apply[T](start: T, end: T) = RDDFilter.Value[Between.type, (T, T)](start -> end)
 

--- a/spark/src/test/scala/geotrellis/spark/io/CoordinateSpaceTimeTests.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/CoordinateSpaceTimeTests.scala
@@ -57,4 +57,25 @@ trait CoordinateSpaceTimeTests { self: PersistenceSpec[SpaceTimeKey, Tile, Raste
 
     actual should contain theSameElementsAs expected
   }
+
+  it("query at particular times") {
+    val actual = query.where(Intersects(bounds1) or Intersects(bounds2))
+      .where(At(dates(0)) or At(dates(4))).toRDD.keys.collect()
+
+    val expected = {
+      for {
+        (col, row) <- bounds1.coords ++ bounds2.coords
+        time <- Seq(dates(0), dates(4))
+      } yield {
+        SpaceTimeKey(col, row, time)
+      }
+    }
+
+    if (expected.diff(actual).nonEmpty)
+      info(s"missing: ${(expected diff actual).toList}")
+    if (actual.diff(expected).nonEmpty)
+      info(s"unwanted: ${(actual diff expected).toList}")
+
+    actual should contain theSameElementsAs expected
+  }
 }


### PR DESCRIPTION
This filter allows an RDD to be filtered so that only items from a particular instant are retained.