### PR TITLE
Performance/API improvements to SpatialIndex

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/Extent.scala
+++ b/vector/src/main/scala/geotrellis/vector/Extent.scala
@@ -61,6 +61,10 @@ case class Extent(xmin: Double, ymin: Double, xmax: Double, ymax: Double) {
       null
     )
 
+  def jtsEnvelope: com.vividsolutions.jts.geom.Envelope =
+    new com.vividsolutions.jts.geom.Envelope(xmin, xmax, ymin, ymax)
+
+
   val width = xmax - xmin
   val height = ymax - ymin
 


### PR DESCRIPTION
As per #1249, add an overload of ``insert`` on ``SpatialIndex`` that accepts an ``Extent``.  Also while I was looking at ``SpatialIndex`` I made a couple of other changes:

* Give it a default parameter so you do not always need to choose a Measure when constructing a spatial index.
* Make ``pointsInExtentAsJavaList`` return a ``java.util.List`` rather than ``scala.collection.immutable.List``
* Add a ``traversePointsInExtent`` method that queries and returns a ``Traversable`` so the result list doesn't necessarily need to be materialized
* Reimplement ``pointsInExtent`` in terms of ``traversePointsInExtent`` so that we don't need to copy a Java List (this approach iterated over the results twice.)