### PR TITLE
Fixed a bug in vectorization.

### DIFF
--- a/engine-test/build.sbt
+++ b/engine-test/build.sbt
@@ -2,9 +2,8 @@ import Dependencies._
 
 name := "geotrellis-engine-test"
 parallelExecution := true
-fork in test := true
-javaOptions in run += "-Xmx4G"
-scalacOptions in compile += "-optimize"
+fork in Test := true
+
 libraryDependencies ++= Seq(
   sprayClient % "test",
   sprayRouting % "test",

--- a/engine-test/build.sbt
+++ b/engine-test/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 name := "geotrellis-engine-test"
 parallelExecution := true
-fork in Test := true
+fork in Test := false
 
 libraryDependencies ++= Seq(
   sprayClient % "test",

--- a/raster-test/build.sbt
+++ b/raster-test/build.sbt
@@ -10,4 +10,3 @@ libraryDependencies ++= Seq(
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
 parallelExecution := false
-fork in test := false

--- a/raster-test/src/test/scala/geotrellis/raster/regiongroup/RegionGroupSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/regiongroup/RegionGroupSpec.scala
@@ -36,7 +36,7 @@ class RegionGroupSpec extends FunSpec
                    7,     7,NODATA,     9,     9),
           5, 6
       )
-      val regions = r.regionGroup.raster
+      val regions = r.regionGroup.tile
 
       val histogram = regions.histogram
       val count = histogram.getValues.length
@@ -55,7 +55,7 @@ class RegionGroupSpec extends FunSpec
           5, 6
       )
       val options = RegionGroupOptions(connectivity = EightNeighbors)
-      val regions = r.regionGroup(options).raster
+      val regions = r.regionGroup(options).tile
 
       val histogram = regions.histogram
       val count = histogram.getValues.length

--- a/raster-test/src/test/scala/geotrellis/raster/vectorize/VectorizeSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/vectorize/VectorizeSpec.scala
@@ -31,22 +31,22 @@ class VectorizeSpec extends FunSpec
   val ymax = 0
 
   // These are specific to cw = 1  ch = 10
-  def d(i:Int) = i.toDouble
-  def tl(col:Int,row:Int) = (d(col),d(row)* -10)        // Top left
-  def tr(col:Int,row:Int) = (d(col+1),(d(row))* -10)    // Top right
-  def bl(col:Int,row:Int) = (d(col),d(row+1)* -10)        // Bottom left
-  def br(col:Int,row:Int) = (d(col+1),(d(row)+1)* -10)    // Bottom right
+  def d(i: Int) = i.toDouble
+  def tl(col: Int, row: Int) = (d(col), d(row)* -10)        // Top left
+  def tr(col: Int, row: Int) = (d(col + 1), (d(row))* -10)    // Top right
+  def bl(col: Int, row: Int) = (d(col), d(row + 1)* -10)        // Bottom left
+  def br(col: Int, row: Int) = (d(col + 1), (d(row) + 1)* -10)    // Bottom right
 
