### PR TITLE
Support for temporal hadoop multiband geotiffs

### DIFF
--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/HadoopModule.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/HadoopModule.scala
@@ -6,6 +6,7 @@ trait HadoopModule extends TypedModule {
   register(new GeoTiffHadoopInput)
   register(new SpatialHadoopOutput)
   register(new TemporalGeoTiffHadoopInput)
+  register(new TemporalMultibandGeoTiffHadoopInput)
   register(new SpaceTimeHadoopOutput)
   register(new SpatialRenderOutput)
   register(new GeoTiffSequenceHadoopInput)

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandSpaceTimeHadoopOutput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandSpaceTimeHadoopOutput.scala
@@ -1,6 +1,6 @@
 package geotrellis.spark.etl.hadoop
 
-import geotrellis.raster.Tile
+import geotrellis.raster.MultiBandTile
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop.HadoopLayerWriter
 import geotrellis.spark.io.index.KeyIndexMethod
@@ -9,7 +9,8 @@ import geotrellis.spark.SpaceTimeKey
 
 import org.apache.hadoop.fs.Path
 
-class MultibandSpaceTimeHadoopOutput extends HadoopOutput[SpaceTimeKey, Tile, RasterMetaData] {
+class MultibandSpaceTimeHadoopOutput extends HadoopOutput[SpaceTimeKey, MultiBandTile, RasterMetaData] {
   def writer(method: KeyIndexMethod[SpaceTimeKey], props: Parameters) =
-    HadoopLayerWriter[SpaceTimeKey, Tile, RasterMetaData](new Path(props("path")), method)
+    HadoopLayerWriter[SpaceTimeKey, MultiBandTile, RasterMetaData](new Path(props("path")), method)
 }
+

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalMultibandGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalMultibandGeoTiffHadoopInput.scala
@@ -1,0 +1,14 @@
+package geotrellis.spark.etl.hadoop
+
+import geotrellis.raster.MultiBandTile
+import geotrellis.spark.ingest._
+import geotrellis.spark.io.hadoop._
+import geotrellis.spark._
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+
+class TemporalMultibandGeoTiffHadoopInput extends HadoopInput[TemporalProjectedExtent, MultiBandTile] {
+  val format = "temporal-geotiff"
+  def apply(props: Parameters)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, MultiBandTile)] = sc.hadoopTemporalMultiBandGeoTiffRDD(props("path"))
+}
+

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopSparkContextMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopSparkContextMethods.scala
@@ -78,6 +78,23 @@ trait HadoopSparkContextMethods {
       classOf[MultiBandTile]
     )
 
+  def hadoopTemporalMultiBandGeoTiffRDD(path: String): RDD[(TemporalProjectedExtent, MultiBandTile)] =
+    hadoopTemporalMultiBandGeoTiffRDD(new Path(path), defaultTiffExtensions)
+
+  def hadoopTemporalMultiBandGeoTiffRDD(path: String, tiffExtension: String): RDD[(TemporalProjectedExtent, MultiBandTile)] =
+    hadoopTemporalMultiBandGeoTiffRDD(new Path(path), Seq(tiffExtension))
+
+  def hadoopTemporalMultiBandGeoTiffRDD(path: String, tiffExtensions: Seq[String]): RDD[(TemporalProjectedExtent, MultiBandTile)] =
+    hadoopTemporalMultiBandGeoTiffRDD(new Path(path), tiffExtensions)
+
+  def hadoopTemporalMultiBandGeoTiffRDD(path: Path, tiffExtensions: Seq[String] = defaultTiffExtensions): RDD[(TemporalProjectedExtent, MultiBandTile)] =
+    sc.newAPIHadoopRDD(
+      sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions),
+      classOf[TemporalMultiBandGeoTiffInputFormat],
+      classOf[TemporalProjectedExtent],
+      classOf[MultiBandTile]
+    )
+
   def newJob: Job =
     Job.getInstance(sc.hadoopConfiguration)
 

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalMultiBandGeoTiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalMultiBandGeoTiffInputFormat.scala
@@ -1,0 +1,33 @@
+package geotrellis.spark.io.hadoop.formats
+
+import geotrellis.spark.TemporalProjectedExtent
+import geotrellis.spark.io.hadoop._
+import geotrellis.spark.ingest._
+import geotrellis.raster._
+import geotrellis.raster.io.geotiff._
+import geotrellis.vector._
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce._
+import org.joda.time._
+import org.joda.time.format._
+
+/** Read multiband GeoTiff with a timestamp
+  *
+  * This can be configured with the hadoop configuration by providing:
+  * TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_TAG; default of "TIFFTAG_DATETIME"
+  * TemporalGeoTiffS3InputFormat.GEOTIFF_TIME_FORMAT; default is ""YYYY:MM:DD HH:MM:SS""
+  */
+class TemporalMultiBandGeoTiffInputFormat extends BinaryFileInputFormat[TemporalProjectedExtent, MultiBandTile] {
+  def read(bytes: Array[Byte], context: TaskAttemptContext): (TemporalProjectedExtent, MultiBandTile) = {
+    val geoTiff = MultiBandGeoTiff(bytes)
+
+    val timeTag = TemporalGeoTiffInputFormat.getTimeTag(context)
+    val dateFormatter = TemporalGeoTiffInputFormat.getTimeFormatter(context)
+
+    val dateTimeString = geoTiff.tags.headTags.getOrElse(timeTag, sys.error(s"There is no tag $timeTag in the GeoTiff header"))
+    val dateTime = DateTime.parse(dateTimeString, dateFormatter)
+
+    val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
+    (TemporalProjectedExtent(extent, crs, dateTime), tile)
+  }
+}


### PR DESCRIPTION
This PR adds support for hadoop temporal multiband geotiffs to spark-etl.

Changes:
* Changed the MultibandSpaceTimeHadoopOutput to use correctly use MultiBandTile instead of Tile.  
* Added new TemporalMultibandGeoTiffHadoopInput input to spark-etl
* Added new hadoopTemporalMultiBandGeoTiffRDD methods to HadoopSparkContextMethods
* Add TemporalMultiBandGeoTiffInputFormat input format.