### PR TITLE
Upgrade All Dependencies

### DIFF
--- a/benchmark/build.sbt
+++ b/benchmark/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= Seq(
   caliper,
   "com.google.guava" % "guava" % "r09",
   "com.google.code.java-allocation-instrumenter" % "java-allocation-instrumenter" % "2.0",
-  "com.google.code.gson" % "gson" % "1.7.1")
+  "com.google.code.gson" % "gson" % "2.6.2")
 fork := true
 
 // custom kludge to get caliper to see the right classpath

--- a/benchmark/build.sbt
+++ b/benchmark/build.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= Seq(
   spire,
   caliper,
   "com.google.guava" % "guava" % "r09",
-  "com.google.code.java-allocation-instrumenter" % "java-allocation-instrumenter" % "2.0",
+  "com.google.code.java-allocation-instrumenter" % "java-allocation-instrumenter" % "2.1",
   "com.google.code.gson" % "gson" % "2.6.2")
 fork := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,8 @@ lazy val commonSettings = Seq(
       <url>http://github.com/lossyrob/</url>
         </developer>
       </developers>),
-  shellPrompt := { s => Project.extract(s).currentProject.id + " > " }
+  shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
+  dependencyUpdatesExclusions := moduleFilter(organization = "org.scala-lang")
 ) ++ net.virtualvoid.sbt.graph.Plugin.graphSettings
 
 lazy val root = Project("geotrellis", file(".")).

--- a/gdal/build.sbt
+++ b/gdal/build.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= Seq(
   "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
   "org.apache.spark" %% "spark-core" % Version.spark % "provided",
   "org.gdal"         % "gdal"       % "1.11.1",
-  "com.github.scopt" %% "scopt" % "3.3.0",
+  "com.github.scopt" %% "scopt" % "3.4.0",
   scalatest % "test")
 
 fork in test := false

--- a/gdal/build.sbt
+++ b/gdal/build.sbt
@@ -4,7 +4,7 @@ name := "geotrellis-gdal"
 libraryDependencies ++= Seq(
   "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
   "org.apache.spark" %% "spark-core" % Version.spark % "provided",
-  "org.gdal"         % "gdal"       % "1.11.1",
+  "org.gdal"         % "gdal"       % "1.11.2",
   "com.github.scopt" %% "scopt" % "3.4.0",
   scalatest % "test")
 

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies <++= scalaVersion {
 
 sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genMacro)
 