-  def assertPolygon(polygon:Polygon,expectedCoords:List[(Double,Double)]) = {
-    assertCoords(polygon.jtsGeom.getCoordinates.map(c => (c.x,c.y)),expectedCoords)
+  def assertPolygon(polygon: Polygon, expectedCoords: List[(Double, Double)]) = {
+    assertCoords(polygon.jtsGeom.getCoordinates.map(c => (c.x, c.y)), expectedCoords)
   }
 
-  def assertCoords(coordinates:Seq[(Double,Double)],expectedCoords:List[(Double,Double)]) = {
+  def assertCoords(coordinates: Seq[(Double, Double)], expectedCoords: List[(Double, Double)]) = {
     def coordString = {
-      val sortedActual = coordinates.toSeq.sortBy(c => (c._1,-c._2)).toList
-      val sortedExpected = expectedCoords.toSeq.sortBy(c => (c._1,-c._2)).toList
-      var s = "Values: (Actual,Expected)\n"
-      for(x <- 0 until math.max(sortedActual.length,sortedExpected.length)) {
+      val sortedActual = coordinates.toSeq.sortBy(c => (c._1, -c._2)).toList
+      val sortedExpected = expectedCoords.toSeq.sortBy(c => (c._1, -c._2)).toList
+      var s = "Values: (Actual, Expected)\n"
+      for(x <- 0 until math.max(sortedActual.length, sortedExpected.length)) {
         if(x < sortedActual.length) { s += s" ${sortedActual(x)}  " }
         if(x < sortedExpected.length) { s += s" ${sortedExpected(x)}  \n" }
         else { s += "\n" }
@@ -55,11 +55,11 @@ class VectorizeSpec extends FunSpec
     }
 
     withClue (s"Coordinate size does not match expected.\n$coordString\n\t\t") {
-      coordinates.length should be (expectedCoords.size+1)
+      coordinates.length should be (expectedCoords.size + 1)
     }
 
     coordinates.map { c =>
-      withClue (s"$c not in expected coordinate set:\n$coordString") {
+      withClue (s"$c not in expected coordinate set: \n$coordString") {
         expectedCoords.contains(c) should be (true) }
     }
   }
@@ -67,7 +67,7 @@ class VectorizeSpec extends FunSpec
   describe("ToVector") {
     it("should get correct vectors for simple case.") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array( n, 1, 1, n, n, n,
                n, 1, 1, n, n, n,
                n, n, n, 1, 1, n,
@@ -79,33 +79,33 @@ class VectorizeSpec extends FunSpec
       val xmax = 6
       val ymin = -50
 
-      val extent = Extent(xmin,ymin,xmax,ymax)
+      val extent = Extent(xmin, ymin, xmax, ymax)
 
       val r = ArrayTile(arr, cols, rows)
 
       val geoms = r.toVector(extent)
       val onesCoords = List(
-        (1.0,0.0), (3.0,-0.0),
-        (1.0,-20.0),(3.0,-20.0),
-        (3.0,-20.0), (5.0,-20.0),
-        (3.0,-40.0), (5.0,-40.0))
+        (1.0, 0.0), (3.0, -0.0),
+        (1.0, -20.0), (3.0, -20.0),
+        (3.0, -20.0), (5.0, -20.0),
+        (3.0, -40.0), (5.0, -40.0))
 
       val ones = geoms.filter(_.data == 1).toList
       ones.length should be (2)
 
       ones.map { polygon =>
         polygon.data should be (1)
-        val coordinates = polygon.geom.jtsGeom.getCoordinates.map(c => (c.x,c.y))
+        val coordinates = polygon.geom.jtsGeom.getCoordinates.map(c => (c.x, c.y))
         coordinates.length should be (5)
         coordinates.map { c =>
-          withClue (s"$c in expected coordinate set:") { onesCoords.contains(c) should be (true) }
+          withClue (s"$c in expected coordinate set: ") { onesCoords.contains(c) should be (true) }
         }
       }
     }
 
     it("should get correct vectors for broken square with hole.") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array( n, n, n, n, n, n,
                n, 1, 1, 1, n, n,
                n, 1, n, 1, n, n,
@@ -117,17 +117,17 @@ class VectorizeSpec extends FunSpec
       val xmax = 6
       val ymin = -50
 
-      val extent = Extent(xmin,ymin,xmax,ymax)
+      val extent = Extent(xmin, ymin, xmax, ymax)
       val r = ArrayTile(arr, cols, rows)
 
       val geoms = r.toVector(extent)
 
-      val onesCoords = List( tl(1,1), tr(3,1),
-                             bl(1,3), br(1,3),
-                             bl(2,4), br(3,4))
+      val onesCoords = List( tl(1, 1), tr(3, 1),
+                             bl(1, 3), br(1, 3),
+                             bl(2, 4), br(3, 4))
 
-      val holeCoords = List( br(1,1), bl(3,1),
-                             tl(2,4), tl(3,4) )
+      val holeCoords = List( br(1, 1), bl(3, 1),
+                             tl(2, 4), tl(3, 4) )
 
       val ones = geoms.filter(_.data == 1).toList
       ones.length should be (1)
@@ -142,7 +142,7 @@ class VectorizeSpec extends FunSpec
 
     it("should vectorize an off shape.") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array(
 //             0  1  2  3  4  5  6  7  8  9  0  1
                n, n, n, n, n, n, n, n, n, n, n, n, // 0
@@ -151,7 +151,7 @@ class VectorizeSpec extends FunSpec
                n, n, n, n, 1, 1, n, n, n, 1, 1, n, // 3
                n, n, n, 1, 1, 1, n, n, n, 1, 1, n, // 4
                n, n, 1, 1, 5, 1, n, n, 1, 1, n, n, // 5
-               n, n, 1, 5, 5, 1, n, 1, 1, n, n, n, // 6 
+               n, n, 1, 5, 5, 1, n, 1, 1, n, n, n, // 6
                n, n, 5, 5, 1, 1, n, 1, n, n, n, n, // 7
                n, n, 5, 5, 1, 1, 1, 1, n, n, n, n, // 8
                n, n, n, n, n, n, n, n, n, n, n, n, // 9
@@ -165,19 +165,19 @@ class VectorizeSpec extends FunSpec
       val xmax = 12
       val ymin = -140
 
-      val extent = Extent(xmin,ymin,xmax,ymax)
+      val extent = Extent(xmin, ymin, xmax, ymax)
       val r = ArrayTile(arr, cols, rows)
 
       val geoms = r.toVector(extent)
 
-      val onesCoords = List(  tl(4,3), tr(5,3),                       tl(9,3), tr(10,3),
-                    tl(3,4), tl(4,4),                                
-                            br(3,4),  bl(5,4),              tl(8,5), tl(9,5),
-            tl(2,5),tl(3,5),br(3,5),               tl(7,6), tl(8,6), br(9,4), br(10,4),
-                    br(2,5),          br(5,7),     tl(7,8), br(8,5), br(9,5),
-            bl(2,6),br(2,6),          bl(5,6),     br(7,6), br(8,6),
-                               tl(4,7),
-                               bl(4,8),            br(7,8) 
+      val onesCoords = List(  tl(4, 3), tr(5, 3),                       tl(9, 3), tr(10, 3),
+                    tl(3, 4), tl(4, 4),
+                            br(3, 4),  bl(5, 4),              tl(8, 5), tl(9, 5),
+            tl(2, 5), tl(3, 5), br(3, 5),               tl(7, 6), tl(8, 6), br(9, 4), br(10, 4),
+                    br(2, 5),          br(5, 7),     tl(7, 8), br(8, 5), br(9, 5),
+            bl(2, 6), br(2, 6),          bl(5, 6),     br(7, 6), br(8, 6),
+                               tl(4, 7),
+                               bl(4, 8),            br(7, 8)
       )
 
       geoms.length should be (2)
@@ -185,14 +185,14 @@ class VectorizeSpec extends FunSpec
       val ones = geoms.filter(_.data == 1).map(_.asInstanceOf[PolygonFeature[Int]]).toList
       ones.length should be (1)
 
-      ones.map(assertPolygon(_,onesCoords))
+      ones.map(assertPolygon(_, onesCoords))
     }
 
     it("should vectorize an shape with a nodata seperation line.") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array(
-//             0  1  2  3  4 
+//             0  1  2  3  4
                1, 1, 1, 1, n,// 0
                1, 5, 5, 1, n,// 1
                5, 5, 1, 1, 1,// 2
@@ -207,31 +207,31 @@ class VectorizeSpec extends FunSpec
       val xmax = 5
       val ymin = -80
 
-      val extent = Extent(xmin,ymin,xmax,ymax)
+      val extent = Extent(xmin, ymin, xmax, ymax)
       val r = ArrayTile(arr, cols, rows)
       val geoms = r.toVector(extent)
 
-      val shellCoords = List( 
-        tl(0,0),                               tr(3,0),
-                br(0,0),               bl(3,0),
-        bl(0,1),br(0,1),              
-                               tl(2,2),tl(3,2),tr(3,2),           tr(4,2),
-                               bl(2,2),                   bl(4,2),
-                               
-        tl(0,4),tr(0,4),       tl(2,4),tr(2,4),                
-                br(0,4),       bl(2,4),
+      val shellCoords = List(
+        tl(0, 0),                               tr(3, 0),
+                br(0, 0),               bl(3, 0),
+        bl(0, 1), br(0, 1),
+                               tl(2, 2), tl(3, 2), tr(3, 2),           tr(4, 2),
+                               bl(2, 2),                   bl(4, 2),
 
-                                                   tl(3,6),tl(4,6),
-                                                           br(3,6),br(4,6),
-        bl(0,7),                                           br(3,7)
+        tl(0, 4), tr(0, 4),       tl(2, 4), tr(2, 4),
+                br(0, 4),       bl(2, 4),
+
+                                                   tl(3, 6), tl(4, 6),
+                                                           br(3, 6), br(4, 6),
+        bl(0, 7),                                           br(3, 7)
       )
 
       val holeCoords = List(
-        br(0,5), br(2,5),
-        tr(0,7), tr(2,7)
+        br(0, 5), br(2, 5),
+        tr(0, 7), tr(2, 7)
       )
 
-      withClue ("Number of polygons did not match expected:") { geoms.length should be (4) }
+      withClue ("Number of polygons did not match expected: ") { geoms.length should be (4) }
 
       val ones = geoms.filter(_.data == 1).map(_.asInstanceOf[PolygonFeature[Int]]).toList
       ones.length should be (1)
@@ -247,9 +247,9 @@ class VectorizeSpec extends FunSpec
 
     it("should vectorize an shape with a hole.") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array(
-//             0  1  2  3  4 
+//             0  1  2  3  4
                n, 1, 1, 1, n,// 0
                1, 1, n, 1, n,// 1
                1, n, n, 1, 1,// 2
@@ -261,45 +261,45 @@ class VectorizeSpec extends FunSpec
       val xmax = 5
       val ymin = -40
 
-      val extent = Extent(xmin,ymin,xmax,ymax)
+      val extent = Extent(xmin, ymin, xmax, ymax)
       val r = ArrayTile(arr, cols, rows)
 
       val geoms = r.toVector(extent)
 
-      val expectedShellCoords = List( 
+      val expectedShellCoords = List(
 
-                tl(1,0),     tr(3,0),
-        tl(0,1),tl(1,1),            
-                             tr(3,2),tr(4,2),
-        bl(0,3),                     br(4,3)
+                tl(1, 0),     tr(3, 0),
+        tl(0, 1), tl(1, 1),
+                             tr(3, 2), tr(4, 2),
+        bl(0, 3),                     br(4, 3)
       )
 
       val expectedHoleCoords = List(
-                 tl(2,1),tr(2,1),
-        tl(1,2), bl(2,1),     
-        bl(1,2),         br(2,2)
+                 tl(2, 1), tr(2, 1),
+        tl(1, 2), bl(2, 1),
+        bl(1, 2),         br(2, 2)
       )
 
-      withClue ("Number of polygons did not match expected:") { geoms.length should be (1) }
+      withClue ("Number of polygons did not match expected: ") { geoms.length should be (1) }
 
       val ones = geoms.filter(_.data == 1).map(_.asInstanceOf[PolygonFeature[Int]]).toList
       ones.length should be (1)
       val polygon = ones(0)
 
       polygon.data should be (1)
-      val shellCoordinates = polygon.geom.jtsGeom.getExteriorRing.getCoordinates.map(c => (c.x,c.y))
-      assertCoords(shellCoordinates,expectedShellCoords)
+      val shellCoordinates = polygon.geom.jtsGeom.getExteriorRing.getCoordinates.map(c => (c.x, c.y))
+      assertCoords(shellCoordinates, expectedShellCoords)
 
       polygon.geom.jtsGeom.getNumInteriorRing() should be (1)
-      val holeCoordinates = polygon.geom.jtsGeom.getInteriorRingN(0).getCoordinates.map(c => (c.x,c.y))
-      assertCoords(holeCoordinates,expectedHoleCoords)
+      val holeCoordinates = polygon.geom.jtsGeom.getInteriorRingN(0).getCoordinates.map(c => (c.x, c.y))
+      assertCoords(holeCoordinates, expectedHoleCoords)
     }
 
-    it("should vectorize an shape with a two holes.") {
+    it("should vectorize an shape with two holes.") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array(
-//             0  1  2  3  4 
+//             0  1  2  3  4
                n, 1, 1, 1, n,// 0
                1, 1, n, 1, n,// 1
                1, n, n, 1, 1,// 2
@@ -314,55 +314,62 @@ class VectorizeSpec extends FunSpec
       val xmax = 5
       val ymin = -60
 
-      val extent = Extent(xmin,ymin,xmax,ymax)
+      val extent = Extent(xmin, ymin, xmax, ymax)
       val r = ArrayTile(arr, cols, rows)
 
 
       val geoms = r.toVector(extent)
 
-      val expectedShellCoords = List( 
-                tl(1,0),     tr(3,0),
-        tl(0,1),tl(1,1),            
-                             tr(3,2),tr(4,2),
+      val expectedShellCoords = List(
+                tl(1, 0),     tr(3, 0),
+        tl(0, 1), tl(1, 1),
+                             tr(3, 2), tr(4, 2),
 
 
 
-        bl(0,5),                     br(4,5)
+        bl(0, 5),                     br(4, 5)
       )
 
       val expectedHoleCoords = List(
-                 tl(2,1),tr(2,1),
-        tl(1,2), bl(2,1),     
-        bl(1,2),         br(2,2)
+                  tl(2, 1), tr(2, 1),
+        tl(1, 2), bl(2, 1),
+        bl(1, 2),           br(2, 2)
       )
 
       val expectedHoleCoords2 = List(
-                     tl(2,4),tr(3,4),
-                     bl(2,4),br(3,4)
+                     tl(2, 4), tr(3, 4),
+                     bl(2, 4), br(3, 4)
       )
 
-      withClue ("Number of polygons did not match expected:") { geoms.length should be (1) }
+      withClue ("Number of polygons did not match expected: ") { geoms.length should be (1) }
 
       val ones = geoms.filter(_.data == 1).map(_.asInstanceOf[PolygonFeature[Int]]).toList
       ones.length should be (1)
       val polygon = ones(0)
 
       polygon.data should be (1)
-      val shellCoordinates = polygon.geom.jtsGeom.getExteriorRing.getCoordinates.map(c => (c.x,c.y))
-      assertCoords(shellCoordinates,expectedShellCoords)
+      val shellCoordinates = polygon.geom.jtsGeom.getExteriorRing.getCoordinates.map(c => (c.x, c.y))
+      assertCoords(shellCoordinates, expectedShellCoords)
 
       polygon.geom.jtsGeom.getNumInteriorRing() should be (2)
-      val holeCoordinates = polygon.geom.jtsGeom.getInteriorRingN(0).getCoordinates.map(c => (c.x,c.y))
-      assertCoords(holeCoordinates,expectedHoleCoords)
-      val holeCoordinates2 = polygon.geom.jtsGeom.getInteriorRingN(1).getCoordinates.map(c => (c.x,c.y))
-      assertCoords(holeCoordinates2,expectedHoleCoords2)
+
+      val holes =
+        Vector(0, 1)
+          .map { i => polygon.geom.jtsGeom.getInteriorRingN(i).getCoordinates }
+          .sortBy { coords => coords.map(c => c.x).min }
+          .map(_.map(c => (c.x, c.y)))
+
+      val holeCoordinates = polygon.geom.jtsGeom.getInteriorRingN(1).getCoordinates.map(c => (c.x, c.y))
+      assertCoords(holes(0), expectedHoleCoords)
+      val holeCoordinates2 = polygon.geom.jtsGeom.getInteriorRingN(0).getCoordinates.map(c => (c.x, c.y))
+      assertCoords(holes(1), expectedHoleCoords2)
     }
 
-    it("should vectorize an shape with a two polys.") {
+    it("should vectorize an shape with two polys.") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array(
-//             0  1  2  3  4 
+//             0  1  2  3  4
                n, 1, n, 1, n,// 0
                1, 1, n, 1, n,// 1
                n, n, n, 1, 1,// 2
@@ -377,12 +384,12 @@ class VectorizeSpec extends FunSpec
       val xmax = 5
       val ymin = -60
 
-      val extent = Extent(xmin,ymin,xmax,ymax)
+      val extent = Extent(xmin, ymin, xmax, ymax)
       val r = ArrayTile(arr, cols, rows)
 
       val geoms = r.toVector(extent)
 
-      withClue ("Number of polygons did not match expected:") { geoms.length should be (3) }
+      withClue ("Number of polygons did not match expected: ") { geoms.length should be (3) }
     }
 
     it("should vectorize a raster that was at one point not vectorizing properly") {
@@ -410,9 +417,9 @@ class VectorizeSpec extends FunSpec
 
     it("should vectorize a two cell polygon") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array(
-//             0  1  2  
+//             0  1  2
                n, n, n,// 0
                n, 1, n,// 1
                n, 1, n,// 2
@@ -423,7 +430,7 @@ class VectorizeSpec extends FunSpec
       val cols = 3
       val rows = 4
 
-      val extent = Extent(0,-4,3,0)
+      val extent = Extent(0, -4, 3, 0)
       val r = ArrayTile(arr, cols, rows)
 
       val toVector = r.toVector(extent)
@@ -435,7 +442,7 @@ class VectorizeSpec extends FunSpec
 
       coordinates.length should be (5)
 
-      val sorted = coordinates.map { c => (c.x,c.y) }.sorted.toList
+      val sorted = coordinates.map { c => (c.x, c.y) }.sorted.toList
 
       val expected = List( (1.0, -3.0), (1.0, -1.0), (1.0, -1.0), (2.0, -3.0), (2.0, -1.0) )
 
@@ -444,7 +451,7 @@ class VectorizeSpec extends FunSpec
 
     it("should vectorize when last move is to left") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array(
 //             0  1  2  3
                n, n, n, n,// 0
@@ -457,11 +464,10 @@ class VectorizeSpec extends FunSpec
       val cols = 4
       val rows = 4
 
-      val extent = Extent(0,-4,4,0)
+      val extent = Extent(0, -4, 4, 0)
       val r = ArrayTile(arr, cols, rows)
 
       val toVector = r.toVector(extent)
-      println(toVector.toSeq)
 
       toVector.length should be (1)
       val geom = toVector.head.geom
@@ -470,16 +476,16 @@ class VectorizeSpec extends FunSpec
 
       coordinates.length should be (7)
 
-      val sorted = coordinates.map { c => (c.x,c.y) }.sorted.toList
+      val sorted = coordinates.map { c => (c.x, c.y) }.sorted.toList
 
-      val expected = List( 
+      val expected = List(
         (1.0, -3.0),
-        (1.0, -1.0), 
-        (1.0, -1.0), 
-        (2.0, -3.0), 
+        (1.0, -1.0),
+        (1.0, -1.0),
+        (2.0, -3.0),
         (2.0, -2.0),
         (3.0, -2.0),
-        (3.0, -1.0) 
+        (3.0, -1.0)
       )
 
       sorted should be (expected)
@@ -487,7 +493,7 @@ class VectorizeSpec extends FunSpec
 
     it("should vectorize when last two moves is down and left") {
       val n = NODATA
-      val arr = 
+      val arr =
         Array(
 //             0  1  2  3
                n, n, n, n,// 0
@@ -500,7 +506,7 @@ class VectorizeSpec extends FunSpec
       val cols = 4
       val rows = 4
 
-      val extent = Extent(0,-4,4,0)
+      val extent = Extent(0, -4, 4, 0)
       val r = ArrayTile(arr, cols, rows)
 
       val toVector = r.toVector(extent)
@@ -512,9 +518,9 @@ class VectorizeSpec extends FunSpec
 
       coordinates.length should be (7)
 
-      val sorted = coordinates.map { c => (c.x,c.y) }.sorted.toList
+      val sorted = coordinates.map { c => (c.x, c.y) }.sorted.toList
 
-      val expected = List( 
+      val expected = List(
         (1.0, -3.0),
         (1.0, -2.0),
         (1.0, -2.0),
@@ -525,6 +531,32 @@ class VectorizeSpec extends FunSpec
       )
 
       sorted should be (expected)
+    }
+
+    it("should handle a situation where the hole has multiple values that need to be considered one large hole") {
+      val n = NODATA
+      val arr =
+        Array(
+//             0  1  2  3  4  5  6
+               3, 3, 3, 3, 3, 3, 3, // 0
+               3, 1, 1, 1, 1, 1, 3, // 1
+               3, 1, 2, 2, 2, 1, 3, // 2
+               3, 1, 2, 7, 2, 1, 3, // 3
+               3, 1, 2, 2, 1, 1, 3, // 4
+               3, 1, 1, 1, 1, 1, 3, // 5
+               3, 3, 3, 3, 3, 3, 3  // 5
+        )
+
+
+      val cols = 7
+      val rows = 7
+
+      val extent = Extent(0, -7, 7, 0)
+      val r = ArrayTile(arr, cols, rows)
+
+      val toVector = r.toVector(extent)
+
+      toVector.length should be (4)
     }
   }
 }

--- a/raster/build.sbt
+++ b/raster/build.sbt
@@ -10,10 +10,8 @@ libraryDependencies ++= Seq(
   openCSV)
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 scalacOptions ++= Seq("-optimize", "-language:experimental.macros")
-javaOptions in run += "-Xmx2G"
 sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genRaster)
-parallelExecution := false
-fork in test := false
+
 initialCommands in console :=
   """
   import geotrellis.raster._

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -50,6 +50,7 @@ package object raster
 
   implicit class withSingleBandRasterRasterizeMethods(val self: SingleBandRaster) extends MethodExtensions[Raster[Tile]]
       with SingleBandRasterRasterizeMethods[Tile, Raster[Tile]]
+      with vectorize.SingleBandRasterVectorizeMethods
 
   implicit class withGeometryRasterizeMethods(val self : Geometry) extends MethodExtensions[Geometry]
       with GeometryRasterizeMethods[Geometry]

--- a/raster/src/main/scala/geotrellis/raster/regiongroup/RegionGroup.scala
+++ b/raster/src/main/scala/geotrellis/raster/regiongroup/RegionGroup.scala
@@ -21,7 +21,7 @@ import spire.syntax.cfor._
 
 import scala.collection.mutable
 
-case class RegionGroupResult(raster: Tile, regionMap: Map[Int, Int])
+case class RegionGroupResult(tile: Tile, regionMap: Map[Int, Int])
 
 object RegionGroupOptions { val default = RegionGroupOptions() }
 case class RegionGroupOptions(
@@ -40,12 +40,12 @@ object RegionGroup {
     val ignoreNoData = options.ignoreNoData
 
     /* Go through each cell row by row, and set all considered neighbors
-     * whose values are equal to the current cell's values to be of the 
+     * whose values are equal to the current cell's values to be of the
      * same region. If there are no equal considered neighbors, then the cell
-     * represents a new region. Considered neighbors are: west and north, for 
+     * represents a new region. Considered neighbors are: west and north, for
      * connectivity of FourNieghbors, and west, north, and northwest for connectivity
      * of EightNeighbors.
-     * 
+     *
      * Code is duplicated for Four and Eight Neighbor connectivity for performance
      * and to try and avoid a mess of conditionals.
      */
@@ -192,13 +192,13 @@ object RegionGroup {
     cfor(0)(_ < rows, _ + 1) { row =>
       cfor(0)(_ < cols, _ + 1) { col =>
         val v = tile.get(col, row)
-        if(isData(v) || !ignoreNoData) { 
+        if(isData(v) || !ignoreNoData) {
           val cls = regions.getClass(v)
           if(cls != v && regionMap.contains(v)) {
             if(!regionMap.contains(cls)) {
               sys.error(s"Region map should contain class identifier $cls")
             }
-            regionMap.remove(v) 
+            regionMap.remove(v)
           }
           tile.set(col, row, regions.getClass(v))
         }
@@ -271,7 +271,7 @@ class RegionPartition() {
     }
   }
 
-  def getClass(x: Int) = 
+  def getClass(x: Int) =
     if(!regionMap.contains(x)) { sys.error(s"There is no partition containing $x") }
     else {
       regionMap(x).min

--- a/raster/src/main/scala/geotrellis/raster/vectorize/Polygonizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/vectorize/Polygonizer.scala
@@ -107,74 +107,74 @@ class Polygonizer(val r: Tile, rasterExtent: RasterExtent) {
     if(d == DOWN) {
       if(pd != DOWN) {
         if(pd == RIGHT) {                //RHT
-          points += mark(col, row-1, BOTTOMLEFT)
+          points += mark(col, row - 1, BOTTOMLEFT)
         } else if(pd == LEFT) {          //LHT
-          points += mark(col, row-1, TOPLEFT)
+          points += mark(col, row - 1, TOPLEFT)
         } else {                         //RT
-          points += mark(col, row-1, TOPRIGHT)
-          points += mark(col, row-1, TOPLEFT)
+          points += mark(col, row - 1, TOPRIGHT)
+          points += mark(col, row - 1, TOPLEFT)
         }
       }
     } else if(d == RIGHT) {
       if(pd != RIGHT) {
         if(pd == UP) {                   //RHT
-          points += mark(col-1, row, BOTTOMRIGHT)
+          points += mark(col - 1, row, BOTTOMRIGHT)
         } else if(pd == DOWN) {          //LHT
-          points += mark(col-1, row, BOTTOMLEFT)
+          points += mark(col - 1, row, BOTTOMLEFT)
         } else {                         //RT
-          points += mark(col-1, row, TOPLEFT)
-          points += mark(col-1, row, BOTTOMLEFT)
+          points += mark(col - 1, row, TOPLEFT)
+          points += mark(col - 1, row, BOTTOMLEFT)
         }
       }
     } else if(d == UP) {
       if(pd != UP) {
         if(pd == LEFT) {                 //RHT
-          points += mark(col, row+1, TOPRIGHT)
+          points += mark(col, row + 1, TOPRIGHT)
         } else if(pd == RIGHT) {         //LHT
-          points += mark(col, row+1, BOTTOMRIGHT)
+          points += mark(col, row + 1, BOTTOMRIGHT)
         } else {                         //RT
-          points += mark(col, row+1, BOTTOMLEFT)
-          points += mark(col, row+1, BOTTOMRIGHT)
+          points += mark(col, row + 1, BOTTOMLEFT)
+          points += mark(col, row + 1, BOTTOMRIGHT)
         }
       }
     } else if(d == LEFT) {
       if(pd != LEFT) {
         if(pd == DOWN) {                 //RHT
-          points += mark(col+1, row, TOPLEFT)
+          points += mark(col + 1, row, TOPLEFT)
         } else if(pd == UP) {            //LHT
-          points += mark(col+1, row, TOPRIGHT)
+          points += mark(col + 1, row, TOPRIGHT)
         } else {                         //RT
-          points += mark(col+1, row, BOTTOMRIGHT)
-          points += mark(col+1, row, TOPRIGHT)
+          points += mark(col + 1, row, BOTTOMRIGHT)
+          points += mark(col + 1, row, TOPRIGHT)
         }
       }
     } else { sys.error(s"Unknown direction $d") }
   }
 
-  def findNextDirection(col: Int, row: Int, d: Int, v: Int): Int = {
+  def findNextDirection(col: Int, row: Int, d: Int, targetValue: Int): Int = {
     var i = d + 3
     while(i < d + 7) {
       val m = i % 4
       if(m == 0) {
         // Check left
         if(col > 0) {
-          if(r.get(col-1, row) == v) {
+          if(r.get(col - 1, row) == targetValue) {
             return LEFT
           }
         }
       }
       else if(m == 1) {
         // Check down
-        if(row+1 < rows) {
-          if(r.get(col, row+1) == v) {
+        if(row + 1 < rows) {
+          if(r.get(col, row + 1) == targetValue) {
             return DOWN
           }
         }
       }
       else if(m == 2) {
         // Check right
-        if(col+1 < cols) {
-          if(r.get(col+1, row) == v) {
+        if(col + 1 < cols) {
+          if(r.get(col + 1, row) == targetValue) {
             return RIGHT
           }
         }
@@ -182,7 +182,7 @@ class Polygonizer(val r: Tile, rasterExtent: RasterExtent) {
       else if(m == 3) {
         // Check up
         if(row > 0) {
-          if(r.get(col, row-1) == v) {
+          if(r.get(col, row - 1) == targetValue) {
             return UP
           }
         }
@@ -193,33 +193,7 @@ class Polygonizer(val r: Tile, rasterExtent: RasterExtent) {
     return NOTFOUND
   }
 
-  def getPolygon[T](v: Int, data: T): PolygonFeature[T] = {
-    // Find upper left start point.
-    var sc = 0
-    var sr = 0
-    var found = false
-    while(!found && sc < cols) {
-      sr = 0
-      while(!found && sr < rows) {
-        if(r.get(sc, sr) == v) { found = true }
-        if(!found) { sr += 1 }
-      }
-      if(!found) { sc += 1 }
-    }
-
-    if(!found) { sys.error(s"This raster does not contain value $v") }
-    getPolygon(v, data, (sc, sr))
-  }
-
-  def getPolygon[T](v: Int, data: T, startPoint: (Int, Int)): PolygonFeature[T] = {
-    val shell = getLinearRing(v: Int, startPoint: (Int, Int))
-    PolygonFeature(
-      Polygon(jtsFactory.createPolygon(shell, Array())),
-      data
-    )
-  }
-
-  def getLinearRing[T](v: Int, startPoint: (Int, Int)): geom.LinearRing = {
+  def getLinearRing[T](targetValue: Int, startPoint: (Int, Int)): geom.LinearRing = {
     val points = mutable.ArrayBuffer[geom.Coordinate]()
 
     val startCol = startPoint._1
@@ -227,14 +201,14 @@ class Polygonizer(val r: Tile, rasterExtent: RasterExtent) {
 
     // First check down and right of first.
     var direction = NOTFOUND
-    if(startRow+1 < rows) {
-      if(r.get(startCol, startRow + 1) == v) {
+    if(startRow + 1 < rows) {
+      if(r.get(startCol, startRow + 1) == targetValue) {
         direction = DOWN
       }
     }
 
     if(direction == NOTFOUND && startCol < cols) {
-      if(r.get(startCol+1, startRow) == v) {
+      if(r.get(startCol + 1, startRow) == targetValue) {
         direction = RIGHT
       }
     }
@@ -269,7 +243,7 @@ class Polygonizer(val r: Tile, rasterExtent: RasterExtent) {
 
         makeMarks(points, col, row, direction, previousDirection)
         previousDirection = direction
-        direction = findNextDirection(col, row, direction, v)
+        direction = findNextDirection(col, row, direction, targetValue)
         //println(s"PREVIOUS ${sd(previousDirection)} NEXT ${sd(direction)}  ($col, $row)")
         if(col == startCol && row == startRow) {
           if(previousDirection == LEFT || previousDirection == DOWN) {

--- a/raster/src/main/scala/geotrellis/raster/vectorize/SingleBandRasterVectorizeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/vectorize/SingleBandRasterVectorizeMethods.scala
@@ -1,0 +1,10 @@
+package geotrellis.raster.vectorize
+
+import geotrellis.raster._
+import geotrellis.vector._
+import geotrellis.util.MethodExtensions
+
+trait SingleBandRasterVectorizeMethods extends MethodExtensions[Raster[Tile]] {
+  def toVector(regionConnectivity: Connectivity = FourNeighbors): List[PolygonFeature[Int]] =
+    Vectorize(self.tile, self.extent, regionConnectivity)
+}

--- a/raster/src/main/scala/geotrellis/raster/vectorize/TileVectorizeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/vectorize/TileVectorizeMethods.scala
@@ -4,7 +4,6 @@ import geotrellis.raster._
 import geotrellis.vector._
 import geotrellis.util.MethodExtensions
 
-
 trait VectorizeMethods extends MethodExtensions[Tile] {
   def toVector(extent: Extent, regionConnectivity: Connectivity = FourNeighbors): List[PolygonFeature[Int]] =
     Vectorize(self, extent, regionConnectivity)

--- a/raster/src/main/scala/geotrellis/raster/vectorize/Vectorize.scala
+++ b/raster/src/main/scala/geotrellis/raster/vectorize/Vectorize.scala
@@ -116,15 +116,15 @@ object Vectorize {
             PolygonRasterizer.foreachCellByPolygon(shellPoly.geom, rasterExtent)(callback)
 
             val holes = {
-              val ringLines = callback.linearRings.map(Line.apply)
-              if(h.size > 1) {
+              val rings = callback.linearRings.map(Line.apply)
+              if(rings.size > 1) {
                 // We need to get rid of intersecting holes.
-                h.map(Polygon.apply).unionGeometries.as[MultiPolygon] match {
+                rings.map(Polygon.apply).unionGeometries.as[MultiPolygon] match {
                   case Some(mp) => mp.polygons.map(_.exterior).toSet
-                  case None => Set[Line]()
+                  case None => sys.error(s"Invalid geometries returned by polygon holes: ${rings.toSeq}")
                 }
               } else {
-                h.toSet
+                rings.toSet
               }
             }
 

--- a/raster/src/main/scala/geotrellis/raster/vectorize/Vectorize.scala
+++ b/raster/src/main/scala/geotrellis/raster/vectorize/Vectorize.scala
@@ -119,9 +119,9 @@ object Vectorize {
               val rings = callback.linearRings.map(Line.apply)
               if(rings.size > 1) {
                 // We need to get rid of intersecting holes.
-                rings.map(Polygon.apply).unionGeometries.as[MultiPolygon] match {
+                rings.map(Polygon.apply).unionGeometries.asMultiPolygon match {
                   case Some(mp) => mp.polygons.map(_.exterior).toSet
-                  case None => sys.error(s"Invalid geometries returned by polygon holes: ${rings.toSeq}")
+                  case None => sys.error(s"Invalid geometries returned by polygon holes: ${rings.map(Polygon.apply).unionGeometries}")
                 }
               } else {
                 rings.toSet

--- a/raster/src/main/scala/geotrellis/raster/vectorize/Vectorize.scala
+++ b/raster/src/main/scala/geotrellis/raster/vectorize/Vectorize.scala
@@ -18,7 +18,6 @@ package geotrellis.raster.vectorize
 
 import com.vividsolutions.jts.geom
 import geotrellis.raster._
-import geotrellis.raster.rasterize.Callback
 import geotrellis.raster.rasterize.polygon.PolygonRasterizer
 import geotrellis.raster.regiongroup.{RegionGroup, RegionGroupOptions}
 import geotrellis.vector._
@@ -31,10 +30,12 @@ object Vectorize {
     extent: Extent,
     regionConnectivity: Connectivity = RegionGroupOptions.default.connectivity
   ): List[PolygonFeature[Int]] = {
-    class ToVectorCallback(val polyizer: Polygonizer,
+    class ToVectorCallback(
+      val polyizer: Polygonizer,
       val r: Tile,
-      val v: Int) extends Callback {
-      val innerStarts = mutable.Map[Int, (Int, Int)]()
+      val v: Int
+    ) extends ((Int, Int) => Unit) {
+      private val innerStarts = mutable.Map[Int, (Int, Int)]()
 
       def linearRings =
         for(k <- innerStarts.keys) yield {
@@ -63,9 +64,7 @@ object Vectorize {
       )
     val rgr = RegionGroup(tile, regionGroupOptions)
 
-    val r = rgr.raster
-
-
+    val r = rgr.tile
 
     val regionMap = rgr.regionMap
     val rasterExtent = RasterExtent(extent, r.cols, r.rows)
@@ -116,8 +115,21 @@ object Vectorize {
 
             PolygonRasterizer.foreachCellByPolygon(shellPoly.geom, rasterExtent)(callback)
 
+            val holes = {
+              val ringLines = callback.linearRings.map(Line.apply)
+              if(h.size > 1) {
+                // We need to get rid of intersecting holes.
+                h.map(Polygon.apply).unionGeometries.as[MultiPolygon] match {
+                  case Some(mp) => mp.polygons.map(_.exterior).toSet
+                  case None => Set[Line]()
+                }
+              } else {
+                h.toSet
+              }
+            }
+
             polygons += PolygonFeature(
-              Polygon(Line(shell), callback.linearRings.map(Line.apply).toSet),
+              Polygon(Line(shell), holes),
               rgr.regionMap(v)
             )
 
@@ -132,5 +144,3 @@ object Vectorize {
     polygons.toList
   }
 }
-
-

--- a/shapefile/build.sbt
+++ b/shapefile/build.sbt
@@ -5,4 +5,4 @@ libraryDependencies ++= Seq(
   "org.geotools" % "gt-shapefile" % Version.geotools
 )
 resolvers += "Geotools" at "http://download.osgeo.org/webdav/geotools/"
-fork in test := false
+fork in Test := false


### PR DESCRIPTION
There was a bug in situations where we were generating polygons with holes, of various values; if the linear rings that were generated for the holes of a polygon intersected, it would produce incorrect geometries. This fix unions all holes so that we are assigning unique non-intersecting linear rings to polygon holes.

/cc @owcm @kagoentzel 

Fixes #1350
Fixes #1361 