### PR TITLE
Supply MultiBandTile bands (reorder) Method

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTileSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTileSpec.scala
@@ -234,18 +234,6 @@ class GeoTiffMultiBandTileSpec extends FunSpec
     }
   }
 
-  describe("MultiBand subset method") {
-
-    it("should be insensative to the order of bandSequence") {
-      val tile0 = MultiBandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
-      val tile1 = tile0.subset(List(1, 2, 0))
-
-      tile0.band(0) should be theSameInstanceAs tile1.band(0)
-      tile0.band(1) should be theSameInstanceAs tile1.band(1)
-      tile0.band(2) should be theSameInstanceAs tile1.band(2)
-    }
-  }
-
   describe("GeoTiffMultiBandTile map") {
 
     it("should map a single band, striped, pixel interleave") {

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTileSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultiBandTileSpec.scala
@@ -190,30 +190,30 @@ class GeoTiffMultiBandTileSpec extends FunSpec
     }
   }
 
-  describe("MultiBand subset methods") {
+  describe("MultiBand bands (reorder) method") {
 
-    it("subset should be inexpensive") {
+    it("should be inexpensive") {
       val tile0 = MultiBandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
-      val tile1 = tile0.subset(List(1, 2, 0))
+      val tile1 = tile0.bands(List(1, 2, 0))
 
       tile0.band(0) should be theSameInstanceAs tile1.band(2)
       tile0.band(1) should be theSameInstanceAs tile1.band(0)
       tile0.band(2) should be theSameInstanceAs tile1.band(1)
     }
 
-    it("subset result should have correct bandCount") {
+    it("result should have correct bandCount") {
       val tile0 = MultiBandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
-      val tile1 = tile0.subset(List(1, 2, 0))
-      val tile2 = tile0.subset(List(1, 2))
+      val tile1 = tile0.bands(List(1, 2, 0))
+      val tile2 = tile0.bands(List(1, 2))
 
       tile1.bandCount should be (3)
       tile2.bandCount should be (2)
     }
 
-    it("subset result should work properly with foreach") {
+    it("result should work properly with foreach") {
       val tile0 = MultiBandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
-      val tile1 = tile0.subset(List(1, 2, 0))
-      val tile2 = tile1.subset(List(1, 2, 0))
+      val tile1 = tile0.bands(List(1, 2, 0))
+      val tile2 = tile1.bands(List(1, 2, 0))
 
       tile0.band(0).foreach { z => z should be (1) }
       tile0.band(1).foreach { z => z should be (2) }
@@ -226,11 +226,23 @@ class GeoTiffMultiBandTileSpec extends FunSpec
       tile2.band(2).foreach { z => z should be (2) }
     }
 
-    it("should disallow \"invalid\" subsets") {
+    it("should disallow \"invalid\" bandSequences") {
       val tile0 = MultiBandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
       an [IllegalArgumentException] should be thrownBy {
-        tile0.subset(0,1,2,3) // There are only 3 bands
+        tile0.bands(0,1,2,3) // There are only 3 bands
       }
+    }
+  }
+
+  describe("MultiBand subset method") {
+
+    it("should be insensative to the order of bandSequence") {
+      val tile0 = MultiBandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
+      val tile1 = tile0.subset(List(1, 2, 0))
+
+      tile0.band(0) should be theSameInstanceAs tile1.band(0)
+      tile0.band(1) should be theSameInstanceAs tile1.band(1)
+      tile0.band(2) should be theSameInstanceAs tile1.band(2)
     }
   }
 

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
@@ -315,10 +315,4 @@ class ArrayMultiBandTile(bands: Array[Tile]) extends MultiBandTile with MacroMul
 
   def bands(bandSequence: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
     bands(bandSequence)
-
-  def subset(bandSequence: Seq[Int]): ArrayMultiBandTile =
-    bands(bandSequence.sorted)
-
-  def subset(bandSequence: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
-    bands(bandSequence.sorted)
 }

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
@@ -24,7 +24,7 @@ object ArrayMultiBandTile {
   }
 }
 
-class ArrayMultiBandTile(bands: Array[Tile]) extends MultiBandTile with MacroMultibandCombiners {
+class ArrayMultiBandTile(bands: Array[Tile]) extends MultiBandTile with MacroMultibandCombiners with SimpleMultiBandTile {
   val bandCount = bands.size
 
   assert(bandCount > 0, "Band count must be greater than 0")

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultiBandTile.scala
@@ -298,12 +298,14 @@ class ArrayMultiBandTile(bands: Array[Tile]) extends MultiBandTile with MacroMul
     result
   }
 
-  def subset(bands: Seq[Int]): ArrayMultiBandTile = {
-    val newBands = Array.ofDim[Tile](bands.size)
+  val _bands = bands
+
+  def bands(bandSequence: Seq[Int]): ArrayMultiBandTile = {
+    val newBands = Array.ofDim[Tile](bandSequence.size)
     var i = 0
 
-    require(bands.size <= this.bandCount)
-    bands.foreach({ j =>
+    require(bandSequence.size <= this.bandCount)
+    bandSequence.foreach({ j =>
       newBands(i) = this.band(j)
       i += 1
     })
@@ -311,6 +313,12 @@ class ArrayMultiBandTile(bands: Array[Tile]) extends MultiBandTile with MacroMul
     new ArrayMultiBandTile(newBands)
   }
 
-  def subset(bands: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
-    subset(bands)
+  def bands(bandSequence: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
+    bands(bandSequence)
+
+  def subset(bandSequence: Seq[Int]): ArrayMultiBandTile =
+    bands(bandSequence.sorted)
+
+  def subset(bandSequence: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
+    bands(bandSequence.sorted)
 }

--- a/raster/src/main/scala/geotrellis/raster/SimpleMultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/SimpleMultiBandTile.scala
@@ -4,8 +4,4 @@ trait SimpleMultiBandTile {
   def bands(bandSequence: Seq[Int]): MultiBandTile
 
   def bands(bandSequence: Int*)(implicit d: DummyImplicit): MultiBandTile
-
-  def subset(bandSequence: Seq[Int]): MultiBandTile
-
-  def subset(bandSequence: Int*)(implicit d: DummyImplicit): MultiBandTile
 }

--- a/raster/src/main/scala/geotrellis/raster/SimpleMultiBandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/SimpleMultiBandTile.scala
@@ -1,0 +1,11 @@
+package geotrellis.raster
+
+trait SimpleMultiBandTile {
+  def bands(bandSequence: Seq[Int]): MultiBandTile
+
+  def bands(bandSequence: Int*)(implicit d: DummyImplicit): MultiBandTile
+
+  def subset(bandSequence: Seq[Int]): MultiBandTile
+
+  def subset(bandSequence: Int*)(implicit d: DummyImplicit): MultiBandTile
+}

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
@@ -11,7 +11,7 @@ class MultiBandGeoTiff(
   val crs: CRS,
   val tags: Tags,
   options: GeoTiffOptions
-) extends GeoTiff[MultiBandTile] {
+) extends GeoTiff[MultiBandTile] with SimpleMultiBandTile {
   val cellType = tile.cellType
 
   def mapTile(f: MultiBandTile => MultiBandTile): MultiBandGeoTiff =

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
@@ -39,12 +39,6 @@ class MultiBandGeoTiff(
 
   def bands(bandSequence: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
     bands(bandSequence)
-
-  def subset(bandSequence: Seq[Int]): ArrayMultiBandTile =
-    bands(bandSequence.sorted)
-
-  def subset(bandSequence: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
-    bands(bandSequence.sorted)
 }
 
 object MultiBandGeoTiff {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
@@ -23,13 +23,13 @@ class MultiBandGeoTiff(
       case _ => GeoTiffMultiBandTile(tile)
     }
 
-  def subset(bands: Seq[Int]): ArrayMultiBandTile = {
+  def bands(bandSequence: Seq[Int]): ArrayMultiBandTile = {
     val mbTile = this.tile
-    val newBands = Array.ofDim[Tile](bands.size)
+    val newBands = Array.ofDim[Tile](bandSequence.size)
     var i = 0
 
-    require(bands.size <= mbTile.bandCount)
-    bands.foreach({ j =>
+    require(bandSequence.size <= mbTile.bandCount)
+    bandSequence.foreach({ j =>
       newBands(i) = mbTile.band(j)
       i += 1
     })
@@ -37,8 +37,14 @@ class MultiBandGeoTiff(
     new ArrayMultiBandTile(newBands)
   }
 
-  def subset(bands: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
-    subset(bands)
+  def bands(bandSequence: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
+    bands(bandSequence)
+
+  def subset(bandSequence: Seq[Int]): ArrayMultiBandTile =
+    bands(bandSequence.sorted)
+
+  def subset(bandSequence: Int*)(implicit d: DummyImplicit): ArrayMultiBandTile =
+    bands(bandSequence.sorted)
 }
 
 object MultiBandGeoTiff {


### PR DESCRIPTION
This pull request adds a `bands` (reorder) method to `MultiBandTiles`, where possible.

In https://github.com/geotrellis/geotrellis/commit/b78a1ef7b3d4ab792de19b5e4ea3f6a0bb6ecb82, a trait is added to gurantee the existence of the method where it is possible to do so.  That commit can be removed if it is not desired.

Closes #1112