### PR TITLE
Provide toSpatial Method

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/TileLayout.scala
+++ b/raster/src/main/scala/geotrellis/raster/TileLayout.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,8 +49,8 @@ case class TileLayout(layoutCols: Int, layoutRows: Int, tileCols: Int, tileRows:
   def tileDimensions: (Int, Int) = (tileCols, tileRows)
 
   def tileSize: Int = tileCols * tileRows
-    
-  def cellSize(extent: Extent): CellSize = 
+
+  def cellSize(extent: Extent): CellSize =
     CellSize(extent.width / totalCols, extent.height / totalRows)
 
   def combine(other: TileLayout) = {

--- a/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
@@ -13,6 +13,6 @@ trait Implicits {
   implicit class withRasterRDDFilterMethods[K: Boundable : ClassTag, V: ClassTag, M](val self: RDD[(K, V)] with Metadata[M])
       extends RasterRDDFilterMethods[K, V, M]
 
-  implicit class withSpaceTimeRasterRDDFilterMethods[K <: SpaceTimeKey : ClassTag, V : ClassTag, M](val self: RDD[(K, V)] with Metadata[M])
-      extends SpaceTimeRasterRDDFilterMethods[K, V, M]
+  implicit class withSpaceTimeToSpatialMethods[K : SpatialComponent : TemporalComponent : ClassTag, V : ClassTag, M](val self: RDD[(K, V)] with Metadata[M])
+      extends SpaceTimeToSpatialMethods[K, V, M]
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
@@ -12,4 +12,7 @@ object Implicits extends Implicits
 trait Implicits {
   implicit class withRasterRDDFilterMethods[K: Boundable : ClassTag, V: ClassTag, M](val self: RDD[(K, V)] with Metadata[M])
       extends RasterRDDFilterMethods[K, V, M]
+
+  implicit class withSpaceTimeRasterRDDFilterMethods[K <: SpaceTimeKey : ClassTag, V : ClassTag, M](val self: RDD[(K, V)] with Metadata[M])
+      extends SpaceTimeRasterRDDFilterMethods[K, V, M]
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeRasterRDDFilterMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeRasterRDDFilterMethods.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.filter
+
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.util.MethodExtensions
+
+import org.apache.spark.rdd._
+import org.joda.time.DateTime
+
+
+abstract class SpaceTimeRasterRDDFilterMethods[K <: SpaceTimeKey, V, M] extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
+  def filterByInstant(instant: DateTime): RDD[(SpatialKey, V)] with Metadata[M] = {
+    val rdd = self.mapPartitions({ p =>
+      p.flatMap({ case (key, tile) =>
+        if (key.time == instant) Some((key.spatialKey, tile))
+        else None
+      })
+    }, preservesPartitioning = true)
+    val metadata = self.metadata
+    ContextRDD(rdd, metadata)
+  }
+
+  def filterByInstant(instant: Long): RDD[(SpatialKey, V)] with Metadata[M] = {
+    val dtInstant = SpaceTimeKey(0, 0, instant).time
+    filterByInstant(dtInstant)
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeRasterToSpatialMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeRasterToSpatialMethods.scala
@@ -24,11 +24,11 @@ import org.apache.spark.rdd._
 import org.joda.time.DateTime
 
 
-abstract class SpaceTimeRasterRDDFilterMethods[K <: SpaceTimeKey, V, M] extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
-  def filterByInstant(instant: DateTime): RDD[(SpatialKey, V)] with Metadata[M] = {
+abstract class SpaceTimeToSpatialMethods[K : SpatialComponent : TemporalComponent, V, M] extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
+  def toSpatial(instant: DateTime): RDD[(SpatialKey, V)] with Metadata[M] = {
     val rdd = self.mapPartitions({ p =>
       p.flatMap({ case (key, tile) =>
-        if (key.time == instant) Some((key.spatialKey, tile))
+        if (key.temporalComponent.time == instant) Some((key.spatialComponent, tile))
         else None
       })
     }, preservesPartitioning = true)
@@ -36,8 +36,8 @@ abstract class SpaceTimeRasterRDDFilterMethods[K <: SpaceTimeKey, V, M] extends 
     ContextRDD(rdd, metadata)
   }
 
-  def filterByInstant(instant: Long): RDD[(SpatialKey, V)] with Metadata[M] = {
+  def toSpatial(instant: Long): RDD[(SpatialKey, V)] with Metadata[M] = {
     val dtInstant = SpaceTimeKey(0, 0, instant).time
-    filterByInstant(dtInstant)
+    toSpatial(dtInstant)
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/filter/RasterRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/filter/RasterRDDFilterMethodsSpec.scala
@@ -53,15 +53,15 @@ class RasterRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
     val rasterRDD = ContextRDD(rdd, metadata)
 
     it("should filter out all items that are not at the given instant") {
-      rasterRDD.filterByInstant(0).count should be (0)
-      rasterRDD.filterByInstant(1).count should be (1)
-      rasterRDD.filterByInstant(2).count should be (2)
-      rasterRDD.filterByInstant(3).count should be (3)
-      rasterRDD.filterByInstant(4).count should be (4)
+      rasterRDD.toSpatial(0).count should be (0)
+      rasterRDD.toSpatial(1).count should be (1)
+      rasterRDD.toSpatial(2).count should be (2)
+      rasterRDD.toSpatial(3).count should be (3)
+      rasterRDD.toSpatial(4).count should be (4)
     }
 
     it ("should produce an RDD whose keys are of type SpatialKey") {
-      rasterRDD.filterByInstant(1).first._1 should be (SpatialKey(0,0))
+      rasterRDD.toSpatial(1).first._1 should be (SpatialKey(0,0))
     }
   }
 

--- a/spark/src/test/scala/geotrellis/spark/filter/RasterRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/filter/RasterRDDFilterMethodsSpec.scala
@@ -16,17 +16,56 @@
 
 package geotrellis.spark.filter
 
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.spark.filter._
+import geotrellis.proj4.LatLng
+import geotrellis.raster.{GridBounds, TileLayout, FloatConstantNoDataCellType}
 import geotrellis.raster.io.geotiff.SingleBandGeoTiff
+import geotrellis.spark._
+import geotrellis.spark.filter._
+import geotrellis.spark.io._
+import geotrellis.spark.tiling._
 
 import org.scalatest.FunSpec
 
 
 class RasterRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
 
-  describe("RasterRDD Crop Methods") {
+  describe("SpaceTime RasterRDD Filter Methods") {
+    val rdd = sc.parallelize(List(
+      (SpaceTimeKey(0, 0, 1), true),
+      (SpaceTimeKey(0, 1, 2), true),
+      (SpaceTimeKey(1, 0, 2), true),
+      (SpaceTimeKey(1, 1, 3), true),
+      (SpaceTimeKey(0, 0, 3), true),
+      (SpaceTimeKey(0, 1, 3), true),
+      (SpaceTimeKey(1, 0, 4), true),
+      (SpaceTimeKey(1, 1, 4), true),
+      (SpaceTimeKey(0, 0, 4), true),
+      (SpaceTimeKey(0, 1, 4), true)))
+    val metadata: RasterMetaData = {
+      val cellType = FloatConstantNoDataCellType
+      val crs = LatLng
+      val tileLayout = TileLayout(8, 8, 3, 4)
+      val mapTransform = MapKeyTransform(crs, tileLayout.layoutDimensions)
+      val gridBounds = GridBounds(1, 1, 6, 7)
+      val extent = mapTransform(gridBounds)
+      RasterMetaData(cellType, LayoutDefinition(crs.worldExtent, tileLayout), extent, crs)
+    }
+    val rasterRDD = ContextRDD(rdd, metadata)
+
+    it("should filter out all items that are not at the given instant") {
+      rasterRDD.filterByInstant(0).count should be (0)
+      rasterRDD.filterByInstant(1).count should be (1)
+      rasterRDD.filterByInstant(2).count should be (2)
+      rasterRDD.filterByInstant(3).count should be (3)
+      rasterRDD.filterByInstant(4).count should be (4)
+    }
+
+    it ("should produce an RDD whose keys are of type SpatialKey") {
+      rasterRDD.filterByInstant(1).first._1 should be (SpatialKey(0,0))
+    }
+  }
+
+  describe("Spatial RasterRDD Filter Methods") {
     val path = "raster-test/data/aspect.tif"
     val gt = SingleBandGeoTiff(path)
     val originalRaster = gt.raster.resample(500, 500)

--- a/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
@@ -1,13 +1,15 @@
 package geotrellis.spark.testfiles
 
-import com.github.nscala_time.time.Imports._
-import geotrellis.spark.tiling._
-import geotrellis.raster.{GridBounds, TileLayout, FloatConstantNoDataCellType}
-import geotrellis.spark.tiling.{LayoutDefinition, MapKeyTransform}
-import org.apache.spark._
-import geotrellis.spark._
 import geotrellis.proj4._
+import geotrellis.raster.{GridBounds, TileLayout, FloatConstantNoDataCellType}
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.spark.tiling.{LayoutDefinition, MapKeyTransform}
+
+import com.github.nscala_time.time.Imports._
+import org.apache.spark._
 import org.joda.time.DateTime
+
 
 object TestFiles extends Logging {
   val ZOOM_LEVEL = 8


### PR DESCRIPTION
These changes equip every `RasterRDD` keyed by `SpaceTimeKey` with a `toSpatial` (formerly `filterByInstant`) method that filters out all entries not occurring at the given instant, and also projects the keys to the `SpatialKey` type.

Closes #1057