-libraryDependencies += "org.spire-math" %% "spire-macros" % "0.10.1"
+libraryDependencies += "org.spire-math" %% "spire-macros" % "0.11.0"
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -4,7 +4,7 @@ name := "geotrellis-macros"
 libraryDependencies <++= scalaVersion {
   case v if v.startsWith("2.10") => Seq(
     "org.scala-lang" %  "scala-reflect" % v,
-    "org.scalamacros" %% "quasiquotes" % "2.0.1"
+    "org.scalamacros" %% "quasiquotes" % "2.1.0"
   )
   case v if v.startsWith("2.11") => Seq(
     "org.scala-lang" %  "scala-reflect" % v

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -17,4 +17,4 @@ libraryDependencies += "org.spire-math" %% "spire-macros" % "0.11.0"
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies {
   val sprayHttpx    = "io.spray"        %% "spray-httpx"   % Version.spray
   val sprayJson     = "io.spray"        %% "spray-json"    % Version.sprayJson
 
-  val apacheMath    = "org.apache.commons" % "commons-math3" % "3.5"
+  val apacheMath    = "org.apache.commons" % "commons-math3" % "3.6"
 
   val jettyWebapp   = "org.eclipse.jetty" % "jetty-webapp" % "8.1.0.RC4"
   val jerseyBundle  = "com.sun.jersey"    % "jersey-bundle" % "1.11"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
   val jerseyBundle  = "com.sun.jersey"    % "jersey-bundle" % "1.11"
   val slf4jApi      = "org.slf4j"         % "slf4j-api" % "1.6.0"
   val asm           = "asm"               % "asm"       % "3.3.1"
-  
+
   val slick         = "com.typesafe.slick" %% "slick"      % "2.1.0"
   val postgresql    = "postgresql"         % "postgresql"  % "9.1-901.jdbc4"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,7 +46,7 @@ object Dependencies {
 
   val jettyWebapp   = "org.eclipse.jetty" % "jetty-webapp" % "8.1.0.RC4"
   val jerseyBundle  = "com.sun.jersey"    % "jersey-bundle" % "1.11"
-  val slf4jApi      = "org.slf4j"         % "slf4j-api" % "1.6.0"
+  val slf4jApi      = "org.slf4j"         % "slf4j-api" % "1.7.18"
   val asm           = "asm"               % "asm"       % "3.3.1"
 
   val slick         = "com.typesafe.slick" %% "slick"      % "2.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
   val asm           = "asm"               % "asm"       % "3.3.1"
 
   val slick         = "com.typesafe.slick" %% "slick"      % "2.1.0"
-  val postgresql    = "postgresql"         % "postgresql"  % "9.1-901.jdbc4"
+  val postgresql    = "postgresql"         % "postgresql"  % "9.2-1002.jdbc4"
 
   val caliper       = ("com.google.code.caliper" % "caliper" % "1.0-SNAPSHOT"
     from "http://plastic-idolatry.com/jars/caliper-1.0-SNAPSHOT.jar")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val caliper       = ("com.google.code.caliper" % "caliper" % "1.0-SNAPSHOT"
     from "http://plastic-idolatry.com/jars/caliper-1.0-SNAPSHOT.jar")
 
-  val nscalaTime    = "com.github.nscala-time" %% "nscala-time" % "2.6.0"
+  val nscalaTime    = "com.github.nscala-time" %% "nscala-time" % "2.10.0"
 
   val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.9.34"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ import sbt._
 object Dependencies {
   val typesafeConfig = "com.typesafe"        % "config"           % "1.2.1"
   val logging       = "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
-  val scalatest     = "org.scalatest"       %%  "scalatest"      % "2.2.0"
+  val scalatest     = "org.scalatest"       %%  "scalatest"      % "2.2.6"
   val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.11.1"
   val jts           = "com.vividsolutions"  %  "jts-core"        % "1.14.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,5 +64,5 @@ object Dependencies {
   val sparkCore     = "org.apache.spark" %% "spark-core" % Version.spark
   val hadoopClient  = "org.apache.hadoop" % "hadoop-client" % Version.hadoop
 
-  val avro          = "org.apache.avro" % "avro" % "1.7.7"
+  val avro          = "org.apache.avro" % "avro" % "1.8.0"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"    % Version.monocle
   val monocleMacro  = "com.github.julien-truffaut" %% "monocle-macro"   % Version.monocle
 
-  val openCSV       = "com.opencsv" % "opencsv" % "3.4"
+  val openCSV       = "com.opencsv" % "opencsv" % "3.7"
 
   val akkaKernel    = "com.typesafe.akka" %% "akka-kernel"  % Version.akka
   val akkaRemote    = "com.typesafe.akka" %% "akka-remote"  % Version.akka

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val typesafeConfig = "com.typesafe"        % "config"           % "1.2.1"
   val logging       = "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
   val scalatest     = "org.scalatest"       %%  "scalatest"      % "2.2.6"
-  val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.11.6"
+  val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.13.0"
   val jts           = "com.vividsolutions"  %  "jts-core"        % "1.14.0"
 
   val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"    % Version.monocle

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   val akkaActor     = "com.typesafe.akka" %% "akka-actor"   % Version.akka
   val akkaCluster   = "com.typesafe.akka" %% "akka-cluster" % Version.akka
 
-  val spire         = "org.spire-math" %% "spire" % "0.10.1"
+  val spire         = "org.spire-math" %% "spire" % "0.11.0"
 
   val sprayClient   = "io.spray"        %% "spray-client"  % Version.spray
   val sprayRouting  = "io.spray"        %% "spray-routing" % Version.spray

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val typesafeConfig = "com.typesafe"        % "config"           % "1.2.1"
   val logging       = "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
   val scalatest     = "org.scalatest"       %%  "scalatest"      % "2.2.6"
-  val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.11.1"
+  val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.11.6"
   val jts           = "com.vividsolutions"  %  "jts-core"        % "1.14.0"
 
   val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"    % Version.monocle

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -24,7 +24,7 @@ object Version {
   val scala       = "2.10.5"
   val crossScala  = Seq("2.11.5", "2.10.5")
   val geotools    = "13.1"
-  val akka        = "2.3.9"
+  val akka        = "2.3.14"
   val spray       = "1.3.3"
   val sprayJson   = "1.3.2"
   val jackson     = "1.6.1"

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -23,7 +23,7 @@ object Version {
    */
   val scala       = "2.10.5"
   val crossScala  = Seq("2.11.5", "2.10.5")
-  val geotools    = "13.1"
+  val geotools    = "14.2"
   val akka        = "2.3.14"
   val spray       = "1.3.3"
   val sprayJson   = "1.3.2"

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -29,7 +29,7 @@ object Version {
   val sprayJson   = "1.3.2"
   val jackson     = "1.6.1"
   val monocle     = "1.0.1"
-  val accumulo    = "1.7.0"
+  val accumulo    = "1.7.1"
   lazy val hadoop = Environment.hadoopVersion
   lazy val spark  = Environment.sparkVersion
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-dirty-money" % "0.1.0")
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")

--- a/raster-test/build.sbt
+++ b/raster-test/build.sbt
@@ -7,7 +7,7 @@ libraryDependencies ++= Seq(
   spire % "test",
   sprayClient % "test",
   sprayRouting % "test")
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
 parallelExecution := false
 fork in test := false

--- a/raster/build.sbt
+++ b/raster/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   monocleCore,
   monocleMacro,
   openCSV)
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 scalacOptions ++= Seq("-optimize", "-language:experimental.macros")
 javaOptions in run += "-Xmx2G"
 sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genRaster)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Predictor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Predictor.scala
@@ -14,10 +14,10 @@ object Predictor {
       &|-> TiffTags._nonBasicTags
       ^|-> NonBasicTags._predictor get
     ) match {
-      case None | Some(PREDICTOR_NONE) => 
-        new Predictor { 
+      case None | Some(PREDICTOR_NONE) =>
+        new Predictor {
           val checkEndian = true
-          def apply(bytes: Array[Byte], segmentIndex: Int) = bytes 
+          def apply(bytes: Array[Byte], segmentIndex: Int) = bytes
         }
       case Some(PREDICTOR_HORIZONTAL) =>
         HorizontalPredictor(tiffTags)
@@ -34,5 +34,3 @@ trait Predictor {
 
   def apply(bytes: Array[Byte], segmentIndex: Int): Array[Byte]
 }
-
-

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
@@ -291,9 +291,9 @@ case class TiffTags(
     val (x1, y1) = (modelPixels(0).x, modelPixels(0).y)
     val (x2, y2) = (modelPixels(1).x, modelPixels(1).y)
 
-    Extent(math.min(x1, x2), 
-           math.min(y1, y2), 
-           math.max(x1, x2), 
+    Extent(math.min(x1, x2),
+           math.min(y1, y2),
+           math.max(x1, x2),
            math.max(y1, y2))
   }
 
@@ -317,7 +317,7 @@ case class TiffTags(
   lazy val geoTiffCSTags = GeoTiffCSParser(this)
 
   def tags: Tags = {
-    val (headTags, bandTags) = 
+    val (headTags, bandTags) =
       (this &|->
         TiffTags._geoTiffTags ^|->
         GeoTiffTags._metadata get
@@ -354,7 +354,7 @@ case class TiffTags(
         case None =>
           (Map[String, String](), (0 until bandCount).map { i => Map[String, String]() }.toList)
       }
-  
+
       this &|->
         TiffTags._metadataTags ^|->
         MetadataTags._dateTime get match {

--- a/scripts/cleanall.sh
+++ b/scripts/cleanall.sh
@@ -11,7 +11,6 @@
 ./sbt -J-Xmx2G "project slick" clean || { exit 1; }
 ./sbt -J-Xmx2G "project gdal" clean || { exit 1; }
 ./sbt -J-Xmx2G "project shapefile" clean || { exit 1; }
-./sbt -J-Xmx2G "project vector-benchmark" clean || { exit 1; }
 ./sbt -J-Xmx2G "project util" clean || { exit 1; }
 
 rm -r proj4/target
@@ -29,7 +28,6 @@ rm -r benchmark/target
 rm -r slick/target
 rm -r gdal/target
 rm -r shapefile/target
-rm -r vector-benchmark/target
 rm -r util/target
 rm -r raster-testkit/target
 rm -r vector-testkit/target

--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -4,8 +4,8 @@ name := "geotrellis-spark"
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % Version.spark % "provided",
   "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
-  "de.javakaffee" % "kryo-serializers" % "0.27" exclude("com.esotericsoftware.kryo", "kryo"),
   "com.esotericsoftware.kryo" % "kryo" % "2.21",
+  "de.javakaffee" % "kryo-serializers" % "0.37" exclude("com.esotericsoftware.kryo", "kryo"),
   "com.google.uzaygezen" % "uzaygezen-core" % "0.2",
   logging,
   avro,

--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -4,8 +4,8 @@ name := "geotrellis-spark"
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % Version.spark % "provided",
   "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
-  "com.esotericsoftware.kryo" % "kryo" % "2.21",
   "de.javakaffee" % "kryo-serializers" % "0.37" exclude("com.esotericsoftware.kryo", "kryo"),
+  "com.esotericsoftware.kryo" % "kryo" % "2.24.0",
   "com.google.uzaygezen" % "uzaygezen-core" % "0.2",
   logging,
   avro,


### PR DESCRIPTION
The following dependencies have not been upgraded:
   * com.typesafe.config due to incompatible byte code
   * com.typesafe.slick due to use of an extension that does not support the newer version
   * hadoop due to the fact that it is marked "provided"
   * spark due to the fact that it is marked "provided"
   * com.google.guava.guava due to the fact that it isn't clear which version to upgrade to