### PR TITLE
Fixed issues with GeoTiff reading and projection

### DIFF
--- a/proj4/src/main/java/org/osgeo/proj4j/BasicCoordinateTransform.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/BasicCoordinateTransform.java
@@ -4,8 +4,8 @@ import org.osgeo.proj4j.datum.*;
 import java.util.Arrays;
 
 /**
- * Represents the operation of transforming 
- * a {@link ProjCoordinate} from one {@link CoordinateReferenceSystem} 
+ * Represents the operation of transforming
+ * a {@link ProjCoordinate} from one {@link CoordinateReferenceSystem}
  * into a different one, using reprojection and datum conversion
  * as required.
  * <p>
@@ -15,71 +15,71 @@ import java.util.Arrays;
  * it is inverse-projected into a geographic coordinate system
  * based on the source datum
  * <li>If the source and target {@link Datum}s are different,
- * the source geographic coordinate is converted 
+ * the source geographic coordinate is converted
  * from the source to the target datum
  * as accurately as possible
- * <li>If the target coordinate system is a projected coordinate system, 
+ * <li>If the target coordinate system is a projected coordinate system,
  * the converted geographic coordinate is projected into a projected coordinate.
  * </ul>
  * Symbolically this can be presented as:
  * <pre>
  * [ SrcProjCRS {InverseProjection} ] SrcGeoCRS [ {Datum Conversion} ] TgtGeoCRS [ {Projection} TgtProjCRS ]
  * </pre>
- * <tt>BasicCoordinateTransform</tt> objects are stateful, 
+ * <tt>BasicCoordinateTransform</tt> objects are stateful,
  * and thus are not thread-safe.
  * However, they may be reused any number of times within a single thread.
  * <p>
  * Information about the transformation procedure is pre-computed
  * and cached in this object for efficient computation.
- * 
+ *
  * @author Martin Davis
  * @see CoordinateTransformFactory
  *
  */
-public class BasicCoordinateTransform 
+public class BasicCoordinateTransform
     implements CoordinateTransform
 {
     private CoordinateReferenceSystem srcCRS;
     private CoordinateReferenceSystem tgtCRS;
-	
+
     // temporary variable for intermediate results
     private ProjCoordinate geoCoord = new ProjCoordinate(0,0);
-	
+
     // precomputed information
     private boolean doInverseProjection = true;
     private boolean doForwardProjection = true;
     private boolean doDatumTransform = false;
     private boolean transformViaGeocentric = false;
-    private GeocentricConverter srcGeoConv; 
-    private GeocentricConverter tgtGeoConv; 
-	
+    private GeocentricConverter srcGeoConv;
+    private GeocentricConverter tgtGeoConv;
+
     /**
-     * Creates a transformation from a source {@link CoordinateReferenceSystem} 
+     * Creates a transformation from a source {@link CoordinateReferenceSystem}
      * to a target one.
-     * 
+     *
      * @param srcCRS the source CRS to transform from
      * @param tgtCRS the target CRS to transform to
      */
-    public BasicCoordinateTransform(CoordinateReferenceSystem srcCRS, 
+    public BasicCoordinateTransform(CoordinateReferenceSystem srcCRS,
                                     CoordinateReferenceSystem tgtCRS)
     {
         this.srcCRS = srcCRS;
         this.tgtCRS = tgtCRS;
-		
+
         // compute strategy for transformation at initialization time, to make transformation more efficient
         // this may include precomputing sets of parameters
-		
+
         doInverseProjection = (srcCRS != null && srcCRS != CoordinateReferenceSystem.CS_GEO);
         doForwardProjection = (tgtCRS != null && tgtCRS != CoordinateReferenceSystem.CS_GEO);
         doDatumTransform = doInverseProjection && doForwardProjection
             && srcCRS.getDatum() != tgtCRS.getDatum();
-    
+
         if (doDatumTransform) {
-      
+
             boolean isEllipsoidEqual = srcCRS.getDatum().getEllipsoid().isEqual(tgtCRS.getDatum().getEllipsoid());
-            if (! isEllipsoidEqual) 
+            if (! isEllipsoidEqual)
                 transformViaGeocentric = true;
-            if (srcCRS.getDatum().hasTransformToWGS84() 
+            if (srcCRS.getDatum().hasTransformToWGS84()
                 || tgtCRS.getDatum().hasTransformToWGS84())
                 transformViaGeocentric = true;
 
@@ -95,29 +95,29 @@ public class BasicCoordinateTransform
                     tgtGeoConv.overrideWithWGS84Params();
                 }
             }
-      
+
         }
     }
-	
+
     public CoordinateReferenceSystem getSourceCRS()
     {
         return srcCRS;
     }
-  
+
     public CoordinateReferenceSystem getTargetCRS()
     {
         return tgtCRS;
     }
-  
-  
+
+
     /**
-     * Tranforms a coordinate from the source {@link CoordinateReferenceSystem} 
+     * Tranforms a coordinate from the source {@link CoordinateReferenceSystem}
      * to the target one.
-     * 
+     *
      * @param src the input coordinate to be transformed
      * @param tgt the transformed coordinate
      * @return the target coordinate which was passed in
-     * 
+     *
      * @throws Proj4jException if a computation error is encountered
      */
     public ProjCoordinate transform( ProjCoordinate src, ProjCoordinate tgt )
@@ -125,6 +125,7 @@ public class BasicCoordinateTransform
     {
         geoCoord.setValue(src);
         srcCRS.getProjection().getAxisOrder().toENU(geoCoord);
+
         // NOTE: this method may be called many times, so needs to be as efficient as possible
         if (doInverseProjection) {
             // inverse project to geographic
@@ -134,14 +135,14 @@ public class BasicCoordinateTransform
         }
 
         srcCRS.getProjection().getPrimeMeridian().toGreenwich(geoCoord);
-    
+
         // fixes bug where computed Z value sticks around
         geoCoord.clearZ();
-		
+
         if (doDatumTransform) {
             datumTransform(geoCoord);
         }
-		
+
         tgtCRS.getProjection().getPrimeMeridian().fromGreenwich(geoCoord);
 
         if (doForwardProjection) {
@@ -156,12 +157,12 @@ public class BasicCoordinateTransform
 
         return tgt;
     }
-  
+
     /**
-     * 
+     *
      * Input:  long/lat/z coordinates in radians in the source datum
      * Output: long/lat/z coordinates in radians in the target datum
-     * 
+     *
      * @param pt the point containing the input and output values
      */
     private void datumTransform(ProjCoordinate pt)
@@ -173,11 +174,11 @@ public class BasicCoordinateTransform
                 || srcCRS.getDatum().getTransformType() == Datum.TYPE_UNKNOWN
                 || tgtCRS.getDatum().getTransformType() == Datum.TYPE_UNKNOWN)
             return;
-    
+
         if (srcCRS.getDatum().getTransformType() == Datum.TYPE_GRIDSHIFT) {
             srcCRS.getDatum().shift(pt);
         }
-    
+
         /* ==================================================================== */
         /*      Do we need to go through geocentric coordinates?                */
         /* ==================================================================== */
@@ -186,7 +187,7 @@ public class BasicCoordinateTransform
             /*      Convert to geocentric coordinates.                              */
             /* -------------------------------------------------------------------- */
             srcGeoConv.convertGeodeticToGeocentric( pt );
-      
+
             /* -------------------------------------------------------------------- */
             /*      Convert between datums.                                         */
             /* -------------------------------------------------------------------- */
@@ -203,11 +204,11 @@ public class BasicCoordinateTransform
             /* -------------------------------------------------------------------- */
             tgtGeoConv.convertGeocentricToGeodetic( pt );
         }
-    
+
 
         if (tgtCRS.getDatum().getTransformType() == Datum.TYPE_GRIDSHIFT) {
             tgtCRS.getDatum().inverseShift(pt);
         }
     }
-  
+
 }

--- a/proj4/src/main/java/org/osgeo/proj4j/CoordinateReferenceSystem.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/CoordinateReferenceSystem.java
@@ -85,6 +85,11 @@ public class CoordinateReferenceSystem implements java.io.Serializable
         return buf.toString();
     }
 
+    public Boolean isGeographic()
+    {
+        return proj.isGeographic();
+    }
+
     /**
      * Creates a geographic (unprojected) {@link CoordinateReferenceSystem}
      * based on the {@link Datum} of this CRS.

--- a/proj4/src/main/java/org/osgeo/proj4j/CoordinateReferenceSystem.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/CoordinateReferenceSystem.java
@@ -13,16 +13,16 @@ import org.osgeo.proj4j.units.Units;
  * A coordinate system is defined by the following things:
  * <ul>
  * <li>an {@link Ellipsoid} specifies how the shape of the Earth is approximated
- * <li>a {@link Datum} provides the mapping from the ellipsoid to 
+ * <li>a {@link Datum} provides the mapping from the ellipsoid to
  * actual locations on the earth
  * <li>a {@link Projection} method maps the ellpsoidal surface to a planar space.
  * (The projection method may be null in the case of geodetic coordinate systems).
- * <li>a {@link Unit} indicates how the ordinate values 
+ * <li>a {@link Unit} indicates how the ordinate values
  * of coordinates are interpreted
  * </ul>
- * 
+ *
  * @author Martin Davis
- * 
+ *
  * @see CRSFactory
  *
  */
@@ -32,51 +32,51 @@ public class CoordinateReferenceSystem implements java.io.Serializable
     public static final CoordinateReferenceSystem CS_GEO = new CoordinateReferenceSystem("CS_GEO", null, null, null);
 
     //TODO: add metadata like authority, id, name, parameter string, datum, ellipsoid, datum shift parameters
-	
+
     private String name;
     private String[] params;
     private Datum datum;
     private Projection proj;
-	
+
     public CoordinateReferenceSystem(String name, String[] params, Datum datum, Projection proj)
     {
         this.name = name;
         this.params = params;
         this.datum = datum;
         this.proj = proj;
-    
+
         if (name == null) {
-            String projName = "null-proj"; 
+            String projName = "null-proj";
             if (proj != null)
                 projName = proj.getName();
             this.name = projName + "-CS";
         }
     }
-	
+
     public String getName()
     {
         return name;
     }
-  
+
     public String[] getParameters()
     {
         return params;
     }
-  
+
     public Datum getDatum()
     {
         return datum;
     }
-  
+
     public Projection getProjection()
     {
         return proj;
     }
-  
+
     public String getParameterString()
     {
         if (params == null) return "";
-    
+
         StringBuffer buf = new StringBuffer();
         for (int i = 0; i < params.length; i++) {
             buf.append(params[i]);
@@ -84,15 +84,15 @@ public class CoordinateReferenceSystem implements java.io.Serializable
         }
         return buf.toString();
     }
-  
+
     /**
-     * Creates a geographic (unprojected) {@link CoordinateReferenceSystem} 
+     * Creates a geographic (unprojected) {@link CoordinateReferenceSystem}
      * based on the {@link Datum} of this CRS.
      * This is useful for defining {@link CoordinateTransform}s
      * to and from geographic coordinate systems,
      * where no datum transformation is required.
-     * The {@link Units} of the geographic CRS are set to {@link Units#DEGREES}. 
-     * 
+     * The {@link Units} of the geographic CRS are set to {@link Units#DEGREES}.
+     *
      * @return a geographic CoordinateReferenceSystem based on the datum of this CRS
      */
     public CoordinateReferenceSystem createGeographic()

--- a/proj4/src/main/java/org/osgeo/proj4j/proj/LongLatProjection.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/proj/LongLatProjection.java
@@ -1,17 +1,17 @@
 /*
-Copyright 2006 Jerry Huxtable
+  Copyright 2006 Jerry Huxtable
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 */
 
 package org.osgeo.proj4j.proj;
@@ -19,31 +19,33 @@ package org.osgeo.proj4j.proj;
 import org.osgeo.proj4j.units.Units;
 
 /**
- * A "projection" for geodetic coordinates in Decimal Degrees. 
+ * A "projection" for geodetic coordinates in Decimal Degrees.
  */
-public class LongLatProjection extends Projection 
+public class LongLatProjection extends Projection
 {
-  // TODO: implement projection methods (which are basically just no-ops)
-	/*
-	
-	public Point2D.Double transformRadians( Point2D.Double src, Point2D.Double dst ) {
-		dst.x = src.x;
-		dst.y = src.y;
-		return dst;
-	}
-	
-	*/
-  
-	public String toString() {
-		return "LongLat";
-	}
+    // TODO: implement projection methods (which are basically just no-ops)
+    /*
 
-  public void initialize()
-  {
-    // units are always in Decimal Degrees
-    unit = Units.DEGREES;
-    totalScale = 1.0;
-  }
-  
-  
+      public Point2D.Double transformRadians( Point2D.Double src, Point2D.Double dst ) {
+      dst.x = src.x;
+      dst.y = src.y;
+      return dst;
+      }
+
+    */
+
+    public String toString() {
+        return "LongLat";
+    }
+
+    public void initialize()
+    {
+        // units are always in Decimal Degrees
+        unit = Units.DEGREES;
+        totalScale = 1.0;
+    }
+
+    @Override public Boolean isGeographic() {
+        return true;
+    }
 }

--- a/proj4/src/main/java/org/osgeo/proj4j/proj/Projection.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/proj/Projection.java
@@ -791,4 +791,9 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setGamma(double gamma) {
         // no-op, overridden for Oblique Mercator
     }
+
+    /** Is this "projection" longlat? Overridden in LongLatProjection. */
+    public Boolean isGeographic() {
+        return false;
+    }
 }

--- a/proj4/src/main/java/org/osgeo/proj4j/proj/Projection.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/proj/Projection.java
@@ -27,7 +27,7 @@ import org.osgeo.proj4j.util.ProjectionMath;
 
 /**
  * A map projection is a mathematical algorithm
- * for representing a spheroidal surface 
+ * for representing a spheroidal surface
  * on a plane.
  * A single projection
  * defines a (usually infinite) family of
@@ -188,11 +188,11 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     protected final static double EPS10 = 1e-10;
     protected final static double RTD = 180.0/Math.PI;
     protected final static double DTR = Math.PI/180.0;
-	
+
     protected Projection() {
         setEllipsoid( Ellipsoid.SPHERE );
     }
-	
+
     public Object clone() {
         try {
             Projection e = (Projection)super.clone();
@@ -202,14 +202,14 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
             throw new InternalError();
         }
     }
-	
+
     /**
-     * Projects a geographic point (in degrees), producing a projected result 
+     * Projects a geographic point (in degrees), producing a projected result
      * (in the units of the target coordinate system).
-     * 
+     *
      * @param src the input geographic coordinate (in degrees)
      * @param dst the projected coordinate (in coordinate system units)
-     * @return the target coordinate 
+     * @return the target coordinate
      */
     public ProjCoordinate project( ProjCoordinate src, ProjCoordinate dst ) {
         double x = src.x*DTR;
@@ -219,13 +219,13 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     }
 
     /**
-     * Projects a geographic point (in radians), producing a projected result 
+     * Projects a geographic point (in radians), producing a projected result
      * (in the units of the target coordinate system).
-     * 
+     *
      * @param src the input geographic coordinate (in radians)
      * @param dst the projected coordinate (in coordinate system units)
-     * @return the target coordinate 
-     * 
+     * @return the target coordinate
+     *
      */
     public ProjCoordinate projectRadians( ProjCoordinate src, ProjCoordinate dst ) {
         double x = src.x;
@@ -233,11 +233,11 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
             x = ProjectionMath.normalizeLongitude( x-projectionLongitude );
         return projectRadians(x, src.y, dst);
     }
-	
+
     /**
-     * Transform a geographic point (in radians), 
+     * Transform a geographic point (in radians),
      * producing a projected result (in the units of the target coordinate system).
-     * 
+     *
      * @param x the geographic x ordinate (in radians)
      * @param y the geographic y ordinate (in radians)
      * @param dst the projected coordinate (in coordinate system units)
@@ -245,7 +245,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
      */
     private ProjCoordinate projectRadians(double x, double y, ProjCoordinate dst ) {
         project(x, y, dst);
-        if (unit == Units.DEGREES) {
+        if (unit != null && unit.equals(Units.DEGREES)) {
             // convert radians to DD
             dst.x *= RTD;
             dst.y *= RTD;
@@ -259,10 +259,10 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     }
 
     /**
-     * Computes the projection of a given point 
-     * (i.e. from geographics to projection space). 
+     * Computes the projection of a given point
+     * (i.e. from geographics to projection space).
      * This should be overridden for all projections.
-     * 
+     *
      * @param x the geographic x ordinate (in radians)
      * @param y the geographic y ordinatee (in radians)
      * @param dst the projected coordinate (in coordinate system units)
@@ -275,9 +275,9 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     }
 
     /**
-     * Inverse-projects a point (in the units defined by the coordinate system), 
+     * Inverse-projects a point (in the units defined by the coordinate system),
      * producing a geographic result (in degrees)
-     * 
+     *
      * @param src the input projected coordinate (in coordinate system units)
      * @param dst the inverse-projected geographic coordinate (in degrees)
      * @return the target coordinate
@@ -290,18 +290,18 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     }
 
     /**
-     * Inverse-transforms a point (in the units defined by the coordinate system), 
+     * Inverse-transforms a point (in the units defined by the coordinate system),
      * producing a geographic result (in radians)
-     * 
+     *
      * @param src the input projected coordinate (in coordinate system units)
      * @param dst the inverse-projected geographic coordinate (in radians)
      * @return the target coordinate
-     * 
+     *
      */
     public ProjCoordinate inverseProjectRadians(ProjCoordinate src, ProjCoordinate dst) {
         double x;
         double y;
-        if (unit == Units.DEGREES) {
+        if (unit != null && unit.equals(Units.DEGREES)) {
             // convert DD to radians
             x = src.x * DTR;
             y = src.y * DTR;
@@ -310,21 +310,24 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
             x = (src.x - totalFalseEasting) / totalScale;
             y = (src.y - totalFalseNorthing) / totalScale;
         }
+
         projectInverse(x, y, dst);
+
         if (dst.x < -Math.PI)
             dst.x = -Math.PI;
         else if (dst.x > Math.PI)
             dst.x = Math.PI;
         if (projectionLongitude != 0)
             dst.x = ProjectionMath.normalizeLongitude(dst.x+projectionLongitude);
+
         return dst;
     }
 
     /**
-     * Computes the inverse projection of a given point 
-     * (i.e. from projection space to geographics). 
+     * Computes the inverse projection of a given point
+     * (i.e. from projection space to geographics).
      * This should be overridden for all projections.
-     * 
+     *
      * @param x the projected x ordinate (in coordinate system units)
      * @param y the projected y ordinate (in coordinate system units)
      * @param dst the inverse-projected geographic coordinate  (in radians)
@@ -336,35 +339,35 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
         return dst;
     }
 
-	
+
     /**
      * Tests whether this projection is conformal.
      * A conformal projection preserves local angles.
-     * 
+     *
      * @return true if this projection is conformal
      */
     public boolean isConformal() {
         return false;
     }
-	
+
     /**
      * Tests whether this projection is equal-area
      * An equal-area projection preserves relative sizes
      * of projected areas.
-     * 
+     *
      * @return true if this projection is equal-area
      */
     public boolean isEqualArea() {
         return false;
     }
-	
+
     /**
      * Tests whether this projection has an inverse.
      * If this method returns <tt>true</tt>
      * then the {@link #inverseProject(ProjCoordinate, ProjCoordinate)}
      * and {@link #inverseProjectRadians(ProjCoordinate, ProjCoordinate)}
      * methods will return meaningful results.
-     * 
+     *
      * @return true if this projection has an inverse
      */
     public boolean hasInverse() {
@@ -372,7 +375,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     }
 
     /**
-     * Tests whether under this projection lines of 
+     * Tests whether under this projection lines of
      * latitude and longitude form a rectangular grid
      */
     public boolean isRectilinear() {
@@ -400,7 +403,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setName( String name ) {
         this.name = name;
     }
-	
+
     public String getName() {
         if ( name != null )
             return name;
@@ -463,7 +466,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setMinLatitude( double minLatitude ) {
         this.minLatitude = minLatitude;
     }
-	
+
     public double getMinLatitude() {
         return minLatitude;
     }
@@ -474,7 +477,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setMaxLatitude( double maxLatitude ) {
         this.maxLatitude = maxLatitude;
     }
-	
+
     public double getMaxLatitude() {
         return maxLatitude;
     }
@@ -490,7 +493,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setMinLongitude( double minLongitude ) {
         this.minLongitude = minLongitude;
     }
-	
+
     public double getMinLongitude() {
         return minLongitude;
     }
@@ -498,7 +501,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setMinLongitudeDegrees( double minLongitude ) {
         this.minLongitude = DTR*minLongitude;
     }
-	
+
     public double getMinLongitudeDegrees() {
         return minLongitude*RTD;
     }
@@ -506,7 +509,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setMaxLongitude( double maxLongitude ) {
         this.maxLongitude = maxLongitude;
     }
-	
+
     public double getMaxLongitude() {
         return maxLongitude;
     }
@@ -514,7 +517,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setMaxLongitudeDegrees( double maxLongitude ) {
         this.maxLongitude = DTR*maxLongitude;
     }
-	
+
     public double getMaxLongitudeDegrees() {
         return maxLongitude*RTD;
     }
@@ -525,173 +528,173 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setProjectionLatitude( double projectionLatitude ) {
         this.projectionLatitude = projectionLatitude;
     }
-	
+
     public double getProjectionLatitude() {
         return projectionLatitude;
     }
-	
+
     /**
      * Set the projection latitude in degrees.
      */
     public void setProjectionLatitudeDegrees( double projectionLatitude ) {
         this.projectionLatitude = DTR*projectionLatitude;
     }
-	
+
     public double getProjectionLatitudeDegrees() {
         return projectionLatitude*RTD;
     }
-	
+
     /**
      * Set the projection longitude in radians.
      */
     public void setProjectionLongitude( double projectionLongitude ) {
         this.projectionLongitude = normalizeLongitudeRadians( projectionLongitude );
     }
-	
+
     public double getProjectionLongitude() {
         return projectionLongitude;
     }
-	
+
     /**
      * Set the projection longitude in degrees.
      */
     public void setProjectionLongitudeDegrees( double projectionLongitude ) {
         this.projectionLongitude = DTR*projectionLongitude;
     }
-	
+
     public double getProjectionLongitudeDegrees() {
         return projectionLongitude*RTD;
     }
-	
+
     /**
      * Set the latitude of true scale in radians. This is only used by certain projections.
      */
     public void setTrueScaleLatitude( double trueScaleLatitude ) {
         this.trueScaleLatitude = trueScaleLatitude;
     }
-	
+
     public double getTrueScaleLatitude() {
         return trueScaleLatitude;
     }
-	
+
     /**
      * Set the latitude of true scale in degrees. This is only used by certain projections.
      */
     public void setTrueScaleLatitudeDegrees( double trueScaleLatitude ) {
         this.trueScaleLatitude = DTR*trueScaleLatitude;
     }
-	
+
     public double getTrueScaleLatitudeDegrees() {
         return trueScaleLatitude*RTD;
     }
-	
+
     /**
      * Set the projection latitude in radians.
      */
     public void setProjectionLatitude1( double projectionLatitude1 ) {
         this.projectionLatitude1 = projectionLatitude1;
     }
-	
+
     public double getProjectionLatitude1() {
         return projectionLatitude1;
     }
-	
+
     /**
      * Set the projection latitude in degrees.
      */
     public void setProjectionLatitude1Degrees( double projectionLatitude1 ) {
         this.projectionLatitude1 = DTR*projectionLatitude1;
     }
-	
+
     public double getProjectionLatitude1Degrees() {
         return projectionLatitude1*RTD;
     }
-	
+
     /**
      * Set the projection latitude in radians.
      */
     public void setProjectionLatitude2( double projectionLatitude2 ) {
         this.projectionLatitude2 = projectionLatitude2;
     }
-	
+
     public double getProjectionLatitude2() {
         return projectionLatitude2;
     }
-	
+
     /**
      * Set the projection latitude in degrees.
      */
     public void setProjectionLatitude2Degrees( double projectionLatitude2 ) {
         this.projectionLatitude2 = DTR*projectionLatitude2;
     }
-	
+
     public double getProjectionLatitude2Degrees() {
         return projectionLatitude2*RTD;
     }
-	
+
     /**
      * Sets the alpha value.
      */
     public void setAlphaDegrees( double alpha ) {
         this.alpha = DTR * alpha;
     }
-  
+
     /**
      * Gets the alpha value, in radians.
-     * 
+     *
      * @return the alpha value
      */
     public double getAlpha()
-    { 
+    {
         return alpha;
     }
-  
+
     /**
      * Sets the lonc value.
      */
     public void setLonCDegrees( double lonc ) {
         this.lonc = DTR * lonc;
     }
-  
+
     /**
      * Gets the lonc value, in radians.
-     * 
+     *
      * @return the lonc value
      */
     public double getLonC()
-    { 
+    {
         return lonc;
     }
-  
+
     /**
      * Set the false Northing in projected units.
      */
     public void setFalseNorthing( double falseNorthing ) {
         this.falseNorthing = falseNorthing;
     }
-  
+
     public double getFalseNorthing() {
         return falseNorthing;
     }
-	
+
     /**
      * Set the false Easting in projected units.
      */
     public void setFalseEasting( double falseEasting ) {
         this.falseEasting = falseEasting;
     }
-	
+
     public double getFalseEasting() {
         return falseEasting;
     }
-	
+
     public void setSouthernHemisphere(boolean isSouth)
     {
         this.isSouth = isSouth;
     }
-  
+
     public boolean getSouthernHemisphere() { return isSouth; }
-  
+
     /**
      * Set the projection scale factor. This is set to 1 by default.
      * This value is called "k0" in PROJ.4.
@@ -703,7 +706,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     /**
      * Gets the projection scale factor.
      * This value is called "k0" in PROJ.4.
-     * 
+     *
      * @return
      */
     public double getScaleFactor() {
@@ -720,18 +723,18 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public void setFromMetres( double fromMetres ) {
         this.fromMetres = fromMetres;
     }
-	
+
     public double getFromMetres() {
         return fromMetres;
     }
-	
+
     public void setEllipsoid( Ellipsoid ellipsoid ) {
         this.ellipsoid = ellipsoid;
         a = ellipsoid.equatorRadius;
         e = ellipsoid.eccentricity;
         es = ellipsoid.eccentricity2;
     }
-	
+
     public Ellipsoid getEllipsoid() {
         return ellipsoid;
     }
@@ -742,7 +745,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public int getEPSGCode() {
         return 0;
     }
-	
+
     public void setUnits(Unit unit)
     {
         this.unit = unit;
@@ -751,7 +754,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public Unit getUnits() {
         return this.unit;
     }
-  
+
     /**
      * Initialize the projection. This should be called after setting parameters and before using the projection.
      * This is for performance reasons as initialization may be expensive.
@@ -762,7 +765,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
         rone_es = 1.0/one_es;
         totalScale = a * fromMetres;
         totalFalseEasting = falseEasting * fromMetres;
-        totalFalseNorthing = falseNorthing * fromMetres;		
+        totalFalseNorthing = falseNorthing * fromMetres;
     }
 
     public static float normalizeLongitude(float angle) {
@@ -789,4 +792,3 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
         // no-op, overridden for Oblique Mercator
     }
 }
-

--- a/proj4/src/main/java/org/osgeo/proj4j/units/Angle.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/units/Angle.java
@@ -5,82 +5,82 @@ import org.osgeo.proj4j.util.ProjectionMath;
 public class Angle
 {
 
-  /**
-   * Parses a text representation of a degree angle in various formats.
-   * 
-   * Formats include DMS and DD in the forms
-   * supported by {@link AngleFormat},
-   * as in the following examples:
-   * <pre>
-   * 123.12
-   * -123.12
-   * 123.12W
-   * 
-   * 123d44m44.555s
-   * 123d44'44.555"
-   * 123d44mN
-   * </pre>
-   *  
-   * @param text
-   * @return the value of the angle, in degrees
-   */
-  public static double parse(String text) 
-    throws NumberFormatException
-  {
-    double d = 0, m = 0, s = 0;
-    double result;
-    boolean negate = false;
-    int length = text.length();
-    if (length > 0) {
-      char c = Character.toUpperCase(text.charAt(length-1));
-      switch (c) {
-      case AngleFormat.CH_W:
-      case AngleFormat.CH_S:
-        negate = true;
-        // Fall into...
-      case AngleFormat.CH_E:
-      case AngleFormat.CH_N:
-        text = text.substring(0, length-1);
-        break;
-      }
-    }
-    int i = text.indexOf(AngleFormat.CH_DEG_ABBREV);
-    if (i == -1)
-      i = text.indexOf(AngleFormat.CH_DEG_SYMBOL);
-    if (i != -1) {
-      String dd = text.substring(0, i);
-      String mmss = text.substring(i+1);
-      d = Double.valueOf(dd).doubleValue();
-      i = mmss.indexOf(AngleFormat.CH_MIN_ABBREV);
-      if (i == -1)
-        i = mmss.indexOf(AngleFormat.CH_MIN_SYMBOL);
-      if (i != -1) {
-        if (i != 0) {
-          String mm = mmss.substring(0, i);
-          m = Double.valueOf(mm).doubleValue();
+    /**
+     * Parses a text representation of a degree angle in various formats.
+     *
+     * Formats include DMS and DD in the forms
+     * supported by {@link AngleFormat},
+     * as in the following examples:
+     * <pre>
+     * 123.12
+     * -123.12
+     * 123.12W
+     *
+     * 123d44m44.555s
+     * 123d44'44.555"
+     * 123d44mN
+     * </pre>
+     *
+     * @param text
+     * @return the value of the angle, in degrees
+     */
+    public static double parse(String text)
+        throws NumberFormatException
+    {
+        double d = 0, m = 0, s = 0;
+        double result;
+        boolean negate = false;
+        int length = text.length();
+        if (length > 0) {
+            char c = Character.toUpperCase(text.charAt(length-1));
+            switch (c) {
+            case AngleFormat.CH_W:
+            case AngleFormat.CH_S:
+                negate = true;
+                // Fall into...
+            case AngleFormat.CH_E:
+            case AngleFormat.CH_N:
+                text = text.substring(0, length-1);
+                break;
+            }
         }
-        if (mmss.endsWith(AngleFormat.STR_SEC_ABBREV) || mmss.endsWith(AngleFormat.STR_SEC_SYMBOL))
-          mmss = mmss.substring(0, mmss.length()-1);
-        if (i != mmss.length()-1) {
-          String ss = mmss.substring(i+1);
-          s = Double.valueOf(ss).doubleValue();
+        int i = text.indexOf(AngleFormat.CH_DEG_ABBREV);
+        if (i == -1)
+            i = text.indexOf(AngleFormat.CH_DEG_SYMBOL);
+        if (i != -1) {
+            String dd = text.substring(0, i);
+            String mmss = text.substring(i+1);
+            d = Double.valueOf(dd).doubleValue();
+            i = mmss.indexOf(AngleFormat.CH_MIN_ABBREV);
+            if (i == -1)
+                i = mmss.indexOf(AngleFormat.CH_MIN_SYMBOL);
+            if (i != -1) {
+                if (i != 0) {
+                    String mm = mmss.substring(0, i);
+                    m = Double.valueOf(mm).doubleValue();
+                }
+                if (mmss.endsWith(AngleFormat.STR_SEC_ABBREV) || mmss.endsWith(AngleFormat.STR_SEC_SYMBOL))
+                    mmss = mmss.substring(0, mmss.length()-1);
+                if (i != mmss.length()-1) {
+                    String ss = mmss.substring(i+1);
+                    s = Double.valueOf(ss).doubleValue();
+                }
+                if (m < 0 || m > 59)
+                    throw new NumberFormatException("Minutes must be between 0 and 59");
+                if (s < 0 || s >= 60)
+                    throw new NumberFormatException("Seconds must be between 0 and 59");
+            } else if (i != 0)
+                if (mmss.length() == 0)
+                    m = 0;
+                else
+                    m = Double.valueOf(mmss).doubleValue();
+            result = ProjectionMath.dmsToDeg(d, m, s);
+        } else {
+            result = Double.parseDouble(text);
         }
-        if (m < 0 || m > 59)
-          throw new NumberFormatException("Minutes must be between 0 and 59");
-        if (s < 0 || s >= 60)
-          throw new NumberFormatException("Seconds must be between 0 and 59");
-      } else if (i != 0)
-        if (mmss.length() == 0)
-          m = 0;
-        else
-          m = Double.valueOf(mmss).doubleValue();
-        result = ProjectionMath.dmsToDeg(d, m, s);
-    } else {
-      result = Double.parseDouble(text);
+        if (negate)
+            result = -result;
+        return result;
     }
-    if (negate)
-      result = -result;
-    return result;
-  }
 
 }

--- a/proj4/src/main/java/org/osgeo/proj4j/units/AngleFormat.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/units/AngleFormat.java
@@ -1,17 +1,17 @@
 /*
-Copyright 2006 Jerry Huxtable
+  Copyright 2006 Jerry Huxtable
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 */
 
 package org.osgeo.proj4j.units;
@@ -28,181 +28,180 @@ import org.osgeo.proj4j.util.ProjectionMath;
  */
 public class AngleFormat extends NumberFormat {
 
-  public static final char CH_MIN_SYMBOL = '\'';
-  public static final String STR_SEC_SYMBOL = "\"";
-  public static final char CH_DEG_SYMBOL = '\u00b0';
-  public static final char CH_DEG_ABBREV = 'd';
-  public static final char CH_MIN_ABBREV = 'm';
-  public static final String STR_SEC_ABBREV = "s";
-  
-  public static final char CH_N = 'N';
-  public static final char CH_E = 'E';
-  public static final char CH_S = 'S';
-  public static final char CH_W = 'W';
+    public static final char CH_MIN_SYMBOL = '\'';
+    public static final String STR_SEC_SYMBOL = "\"";
+    public static final char CH_DEG_SYMBOL = '\u00b0';
+    public static final char CH_DEG_ABBREV = 'd';
+    public static final char CH_MIN_ABBREV = 'm';
+    public static final String STR_SEC_ABBREV = "s";
 
-	public final static String ddmmssPattern = "DdM";
-	public final static String ddmmssPattern2 = "DdM'S\"";
-	public final static String ddmmssLongPattern = "DdM'S\"W";
-	public final static String ddmmssLatPattern = "DdM'S\"N";
-	public final static String ddmmssPattern4 = "DdMmSs";
-	public final static String decimalPattern = "D.F";
+    public static final char CH_N = 'N';
+    public static final char CH_E = 'E';
+    public static final char CH_S = 'S';
+    public static final char CH_W = 'W';
 
-	private DecimalFormat format;
-	private String pattern;
-	private boolean isDegrees;
+    public final static String ddmmssPattern = "DdM";
+    public final static String ddmmssPattern2 = "DdM'S\"";
+    public final static String ddmmssLongPattern = "DdM'S\"W";
+    public final static String ddmmssLatPattern = "DdM'S\"N";
+    public final static String ddmmssPattern4 = "DdMmSs";
+    public final static String decimalPattern = "D.F";
 
-	public AngleFormat() {
-		this(ddmmssPattern);
-	}
-	
-	public AngleFormat(String pattern) {
-		this(pattern, false);
-	}
-	
-	public AngleFormat(String pattern, boolean isDegrees) {
-		this.pattern = pattern;
-		this.isDegrees = isDegrees;
-		format = new DecimalFormat();
-		format.setMaximumFractionDigits(0);
-		format.setGroupingUsed(false);
-	}
-	
-	public StringBuffer format(long number, StringBuffer result, FieldPosition fieldPosition) {
-		return format((double)number, result, fieldPosition);
-	}
+    private DecimalFormat format;
+    private String pattern;
+    private boolean isDegrees;
 
-	public StringBuffer format(double number, StringBuffer result, FieldPosition fieldPosition) {
-		int length = pattern.length();
-		int f;
-		boolean negative = false;
+    public AngleFormat() {
+        this(ddmmssPattern);
+    }
 
-		if (number < 0) {
-			for (int i = length-1; i >= 0; i--) {
-				char c = pattern.charAt(i);
-				if (c == 'W' || c == 'N') {
-					number = -number;
-					negative = true;
-					break;
-				}
-			}
-		}
-		
-		double ddmmss = isDegrees ? number : Math.toDegrees(number);
-		int iddmmss = (int)Math.round(ddmmss * 3600);
-		if (iddmmss < 0)
-			iddmmss = -iddmmss;
-		int fraction = iddmmss % 3600;
+    public AngleFormat(String pattern) {
+        this(pattern, false);
+    }
 
-		for (int i = 0; i < length; i++) {
-			char c = pattern.charAt(i);
-			switch (c) {
-			case 'R':
-				result.append(number);
-				break;
-			case 'D':
-				result.append((int)ddmmss);
-				break;
-			case 'M':
-				f = fraction / 60;
-				if (f < 10)
-					result.append('0');
-				result.append(f);
-				break;
-			case 'S':
-				f = fraction % 60;
-				if (f < 10)
-					result.append('0');
-				result.append(f);
-				break;
-			case 'F':
-				result.append(fraction);
-				break;
-			case 'W':
-				if (negative)
-					result.append(CH_W);
-				else
-					result.append(CH_E);
-				break;
-			case 'N':
-				if (negative)
-					result.append(CH_S);
-				else
-					result.append(CH_N);
-				break;
-			default:
-				result.append(c);
-				break;
-			}
-		}
-		return result;
-	}
-	
-  /**
-   * 
-   * @param s
-   * @return
-   * @deprecated
-   * @see Angle#parse(String)
-   */
-	public Number parse(String text, ParsePosition parsePosition) {
-		double d = 0, m = 0, s = 0;
-		double result;
-		boolean negate = false;
-		int length = text.length();
-		if (length > 0) {
-			char c = Character.toUpperCase(text.charAt(length-1));
-			switch (c) {
-			case 'W':
-			case 'S':
-				negate = true;
-				// Fall into...
-			case 'E':
-			case 'N':
-				text = text.substring(0, length-1);
-				break;
-			}
-		}
-		int i = text.indexOf('d');
-		if (i == -1)
-			i = text.indexOf('\u00b0');
-		if (i != -1) {
-			String dd = text.substring(0, i);
-			String mmss = text.substring(i+1);
-			d = Double.valueOf(dd).doubleValue();
-			i = mmss.indexOf('m');
-			if (i == -1)
-				i = mmss.indexOf('\'');
-			if (i != -1) {
-				if (i != 0) {
-					String mm = mmss.substring(0, i);
-					m = Double.valueOf(mm).doubleValue();
-				}
-				if (mmss.endsWith("s") || mmss.endsWith("\""))
-					mmss = mmss.substring(0, mmss.length()-1);
-				if (i != mmss.length()-1) {
-					String ss = mmss.substring(i+1);
-					s = Double.valueOf(ss).doubleValue();
-				}
-				if (m < 0 || m > 59)
-					throw new NumberFormatException("Minutes must be between 0 and 59");
-				if (s < 0 || s >= 60)
-					throw new NumberFormatException("Seconds must be between 0 and 59");
-			} else if (i != 0)
-				m = Double.valueOf(mmss).doubleValue();
-			if (isDegrees)
-				result = ProjectionMath.dmsToDeg(d, m, s);
-			else
-				result = ProjectionMath.dmsToRad(d, m, s);
-		} else {
-			result = Double.parseDouble(text);
-			if (!isDegrees)
-				result = Math.toRadians(result);
-		}
-		if (parsePosition != null)
-			parsePosition.setIndex(text.length());
-		if (negate)
-			result = -result;
-		return new Double(result);
-	}
+    public AngleFormat(String pattern, boolean isDegrees) {
+        this.pattern = pattern;
+        this.isDegrees = isDegrees;
+        format = new DecimalFormat();
+        format.setMaximumFractionDigits(0);
+        format.setGroupingUsed(false);
+    }
+
+    public StringBuffer format(long number, StringBuffer result, FieldPosition fieldPosition) {
+        return format((double)number, result, fieldPosition);
+    }
+
+    public StringBuffer format(double number, StringBuffer result, FieldPosition fieldPosition) {
+        int length = pattern.length();
+        int f;
+        boolean negative = false;
+
+        if (number < 0) {
+            for (int i = length-1; i >= 0; i--) {
+                char c = pattern.charAt(i);
+                if (c == 'W' || c == 'N') {
+                    number = -number;
+                    negative = true;
+                    break;
+                }
+            }
+        }
+
+        double ddmmss = isDegrees ? number : Math.toDegrees(number);
+        int iddmmss = (int)Math.round(ddmmss * 3600);
+        if (iddmmss < 0)
+            iddmmss = -iddmmss;
+        int fraction = iddmmss % 3600;
+
+        for (int i = 0; i < length; i++) {
+            char c = pattern.charAt(i);
+            switch (c) {
+            case 'R':
+                result.append(number);
+                break;
+            case 'D':
+                result.append((int)ddmmss);
+                break;
+            case 'M':
+                f = fraction / 60;
+                if (f < 10)
+                    result.append('0');
+                result.append(f);
+                break;
+            case 'S':
+                f = fraction % 60;
+                if (f < 10)
+                    result.append('0');
+                result.append(f);
+                break;
+            case 'F':
+                result.append(fraction);
+                break;
+            case 'W':
+                if (negative)
+                    result.append(CH_W);
+                else
+                    result.append(CH_E);
+                break;
+            case 'N':
+                if (negative)
+                    result.append(CH_S);
+                else
+                    result.append(CH_N);
+                break;
+            default:
+                result.append(c);
+                break;
+            }
+        }
+        return result;
+    }
+
+    /**
+     *
+     * @param s
+     * @return
+     * @deprecated
+     * @see Angle#parse(String)
+     */
+    public Number parse(String text, ParsePosition parsePosition) {
+        double d = 0, m = 0, s = 0;
+        double result;
+        boolean negate = false;
+        int length = text.length();
+        if (length > 0) {
+            char c = Character.toUpperCase(text.charAt(length-1));
+            switch (c) {
+            case 'W':
+            case 'S':
+                negate = true;
+                // Fall into...
+            case 'E':
+            case 'N':
+                text = text.substring(0, length-1);
+                break;
+            }
+        }
+        int i = text.indexOf('d');
+        if (i == -1)
+            i = text.indexOf('\u00b0');
+        if (i != -1) {
+            String dd = text.substring(0, i);
+            String mmss = text.substring(i+1);
+            d = Double.valueOf(dd).doubleValue();
+            i = mmss.indexOf('m');
+            if (i == -1)
+                i = mmss.indexOf('\'');
+            if (i != -1) {
+                if (i != 0) {
+                    String mm = mmss.substring(0, i);
+                    m = Double.valueOf(mm).doubleValue();
+                }
+                if (mmss.endsWith("s") || mmss.endsWith("\""))
+                    mmss = mmss.substring(0, mmss.length()-1);
+                if (i != mmss.length()-1) {
+                    String ss = mmss.substring(i+1);
+                    s = Double.valueOf(ss).doubleValue();
+                }
+                if (m < 0 || m > 59)
+                    throw new NumberFormatException("Minutes must be between 0 and 59");
+                if (s < 0 || s >= 60)
+                    throw new NumberFormatException("Seconds must be between 0 and 59");
+            } else if (i != 0)
+                m = Double.valueOf(mmss).doubleValue();
+            if (isDegrees)
+                result = ProjectionMath.dmsToDeg(d, m, s);
+            else
+                result = ProjectionMath.dmsToRad(d, m, s);
+        } else {
+            result = Double.parseDouble(text);
+            if (!isDegrees)
+                result = Math.toRadians(result);
+        }
+        if (parsePosition != null)
+            parsePosition.setIndex(text.length());
+        if (negate)
+            result = -result;
+        return new Double(result);
+    }
 }
-

--- a/proj4/src/main/java/org/osgeo/proj4j/units/DegreeUnit.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/units/DegreeUnit.java
@@ -1,55 +1,54 @@
 /*
-Copyright 2006 Jerry Huxtable
+  Copyright 2006 Jerry Huxtable
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 */
 
 package org.osgeo.proj4j.units;
 
 
 public class DegreeUnit extends Unit {
-	
-	static final long serialVersionUID = -3212757578604686538L;
-	
-	private static AngleFormat format = new AngleFormat(AngleFormat.ddmmssPattern, true);
-	
-	public DegreeUnit() {
-		super("degree", "degrees", "deg", 1);
-	}
-	
-	public double parse(String s) throws NumberFormatException {
-		try {
-			return format.parse(s).doubleValue();
-		}
-		catch (java.text.ParseException e) {
-			throw new NumberFormatException(e.getMessage());
-		}
-	}
-	
-	public String format(double n) {
-		return format.format(n)+" "+abbreviation;
-	}
-	
-	public String format(double n, boolean abbrev) {
-		if (abbrev)
-			return format.format(n)+" "+abbreviation;
-		return format.format(n);
-	}
-	
-	public String format(double x, double y, boolean abbrev) {
-		if (abbrev)
-			return format.format(x)+"/"+format.format(y)+" "+abbreviation;
-		return format.format(x)+"/"+format.format(y);
-	}
-}
 
+    static final long serialVersionUID = -3212757578604686538L;
+
+    private static AngleFormat format = new AngleFormat(AngleFormat.ddmmssPattern, true);
+
+    public DegreeUnit() {
+        super("degree", "degrees", "deg", 1);
+    }
+
+    public double parse(String s) throws NumberFormatException {
+        try {
+            return format.parse(s).doubleValue();
+        }
+        catch (java.text.ParseException e) {
+            throw new NumberFormatException(e.getMessage());
+        }
+    }
+
+    public String format(double n) {
+        return format.format(n)+" "+abbreviation;
+    }
+
+    public String format(double n, boolean abbrev) {
+        if (abbrev)
+            return format.format(n)+" "+abbreviation;
+        return format.format(n);
+    }
+
+    public String format(double x, double y, boolean abbrev) {
+        if (abbrev)
+            return format.format(x)+"/"+format.format(y)+" "+abbreviation;
+        return format.format(x)+"/"+format.format(y);
+    }
+}

--- a/proj4/src/main/java/org/osgeo/proj4j/units/Unit.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/units/Unit.java
@@ -1,17 +1,17 @@
 /*
-Copyright 2006 Jerry Huxtable
+  Copyright 2006 Jerry Huxtable
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 */
 
 package org.osgeo.proj4j.units;
@@ -21,76 +21,76 @@ import java.text.NumberFormat;
 
 public class Unit implements Serializable {
 
-	static final long serialVersionUID = -6704954923429734628L;
-	
-	public final static int ANGLE_UNIT = 0;
-	public final static int LENGTH_UNIT = 1;
-	public final static int AREA_UNIT = 2;
-	public final static int VOLUME_UNIT = 3;
-	
-	public String name, plural, abbreviation;
-	public double value;
-	public static final NumberFormat format;
-	
-	static {
-		format = NumberFormat.getNumberInstance();
-		format.setMaximumFractionDigits(2);
-		format.setGroupingUsed(false);
-	}
-	
-	public Unit(String name, String plural, String abbreviation, double value) {
-		this.name = name;
-		this.plural = plural;
-		this.abbreviation = abbreviation;
-		this.value = value;
-	}
+    static final long serialVersionUID = -6704954923429734628L;
 
-	public double toBase(double n) {
-		return n * value;
-	}
+    public final static int ANGLE_UNIT = 0;
+    public final static int LENGTH_UNIT = 1;
+    public final static int AREA_UNIT = 2;
+    public final static int VOLUME_UNIT = 3;
 
-	public double fromBase(double n) {
-		return n / value;
-	}
-	
-	public double parse(String s) throws NumberFormatException {
-		try {
-			return format.parse(s).doubleValue();
-		}
-		catch (java.text.ParseException e) {
-			throw new NumberFormatException(e.getMessage());
-		}
-	}
-	
-	public String format(double n) {
-		return format.format(n)+" "+abbreviation;
-	}
-	
-	public String format(double n, boolean abbrev) {
-		if (abbrev)
-			return format.format(n)+" "+abbreviation;
-		return format.format(n);
-	}
-	
-	public String format(double x, double y, boolean abbrev) {
-		if (abbrev)
-			return format.format(x)+"/"+format.format(y)+" "+abbreviation;
-		return format.format(x)+"/"+format.format(y);
-	}
+    public String name, plural, abbreviation;
+    public double value;
+    public static final NumberFormat format;
 
-	public String format(double x, double y) {
-		return format(x, y, true);
-	}
+    static {
+        format = NumberFormat.getNumberInstance();
+        format.setMaximumFractionDigits(2);
+        format.setGroupingUsed(false);
+    }
 
-	public String toString() {
-		return plural;
-	}
+    public Unit(String name, String plural, String abbreviation, double value) {
+        this.name = name;
+        this.plural = plural;
+        this.abbreviation = abbreviation;
+        this.value = value;
+    }
 
-	public boolean equals(Object o) {
-		if (o instanceof Unit) {
-			return ((Unit)o).value == value;
-		}
-		return false;
-	}
+    public double toBase(double n) {
+        return n * value;
+    }
+
+    public double fromBase(double n) {
+        return n / value;
+    }
+
+    public double parse(String s) throws NumberFormatException {
+        try {
+            return format.parse(s).doubleValue();
+        }
+        catch (java.text.ParseException e) {
+            throw new NumberFormatException(e.getMessage());
+        }
+    }
+
+    public String format(double n) {
+        return format.format(n)+" "+abbreviation;
+    }
+
+    public String format(double n, boolean abbrev) {
+        if (abbrev)
+            return format.format(n)+" "+abbreviation;
+        return format.format(n);
+    }
+
+    public String format(double x, double y, boolean abbrev) {
+        if (abbrev)
+            return format.format(x)+"/"+format.format(y)+" "+abbreviation;
+        return format.format(x)+"/"+format.format(y);
+    }
+
+    public String format(double x, double y) {
+        return format(x, y, true);
+    }
+
+    public String toString() {
+        return plural;
+    }
+
+    public boolean equals(Object o) {
+        if (o instanceof Unit) {
+            return ((Unit)o).name.equals(name) && ((Unit)o).value == value;
+        }
+        return false;
+    }
 
 }

--- a/proj4/src/main/java/org/osgeo/proj4j/units/Units.java
+++ b/proj4/src/main/java/org/osgeo/proj4j/units/Units.java
@@ -1,79 +1,79 @@
 /*
-Copyright 2006 Jerry Huxtable
+  Copyright 2006 Jerry Huxtable
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 */
 
 package org.osgeo.proj4j.units;
 
 public class Units {
 
-	// Angular units
-	public final static Unit DEGREES = new DegreeUnit();
-	public final static Unit RADIANS = new Unit("radian", "radians", "rad", Math.toDegrees(1));
-	public final static Unit ARC_MINUTES = new Unit("arc minute", "arc minutes", "min", 1/60.0);
-	public final static Unit ARC_SECONDS = new Unit("arc second", "arc seconds", "sec", 1/3600.0);
+    // Angular units
+    public final static Unit DEGREES = new DegreeUnit();
+    public final static Unit RADIANS = new Unit("radian", "radians", "rad", Math.toDegrees(1));
+    public final static Unit ARC_MINUTES = new Unit("arc minute", "arc minutes", "min", 1/60.0);
+    public final static Unit ARC_SECONDS = new Unit("arc second", "arc seconds", "sec", 1/3600.0);
 
-	// Distance units
-	
-	// Metric units
-	public final static Unit KILOMETRES = new Unit("kilometre", "kilometres", "km", 1000);
-	public final static Unit METRES = new Unit("metre", "metres", "m", 1);
-	public final static Unit DECIMETRES = new Unit("decimetre", "decimetres", "dm", 0.1);
-	public final static Unit CENTIMETRES = new Unit("centimetre", "centimetres", "cm", 0.01);
-	public final static Unit MILLIMETRES = new Unit("millimetre", "millimetres", "mm", 0.001);
+    // Distance units
 
-	// International units
-	public final static Unit NAUTICAL_MILES = new Unit("nautical mile", "nautical miles", "kmi", 1852);
-	public final static Unit MILES = new Unit("mile", "miles", "mi", 1609.344);
-	public final static Unit CHAINS = new Unit("chain", "chains", "ch", 20.1168);
-	public final static Unit YARDS = new Unit("yard", "yards", "yd", 0.9144);
-	public final static Unit FEET = new Unit("foot", "feet", "ft", 0.3048);
-	public final static Unit INCHES = new Unit("inch", "inches", "in", 0.0254);
+    // Metric units
+    public final static Unit KILOMETRES = new Unit("kilometre", "kilometres", "km", 1000);
+    public final static Unit METRES = new Unit("metre", "metres", "m", 1);
+    public final static Unit DECIMETRES = new Unit("decimetre", "decimetres", "dm", 0.1);
+    public final static Unit CENTIMETRES = new Unit("centimetre", "centimetres", "cm", 0.01);
+    public final static Unit MILLIMETRES = new Unit("millimetre", "millimetres", "mm", 0.001);
 
-	// U.S. units
-	public final static Unit US_MILES = new Unit("U.S. mile", "U.S. miles", "us-mi", 1609.347218694437);
-	public final static Unit US_CHAINS = new Unit("U.S. chain", "U.S. chains", "us-ch", 20.11684023368047);
-	public final static Unit US_YARDS = new Unit("U.S. yard", "U.S. yards", "us-yd", 0.914401828803658);
-	public final static Unit US_FEET = new Unit("U.S. foot", "U.S. feet", "us-ft", 0.304800609601219);
-	public final static Unit US_INCHES = new Unit("U.S. inch", "U.S. inches", "us-in", 1.0/39.37);
+    // International units
+    public final static Unit NAUTICAL_MILES = new Unit("nautical mile", "nautical miles", "kmi", 1852);
+    public final static Unit MILES = new Unit("mile", "miles", "mi", 1609.344);
+    public final static Unit CHAINS = new Unit("chain", "chains", "ch", 20.1168);
+    public final static Unit YARDS = new Unit("yard", "yards", "yd", 0.9144);
+    public final static Unit FEET = new Unit("foot", "feet", "ft", 0.3048);
+    public final static Unit INCHES = new Unit("inch", "inches", "in", 0.0254);
 
-	// Miscellaneous units
-	public final static Unit FATHOMS = new Unit("fathom", "fathoms", "fath", 1.8288);
-	public final static Unit LINKS = new Unit("link", "links", "link", 0.201168);
+    // U.S. units
+    public final static Unit US_MILES = new Unit("U.S. mile", "U.S. miles", "us-mi", 1609.347218694437);
+    public final static Unit US_CHAINS = new Unit("U.S. chain", "U.S. chains", "us-ch", 20.11684023368047);
+    public final static Unit US_YARDS = new Unit("U.S. yard", "U.S. yards", "us-yd", 0.914401828803658);
+    public final static Unit US_FEET = new Unit("U.S. foot", "U.S. feet", "us-ft", 0.304800609601219);
+    public final static Unit US_INCHES = new Unit("U.S. inch", "U.S. inches", "us-in", 1.0/39.37);
 
-	public final static Unit POINTS = new Unit("point", "points", "point", 0.0254/72.27);
+    // Miscellaneous units
+    public final static Unit FATHOMS = new Unit("fathom", "fathoms", "fath", 1.8288);
+    public final static Unit LINKS = new Unit("link", "links", "link", 0.201168);
 
-	public static Unit[] units = {
-		DEGREES,
-		KILOMETRES, METRES, DECIMETRES, CENTIMETRES, MILLIMETRES,
-		MILES, YARDS, FEET, INCHES,
-		US_MILES, US_YARDS, US_FEET, US_INCHES,
-		NAUTICAL_MILES
-	};
+    public final static Unit POINTS = new Unit("point", "points", "point", 0.0254/72.27);
 
-	public static Unit findUnits(String name) {
-		for (int i = 0; i < units.length; i++) {
-			if (name.equals(units[i].name) || name.equals(units[i].plural) || name.equals(units[i].abbreviation))
-				return units[i];
-		}
-		return METRES;
-	}
+    public static Unit[] units = {
+        DEGREES,
+        KILOMETRES, METRES, DECIMETRES, CENTIMETRES, MILLIMETRES,
+        MILES, YARDS, FEET, INCHES,
+        US_MILES, US_YARDS, US_FEET, US_INCHES,
+        NAUTICAL_MILES
+    };
 
-	public static double convert(double value, Unit from, Unit to) {
-		if (from == to)
-			return value;
-		return to.fromBase(from.toBase(value));
-	}
+    public static Unit findUnits(String name) {
+        for (int i = 0; i < units.length; i++) {
+            if (name.equals(units[i].name) || name.equals(units[i].plural) || name.equals(units[i].abbreviation))
+                return units[i];
+        }
+        return METRES;
+    }
+
+    public static double convert(double value, Unit from, Unit to) {
+        if (from == to)
+            return value;
+        return to.fromBase(from.toBase(value));
+    }
 
 }

--- a/proj4/src/main/scala/geotrellis/proj4/CRS.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/CRS.scala
@@ -23,7 +23,7 @@ object CRS {
    */
   def fromString(proj4Params: String): CRS =
     new CRS {
-      val crs = crsFactory.createFromParameters(null, proj4Params)
+      val proj4jCrs = crsFactory.createFromParameters(null, proj4Params)
 
       def epsgCode: Option[Int] = getEPSGCode(toProj4String + " <>")
     }
@@ -50,7 +50,7 @@ object CRS {
    */
   def fromString(name: String, proj4Params: String): CRS =
     new CRS {
-      val crs = crsFactory.createFromParameters(name, proj4Params)
+      val proj4jCrs = crsFactory.createFromParameters(name, proj4Params)
 
       def epsgCode: Option[Int] = getEPSGCode(toProj4String + " <>")
     }
@@ -90,11 +90,12 @@ object CRS {
    * @param name the name of a coordinate system, with optional authority prefix
    * @return the [[CoordinateReferenceSystem]] corresponding to the given name
    */
-  def fromName(name: String): CRS = new CRS {
-    val crs = crsFactory.createFromName(name)
+  def fromName(name: String): CRS =
+    new CRS {
+      val proj4jCrs = crsFactory.createFromName(name)
 
-    def epsgCode: Option[Int] = getEPSGCode(toProj4String + " <>")
-  }
+      def epsgCode: Option[Int] = getEPSGCode(toProj4String + " <>")
+    }
 
   /** Creates a [[CoordinateReferenceSystem]] (CRS) from an EPSG code. */
   def fromEpsgCode(epsgCode: Int) =
@@ -128,7 +129,7 @@ trait CRS extends Serializable {
 
   def epsgCode: Option[Int]
 
-  private[proj4] val crs: CoordinateReferenceSystem
+  def proj4jCrs: CoordinateReferenceSystem
 
   /** Override this function to handle reprojecting to another CRS in a more performant way */
   def alternateTransform(dest: CRS): Option[(Double, Double) => (Double, Double)] =
@@ -145,7 +146,9 @@ trait CRS extends Serializable {
   override
   def hashCode = toProj4String.hashCode
 
-  def toProj4String: String = crs.getParameterString
+  def toProj4String: String = proj4jCrs.getParameterString
+
+  def isGeographic: Boolean = proj4jCrs.isGeographic
 
   override
   def equals(o: Any): Boolean =

--- a/proj4/src/main/scala/geotrellis/proj4/LatLng.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/LatLng.scala
@@ -1,7 +1,7 @@
 package geotrellis.proj4
 
 object LatLng extends CRS {
-  lazy val crs = factory.createFromName("EPSG:4326")
+  lazy val proj4jCrs = factory.createFromName("EPSG:4326")
 
   def epsgCode: Option[Int] = CRS.getEPSGCode(toProj4String + " <>")
 }

--- a/proj4/src/main/scala/geotrellis/proj4/Transform.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/Transform.scala
@@ -12,7 +12,7 @@ object Transform {
 
 object Proj4Transform {
   def apply(src: CRS, dest: CRS): Transform = {
-    val t = new BasicCoordinateTransform(src.crs, dest.crs)
+    val t = new BasicCoordinateTransform(src.proj4jCrs, dest.proj4jCrs)
 
     { (x: Double, y: Double) =>
       val srcP = new ProjCoordinate(x, y)

--- a/proj4/src/main/scala/geotrellis/proj4/WebMercator.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/WebMercator.scala
@@ -1,7 +1,7 @@
 package geotrellis.proj4
 
 object WebMercator extends CRS {
-  lazy val crs = factory.createFromName("EPSG:3857")
+  lazy val proj4jCrs = factory.createFromName("EPSG:3857")
 
   def epsgCode: Option[Int] = CRS.getEPSGCode(toProj4String + " <>")
 }

--- a/proj4/src/main/scala/geotrellis/proj4/util/UTM.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/util/UTM.scala
@@ -1,0 +1,41 @@
+package geotrellis.proj4.util
+
+import geotrellis.proj4._
+
+// Ported from javascript https://github.com/chrisveness/geodesy by Chris Veness (MIT license)
+object UTM {
+  /** Gets a UTM zone based on a LatLn coordinate.
+    * @return Left(zone) if the zone is North and Right(zone) if the zone is right
+    */
+  def getZone(lon: Double, lat: Double): Either[Int, Int] = {
+    if (!(-80 <= lat && lat <= 84))
+      throw new IllegalArgumentException("Outside UTM limits")
+
+    var zone = (math.floor((lon + 180) / 6) + 1).toInt
+
+    // handle Norway/Svalbard exceptions
+    // grid zones are 8° tall; 0°N is offset 10 into latitude bands array
+    val mgrsLatBands = "CDEFGHJKLMNPQRSTUVWXX" // X is repeated for 80-84°N
+    val latBand = mgrsLatBands.charAt(math.floor(lat / 8 + 10).toInt)
+    // adjust zone & central meridian for Norway
+    if (zone==31 && latBand=='V' && lon >= 3) { zone += 1 }
+    // adjust zone & central meridian for Svalbard
+    if (zone==32 && latBand=='X' && lon <  9) { zone -= 1 }
+    if (zone==32 && latBand=='X' && lon >= 9) { zone += 1 }
+    if (zone==34 && latBand=='X' && lon < 21) { zone -= 1 }
+    if (zone==34 && latBand=='X' && lon >=21) { zone += 1 }
+    if (zone==36 && latBand=='X' && lon < 33) { zone -= 1 }
+    if (zone==36 && latBand=='X' && lon >=33) { zone += 1 }
+
+    if(lat >= 0) Left(zone) else Right(zone)
+  }
+
+  /** Retrieves a CRS for the UTM zone that contains the LatLng point */
+  def getZoneCrs(lon: Double, lat: Double): CRS =
+    getZone(lon, lat) match {
+      case Left(zone) =>
+        CRS.fromName(f"EPSG:326$zone%02d")
+      case Right(zone) =>
+        CRS.fromName(f"EPSG:327$zone%02d")
+    }
+}

--- a/proj4/src/main/scala/geotrellis/proj4/util/UTM.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/util/UTM.scala
@@ -4,11 +4,14 @@ import geotrellis.proj4._
 
 // Ported from javascript https://github.com/chrisveness/geodesy by Chris Veness (MIT license)
 object UTM {
+  def inValidZone(lat: Double): Boolean =
+    (-80 <= lat && lat <= 84)
+
   /** Gets a UTM zone based on a LatLn coordinate.
     * @return Left(zone) if the zone is North and Right(zone) if the zone is right
     */
   def getZone(lon: Double, lat: Double): Either[Int, Int] = {
-    if (!(-80 <= lat && lat <= 84))
+    if (!inValidZone(lat))
       throw new IllegalArgumentException("Outside UTM limits")
 
     var zone = (math.floor((lon + 180) / 6) + 1).toInt

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -249,7 +249,7 @@ class GeoTiffReaderSpec extends FunSpec
     it("must match aspect.tif geokeys") {
       val tiffTags = TiffTagsReader.read(s"$baseDataPath/aspect.tif")
 
-      tiffTags.hasPixelArea should be (true)
+      tiffTags.tags.headTags("AREA_OR_POINT") should be ("AREA")
 
       val extent = tiffTags.extent
 
@@ -435,7 +435,7 @@ class GeoTiffReaderSpec extends FunSpec
 
       tags.headTags("HEADTAG") should be ("1")
       tags.headTags("TAG_TYPE") should be ("HEAD")
-      tags.headTags.size should be (2)
+      tags.headTags.size should be (3)
 
       val bandCount = geoTiff.tile.bandCount
 

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -362,7 +362,7 @@ class GeoTiffReaderSpec extends FunSpec
     val MeanEpsilon = 1e-8
 
     def testMinMaxAndMean(min: Double, max: Double, mean: Double, file: String) {
-      val SingleBandGeoTiff(tile, extent, _, _) = SingleBandGeoTiff.compressed(s"$baseDataPath/$file")
+      val SingleBandGeoTiff(tile, extent, _, _, _) = SingleBandGeoTiff.compressed(s"$baseDataPath/$file")
 
       tile.polygonalMax(extent, extent.toPolygon) should be (max)
       tile.polygonalMin(extent, extent.toPolygon) should be (min)
@@ -388,7 +388,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff without GeoKey Directory correctly") {
-      val SingleBandGeoTiff(tile, extent, crs, _) = SingleBandGeoTiff.compressed(geoTiffPath("no-geokey-dir.tif"))
+      val SingleBandGeoTiff(tile, extent, crs, _, _) = SingleBandGeoTiff.compressed(geoTiffPath("no-geokey-dir.tif"))
 
       crs should be (LatLng)
       extent should be (Extent(307485, 3911490, 332505, 3936510))
@@ -471,6 +471,39 @@ class GeoTiffReaderSpec extends FunSpec
 
   }
 
+  describe("Reading and writing special metadata tags ") {
+    val temp = java.io.File.createTempFile("geotiff-writer", ".tif");
+    val path = temp.getPath()
+
+    it("must read a tif, change the pixel sample type, write it out, and then read the correct in") {
+      val gt = SingleBandGeoTiff.compressed(s"$baseDataPath/slope.tif")
+      var headTags = gt.tags.headTags
+      assert(headTags(Tags.AREA_OR_POINT) == "AREA")
+      headTags -= Tags.AREA_OR_POINT
+      headTags += ((Tags.AREA_OR_POINT, "POINT"))
+      val tags = Tags(headTags, gt.tags.bandTags)
+      val gt2 = gt.copy(tags = tags)
+      writer.GeoTiffWriter.write(gt2, path)
+      addToPurge(path)
+      val gt3 = SingleBandGeoTiff.compressed(path)
+
+      gt3.tags.headTags.get(Tags.AREA_OR_POINT) should be (Some("POINT"))
+    }
+
+    it("must read a tif, set a datetime, write it out, and then read the correct in") {
+      val gt = SingleBandGeoTiff.compressed(s"$baseDataPath/reproject/nlcd_tile_wsg84.tif")
+      var headTags = gt.tags.headTags
+      headTags += ((Tags.TIFFTAG_DATETIME, "1988:02:18 13:59:59"))
+      val tags = Tags(headTags, gt.tags.bandTags)
+      val gt2 = gt.copy(tags = tags)
+      writer.GeoTiffWriter.write(gt2, path)
+      addToPurge(path)
+      val gt3 = SingleBandGeoTiff.compressed(path)
+      assert(gt3.crs == LatLng)
+
+      gt3.tags.headTags.get(Tags.TIFFTAG_DATETIME) should be (Some("1988:02:18 13:59:59"))
+    }
+  }
 }
 
 class PackBitsGeoTiffReaderSpec extends FunSpec

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -43,7 +43,7 @@ class GeoTiffWriterSpec extends FunSpec
   private val testCRS = CRS.fromName("EPSG:3857")
 
   describe ("writing GeoTiffs without errors and with correct tiles, crs and extent") {
-    val temp = File.createTempFile("geotiff-writer", ".tif"); 
+    val temp = File.createTempFile("geotiff-writer", ".tif");
     val path = temp.getPath()
 
     it("should write GeoTiff with tags") {
@@ -98,7 +98,7 @@ class GeoTiffWriterSpec extends FunSpec
 
       addToPurge(path)
 
-      val SingleBandGeoTiff(tile, extent, crs, _) = SingleBandGeoTiff(path)
+      val SingleBandGeoTiff(tile, extent, crs, _, _) = SingleBandGeoTiff(path)
 
       extent should equal (e)
       crs should equal (testCRS)
@@ -115,7 +115,7 @@ class GeoTiffWriterSpec extends FunSpec
 
       addToPurge(path)
 
-      val SingleBandGeoTiff(actualTile, actualExtent, actualCrs, _) = SingleBandGeoTiff(path)
+      val SingleBandGeoTiff(actualTile, actualExtent, actualCrs, _, _) = SingleBandGeoTiff(path)
 
       actualExtent should equal (extent)
       crs should equal (LatLng)

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -41,6 +41,7 @@ object GridBounds {
 case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
   def width = colMax - colMin + 1
   def height = rowMax - rowMin + 1
+  if(width.toLong * height.toLong > Int.MaxValue) { sys.error(s"Cannot construct grid bounds of this size: $width x $height") }
   def size = width * height
   def isEmpty = size == 0
 

--- a/raster/src/main/scala/geotrellis/raster/VectorToRaster.scala
+++ b/raster/src/main/scala/geotrellis/raster/VectorToRaster.scala
@@ -82,7 +82,7 @@ object VectorToRaster {
               val destX = re.gridColToMap(col)
               val destY = re.gridRowToMap(row)
               val pts = index.pointsInExtent(Extent(destX - r, destY - r, destX + r, destY + r))
-              println(pts.size)
+
               if (pts.isEmpty) {
                 tile.set(col, row, NODATA)
               } else {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
@@ -13,6 +13,15 @@ trait GeoTiffData {
   def extent: Extent
   def crs: CRS
   def tags: Tags
+
+  def pixelSampleType: Option[PixelSampleType] =
+    tags.headTags.get(Tags.AREA_OR_POINT).flatMap { aop =>
+      aop match {
+        case "AREA" => Some(PixelIsArea)
+        case "POINT" => Some(PixelIsPoint)
+        case _ => None
+      }
+    }
 }
 
 trait GeoTiff[T <: CellGrid] extends GeoTiffData {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultiBandGeoTiff.scala
@@ -5,7 +5,7 @@ import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.vector.Extent
 import geotrellis.proj4.CRS
 
-class MultiBandGeoTiff(
+case class MultiBandGeoTiff(
   val tile: MultiBandTile,
   val extent: Extent,
   val crs: CRS,
@@ -66,13 +66,11 @@ object MultiBandGeoTiff {
   def apply(path: String, decompress: Boolean): MultiBandGeoTiff =
     GeoTiffReader.readMultiBand(path, decompress)
 
-
   /** Read a multi-band GeoTIFF file from the file at a given path.
     * The tile data will remain tiled/striped and compressed in the TIFF format.
     */
   def compressed(path: String): MultiBandGeoTiff =
     GeoTiffReader.readMultiBand(path, false)
-
 
   /** Read a multi-band GeoTIFF file from a byte array.
     * The tile data will remain tiled/striped and compressed in the TIFF format.
@@ -94,18 +92,6 @@ object MultiBandGeoTiff {
     tags: Tags
   ): MultiBandGeoTiff =
     apply(tile, extent, crs, tags, GeoTiffOptions.DEFAULT)
-
-  def apply(
-    tile: MultiBandTile,
-    extent: Extent,
-    crs: CRS,
-    tags: Tags,
-    options: GeoTiffOptions
-  ): MultiBandGeoTiff =
-    new MultiBandGeoTiff(tile, extent, crs, tags, options)
-
-  def unapply(mbg: MultiBandGeoTiff): Option[(MultiBandTile, Extent, CRS, Tags)] =
-    Some((mbg.tile, mbg.extent, mbg.crs, mbg.tags))
 
   implicit def multiBandGeoTiffToTile(mbg: MultiBandGeoTiff): MultiBandTile =
     mbg.tile

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SingleBandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SingleBandGeoTiff.scala
@@ -5,7 +5,7 @@ import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.vector.Extent
 import geotrellis.proj4.CRS
 
-class SingleBandGeoTiff(
+case class SingleBandGeoTiff(
   val tile: Tile,
   val extent: Extent,
   val crs: CRS,
@@ -26,9 +26,6 @@ class SingleBandGeoTiff(
 
 object SingleBandGeoTiff {
 
-  def unapply(sbg: SingleBandGeoTiff): Option[(Tile, Extent, CRS, Tags)] =
-    Some((sbg.tile, sbg.extent, sbg.crs, sbg.tags))
-
   def apply(
     tile: Tile,
     extent: Extent,
@@ -36,37 +33,28 @@ object SingleBandGeoTiff {
   ): SingleBandGeoTiff =
     new SingleBandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT)
 
-  def apply(
-    tile: Tile,
-    extent: Extent,
-    crs: CRS,
-    tags: Tags,
-    options: GeoTiffOptions
-  ): SingleBandGeoTiff =
-    new SingleBandGeoTiff(tile, extent, crs, tags, options)
-
   /** Read a single-band GeoTIFF file from a byte array.
     * The GeoTIFF will be fully decompressed and held in memory.
     */
-  def apply(bytes: Array[Byte]): SingleBandGeoTiff = 
+  def apply(bytes: Array[Byte]): SingleBandGeoTiff =
     GeoTiffReader.readSingleBand(bytes)
 
   /** Read a single-band GeoTIFF file from a byte array.
     * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
     */
-  def apply(bytes: Array[Byte], decompress: Boolean): SingleBandGeoTiff = 
+  def apply(bytes: Array[Byte], decompress: Boolean): SingleBandGeoTiff =
     GeoTiffReader.readSingleBand(bytes, decompress)
-  
+
   /** Read a single-band GeoTIFF file from the file at the given path.
     * The GeoTIFF will be fully decompressed and held in memory.
     */
-  def apply(path: String): SingleBandGeoTiff = 
+  def apply(path: String): SingleBandGeoTiff =
     GeoTiffReader.readSingleBand(path)
 
   /** Read a single-band GeoTIFF file from the file at the given path.
     * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
     */
-  def apply(path: String, decompress: Boolean): SingleBandGeoTiff = 
+  def apply(path: String, decompress: Boolean): SingleBandGeoTiff =
     GeoTiffReader.readSingleBand(path, decompress)
 
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Tags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Tags.scala
@@ -2,6 +2,9 @@ package geotrellis.raster.io.geotiff
 
 object Tags {
   def empty: Tags = Tags(Map(), List())
+
+  final val AREA_OR_POINT = "AREA_OR_POINT"
+  final val TIFFTAG_DATETIME = "TIFFTAG_DATETIME"
 }
 
 /** Tags are user data that the GeoTiff is tagged with.

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffCSParser.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffCSParser.scala
@@ -39,7 +39,7 @@ import scala.collection.immutable.HashMap
 
 import monocle.syntax._
 
-case class GeoTiffGDALParameters(
+case class GeoTiffCSParameters(
   var model: Int = UserDefinedCPV,
   var pcs: Int = UserDefinedCPV,
   var gcs: Int = UserDefinedCPV,
@@ -62,26 +62,26 @@ case class GeoTiffGDALParameters(
 )
 
 object GeoTiffCSParser {
-
-  def apply(directory: TiffTags) = new GeoTiffCSParser(directory)
-
+  def apply(directory: GeoKeyDirectory) = new GeoTiffCSParser(directory)
 }
 
 /**
   * This class is indirectly ported from the GDAL github repository.
   */
-class GeoTiffCSParser(directory: TiffTags) {
-
-  private val geoKeyDirectory = directory.geoKeyDirectory
+class GeoTiffCSParser(geoKeyDirectory: GeoKeyDirectory) {
 
   private val csvReader = EPSGCSVReader()
 
-  def getProj4String: Option[String] = getProj4String(createGeoTiffGDALParameters)
+  def getProj4String: Option[String] = getProj4String(createGeoTiffCSParameters)
 
-  lazy val pcs: Int = createGeoTiffGDALParameters.pcs
+  lazy val geoTiffCSParameters = createGeoTiffCSParameters
 
-  private def createGeoTiffGDALParameters: GeoTiffGDALParameters = {
-    val gtgp = GeoTiffGDALParameters()
+  def model: Int = geoTiffCSParameters.model
+  def pcs: Int = geoTiffCSParameters.pcs
+  def gcs: Int = geoTiffCSParameters.gcs
+
+  private def createGeoTiffCSParameters: GeoTiffCSParameters = {
+    val gtgp = GeoTiffCSParameters()
 
     gtgp.model = (geoKeyDirectory &|->
       GeoKeyDirectory._configKeys ^|->
@@ -264,7 +264,7 @@ class GeoTiffCSParser(directory: TiffTags) {
     gtgp
   }
 
-  private def getPCSData(pcs: Int, gtgp: GeoTiffGDALParameters) {
+  private def getPCSData(pcs: Int, gtgp: GeoTiffCSParameters) {
     val (optDatum, optZone, optMapSystem) = pcsToDatumZoneAndMapSystem(pcs)
 
     val optDatumName = optMapSystem match {
@@ -656,7 +656,7 @@ class GeoTiffCSParser(directory: TiffTags) {
     }
     else angle
 
-  private def setProjectionParameters(gtgp: GeoTiffGDALParameters) {
+  private def setProjectionParameters(gtgp: GeoTiffCSParameters) {
     var originLong, originLat, rectGridAngle = 0.0
     var falseEasting, falseNorthing = 0.0
     var originScale = 1.0
@@ -952,7 +952,7 @@ class GeoTiffCSParser(directory: TiffTags) {
       else Some((MapSys_State_Plane_27, projCode - 10000))
     } else None
 
-  private def getProj4String(gtgp: GeoTiffGDALParameters): Option[String] = {
+  private def getProj4String(gtgp: GeoTiffCSParameters): Option[String] = {
     val proj4SB = new StringBuilder
 
     val units = projectedLinearUnitsMap.get(gtgp.length) match {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -240,7 +240,7 @@ object TiffTagsReader {
           TiffTags._geoTiffTags ^|->
           GeoTiffTags._metadata set(Some(string))
         case GDALInternalNoDataTag =>
-          tiffTags.setGDALNoData(string)
+         tiffTags.setGDALNoData(string)
         case tag => tiffTags &|->
           TiffTags._nonStandardizedTags ^|->
           NonStandardizedTags._asciisMap modify(_ + (tag -> string))
@@ -434,6 +434,9 @@ object TiffTagsReader {
         case JpegInterchangeFormatLengthTag => tiffTags &|->
           TiffTags._jpegTags ^|->
           JpegTags._jpegInterchangeFormatLength set(Some(ints(0)))
+        case RowsPerStripTag => tiffTags &|->
+          TiffTags._basicTags ^|->
+          BasicTags._rowsPerStrip set(ints(0))
         case StripOffsetsTag => tiffTags &|->
           TiffTags._basicTags ^|->
           BasicTags._stripOffsets set(Some(ints.map(_.toInt)))

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/BasicTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/BasicTags.scala
@@ -11,7 +11,7 @@ case class BasicTags(
   compression: Int = 1,
   photometricInterp: Int = -1,
   resolutionUnit: Option[Int] = None,
-  rowsPerStrip: Long = (1 << 31) - 1,
+  rowsPerStrip: Long = 1,
   samplesPerPixel: Int = 1,
   stripByteCounts: Option[Array[Int]] = None,
   stripOffsets: Option[Array[Int]] = None,

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
@@ -363,16 +363,16 @@ case class TiffTags(
       TiffTags._metadataTags ^|->
       MetadataTags._dateTime get match {
         case Some(dateTime) =>
-          headTags = headTags + (("TIFFTAG_DATETIME", dateTime))
+          headTags = headTags + ((Tags.TIFFTAG_DATETIME, dateTime))
         case None =>
       }
 
     // pixel sample type
     pixelSampleType match {
       case Some(v) if v == PixelIsPoint =>
-        headTags = headTags + (("AREA_OR_POINT", "POINT"))
+        headTags = headTags + ((Tags.AREA_OR_POINT, "POINT"))
       case Some(v) if v == PixelIsArea =>
-        headTags = headTags + (("AREA_OR_POINT", "AREA"))
+        headTags = headTags + ((Tags.AREA_OR_POINT, "AREA"))
       case _ =>
     }
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
@@ -6,6 +6,8 @@ import geotrellis.raster.io.geotiff.tags.codes._
 import geotrellis.raster.io.geotiff.reader._
 import geotrellis.raster.io.geotiff.util._
 import CommonPublicValues._
+import ModelTypes._
+import ProjectionTypesMap.UserDefinedProjectionType
 
 import geotrellis.vector.Extent
 
@@ -197,34 +199,34 @@ case class TiffTags(
     BandType(bitsPerSample, sampleFormat)
   }
 
-  def proj4String: Option[String] = try {
-    geoTiffCSTags.getProj4String
-  } catch {
-    case e: Exception => {
-      None
-    }
-  }
-
-  def projectedCoordinateSystem: Int =
-    if(geoTiffTags.geoKeyDirectory.isDefined) {
-      geoTiffCSTags.pcs
-    } else {
-      32767
-    }
+  def proj4String: Option[String] =
+    geoTiffCSTags.flatMap(_.getProj4String)
 
   lazy val crs: CRS = {
-    if (projectedCoordinateSystem != 32767) {
-      CRS.fromName(s"EPSG:${projectedCoordinateSystem}")
-    } else {
+    val fromCode: Option[CRS] =
+      geoTiffCSTags.flatMap { csTags =>
+        csTags.model match {
+          case ModelTypeProjected =>
+            val pcs = csTags.pcs
+            if (pcs != UserDefinedProjectionType)
+              Some(CRS.fromName(s"EPSG:${pcs}"))
+            else
+              None
+          case ModelTypeGeographic =>
+            val gcs = csTags.gcs
+            if (gcs != UserDefinedProjectionType)
+              Some(CRS.fromName(s"EPSG:${gcs}"))
+            else
+              None
+          case _ => None
+        }
+      }
+    fromCode.getOrElse({
       proj4String match {
         case Some(s) => CRS.fromString(s)
         case None => LatLng
       }
-    }
-  }
-
-  def geoKeyDirectory = geoTiffTags.geoKeyDirectory.getOrElse {
-    throw new IllegalAccessException("no geo key directory present")
+    })
   }
 
   private def getRasterBoundaries: Array[Pixel3D] = {
@@ -297,27 +299,25 @@ case class TiffTags(
            math.max(y1, y2))
   }
 
-  def hasPixelArea(): Boolean =
-    (geoKeyDirectory &|->
-      GeoKeyDirectory._configKeys ^|->
-      ConfigKeys._gtRasterType get) match {
-      case Some(UndefinedCPV) => throw new MalformedGeoTiffException(
-        "the raster type must be present."
-      )
-      case Some(UserDefinedCPV) => throw new GeoTiffReaderLimitationException(
-        "this reader doesn't support user defined raster types."
-      )
-      case Some(v) => v == 1
-      case None => true
+  def pixelSampleType(): Option[PixelSampleType] =
+    geoTiffTags.geoKeyDirectory.flatMap { dir =>
+      (dir
+        &|-> GeoKeyDirectory._configKeys
+        ^|-> ConfigKeys._gtRasterType get) match {
+        case Some(v) if v == 1 => Some(PixelIsArea)
+        case Some(v) if v == 2 => Some(PixelIsPoint)
+        case None => None
+      }
     }
 
   def setGDALNoData(input: String) = (this &|-> TiffTags._geoTiffTags
     ^|-> GeoTiffTags._gdalInternalNoData set (parseGDALNoDataString(input)))
 
-  lazy val geoTiffCSTags = GeoTiffCSParser(this)
+  private lazy val geoTiffCSTags: Option[GeoTiffCSParser] =
+    geoTiffTags.geoKeyDirectory.map(GeoTiffCSParser(_))
 
   def tags: Tags = {
-    val (headTags, bandTags) =
+    var (headTags, bandTags) =
       (this &|->
         TiffTags._geoTiffTags ^|->
         GeoTiffTags._metadata get
@@ -355,14 +355,28 @@ case class TiffTags(
           (Map[String, String](), (0 until bandCount).map { i => Map[String, String]() }.toList)
       }
 
-      this &|->
-        TiffTags._metadataTags ^|->
-        MetadataTags._dateTime get match {
-          case Some(dateTime) =>
-            Tags(headTags + (("TIFFTAG_DATETIME", dateTime)), bandTags)
-          case None =>
-            Tags(headTags, bandTags)
-        }
+
+    // Account for special metadata that should be included as tags
+
+    // Date time tag
+    this &|->
+      TiffTags._metadataTags ^|->
+      MetadataTags._dateTime get match {
+        case Some(dateTime) =>
+          headTags = headTags + (("TIFFTAG_DATETIME", dateTime))
+        case None =>
+      }
+
+    // pixel sample type
+    pixelSampleType match {
+      case Some(v) if v == PixelIsPoint =>
+        headTags = headTags + (("AREA_OR_POINT", "POINT"))
+      case Some(v) if v == PixelIsArea =>
+        headTags = headTags + (("AREA_OR_POINT", "AREA"))
+      case _ =>
+    }
+
+    Tags(headTags, bandTags)
   }
 
   private def metadataNodeSeqToMap(ns: NodeSeq): Map[String, String] =

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteBufferExtensions.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteBufferExtensions.scala
@@ -37,7 +37,7 @@ trait ByteBufferExtensions {
       int & 0XFFFFFFFFL
 
     @inline
-    final def getUnsignedShort: Int = 
+    final def getUnsignedShort: Int =
       byteBuffer.getChar.toInt
 
     final def getByteArray(length: Int): Array[Short] = {
@@ -95,6 +95,7 @@ trait ByteBufferExtensions {
       arr
     }
 
+    /** Get these as Longs, since they are unsigned and we might want to deal with values greater than Int.MaxValue */
     final def getIntArray(length: Int, valueOffset: Int): Array[Long] = {
       val arr = Array.ofDim[Long](length)
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -79,7 +79,8 @@ object TiffTagFieldValue {
 
     createNoDataString(geoTiff.cellType) match {
       case Some(noDataString) =>
-        fieldValues += TiffTagFieldValue(GDALInternalNoDataTag, AsciisFieldType, noDataString.length + 1, toBytes(noDataString))
+        val bs = toBytes(noDataString)
+        fieldValues += TiffTagFieldValue(GDALInternalNoDataTag, AsciisFieldType, bs.length, bs)
       case _ => ()
     }
 
@@ -89,7 +90,7 @@ object TiffTagFieldValue {
     fieldValues += TiffTagFieldValue(ModelTiePointsTag, DoublesFieldType, 6, toBytes(Array(0.0, 0.0, 0.0, extent.xmin, extent.ymax, 0.0)))
 
     // GeoKeyDirectory: Tags that describe the CRS
-    val GeoDirectoryTags(shortGeoKeys, doubleGeoKeys) = CoordinateSystemParser.parse(geoTiff.crs)
+    val GeoDirectoryTags(shortGeoKeys, doubleGeoKeys) = CoordinateSystemParser.parse(geoTiff.crs, geoTiff.pixelSampleType)
 
     // Write the short values of the GeoKeyDirectory
     val shortValues = Array.ofDim[Short]( (shortGeoKeys.length + 1) * 4)
@@ -116,8 +117,26 @@ object TiffTagFieldValue {
     // Not written (what goes here?):
     //GeoKeyDirectory ASCII     TagCodes.GeoAsciiParamsTag, TiffFieldType.AsciisFieldType, N = Number of Characters (pipe sparated |), GeoKeyAsciis _
 
-    // GDAL MetaData
-    val metaData = toBytes(new scala.xml.PrettyPrinter(80, 2).format(geoTiff.tags.toXml))
+    // Metadata Tags
+    // Account for special metadata tags, and then write out the rest in XML as the metadata tag
+    val Tags(headerTags, bandTags) = geoTiff.tags
+    var modifiedHeaderTags = headerTags
+    geoTiff.pixelSampleType match {
+      case Some(_) =>
+        // This was captured in the GeoKeys already
+        modifiedHeaderTags -= Tags.AREA_OR_POINT
+      case None =>
+    }
+
+    modifiedHeaderTags.get(Tags.TIFFTAG_DATETIME) match {
+      case Some(dateTime) =>
+        val bs = toBytes(dateTime)
+        fieldValues += TiffTagFieldValue(DateTimeTag, AsciisFieldType, bs.length, bs)
+        modifiedHeaderTags -= Tags.TIFFTAG_DATETIME
+      case None =>
+    }
+
+    val metaData = toBytes(new scala.xml.PrettyPrinter(80, 2).format(Tags(modifiedHeaderTags, geoTiff.tags.bandTags).toXml))
     fieldValues += TiffTagFieldValue(MetadataTag, AsciisFieldType, metaData.length, metaData)
 
     // Tags that are different if it is striped or tiled storage, and a function

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -134,7 +134,13 @@ object TiffTagFieldValue {
           { offsets: Array[Int] => TiffTagFieldValue(TileOffsetsTag, IntsFieldType, offsets.length, toBytes(offsets)) }
         case s: Striped =>
           val rowsPerStrip = imageData.segmentLayout.tileLayout.tileRows
-          fieldValues += TiffTagFieldValue(RowsPerStripTag, IntsFieldType, 1, toBytes(rowsPerStrip))
+          fieldValues += {
+            if(rowsPerStrip < Short.MaxValue) {
+              TiffTagFieldValue(RowsPerStripTag, ShortsFieldType, 1, rowsPerStrip)
+            } else {
+              TiffTagFieldValue(RowsPerStripTag, IntsFieldType, 1, rowsPerStrip)
+            }
+          }
           fieldValues += TiffTagFieldValue(StripByteCountsTag, IntsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
 
           { offsets: Array[Int] => TiffTagFieldValue(StripOffsetsTag, IntsFieldType, offsets.length, toBytes(offsets)) }

--- a/raster/src/main/scala/geotrellis/raster/reproject/ReprojectRasterExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/ReprojectRasterExtent.scala
@@ -26,7 +26,7 @@ object ReprojectRasterExtent {
     val extent = gd.extent
     val (cols, rows) = (extent.width / gd.cellwidth, extent.height / gd.cellheight)
     val PIXEL_STEP = math.min(50.0, math.min(cols, rows)).toInt
-    
+
     // Find the threshold to densify the extent at.
     val xThreshold = (cols / PIXEL_STEP) * gd.cellwidth
     val yThreshold = (rows / PIXEL_STEP) * gd.cellheight

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/package.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/package.scala
@@ -1,0 +1,27 @@
+package geotrellis.spark
+
+package object testkit {
+  implicit class TestJavaSerialization[T](val t: T) {
+    def serializeAndDeserialize(): T = {
+      import java.io.ByteArrayInputStream
+      import java.io.ByteArrayOutputStream
+      import java.io.DataInputStream
+      import java.io.DataOutputStream
+      import java.io.ObjectInputStream
+      import java.io.ObjectOutputStream
+
+      val baos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(baos)
+      oos.writeObject(t)
+      oos.close()
+
+      val b = baos.toByteArray()
+      val bais = new ByteArrayInputStream(b)
+      val ois = new ObjectInputStream(bais)
+
+      val actual = ois.readObject().asInstanceOf[T]
+      ois.close()
+      actual
+    }
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -89,7 +89,6 @@ object TileRDDReproject {
               } else {
                 // Reproject extra cells that are half the buffer size, as to avoid
                 // any missed cells between tiles.
-
                 GridBounds(
                   gridBounds.colMin / 2,
                   gridBounds.rowMin / 2,

--- a/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
@@ -22,7 +22,9 @@ object CutTiles {
     cellType: CellType,
     layoutDefinition: LayoutDefinition,
     resampleMethod: ResampleMethod = NearestNeighbor
-  ): RDD[(K2, V)] =
+  ): RDD[(K2, V)] = {
+    val (tileCols, tileRows) = layoutDefinition.tileLayout.tileDimensions
+
     rdd
       .flatMap { tup =>
         val (inKey, tile) = tup
@@ -37,4 +39,5 @@ object CutTiles {
             (outKey, newTile.merge(mapTransform(outKey), extent, tile))
           }
       }
+  }
 }

--- a/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
@@ -23,14 +23,14 @@ object CutTiles {
     layoutDefinition: LayoutDefinition,
     resampleMethod: ResampleMethod = NearestNeighbor
   ): RDD[(K2, V)] = {
+    val mapTransform = layoutDefinition.mapTransform
     val (tileCols, tileRows) = layoutDefinition.tileLayout.tileDimensions
 
     rdd
       .flatMap { tup =>
         val (inKey, tile) = tup
         val extent = inKey.extent
-        val mapTransform = layoutDefinition.mapTransform
-        val (tileCols, tileRows) = layoutDefinition.tileLayout.tileDimensions
+
         mapTransform(extent)
           .coords
           .map  { spatialComponent =>

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -48,7 +48,7 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
       val d = (extent.ymax - otherExtent.ymin) / extent.height
 
       if(d == math.floor(d)) { (d * layoutRows).toInt - 1 }
-      else { (d * layoutRows).toInt } 
+      else { (d * layoutRows).toInt }
     }
 
     GridBounds(colMin, rowMin, colMax, rowMax)

--- a/spark/src/test/scala/geotrellis/spark/SerializationTests.scala
+++ b/spark/src/test/scala/geotrellis/spark/SerializationTests.scala
@@ -1,0 +1,48 @@
+package geotrellis.spark
+
+import geotrellis.proj4._
+import geotrellis.raster.io.geotiff._
+import geotrellis.spark.testkit._
+import geotrellis.vector._
+import geotrellis.vector.reproject._
+
+import org.apache.hadoop.fs.Path
+import org.scalatest._
+
+class SerializationTests extends FunSuite with Matchers {
+  test("Serializing CRS's") {
+    val crs = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
+    assert(crs == LatLng)
+
+    {
+      val t = Transform(crs, LatLng)
+      val expected = (141.7066666666667, -17.946666666666676)
+      val actual = t(expected._1, expected._2)
+      assert(actual == expected)
+    }
+
+    {
+      val (crs1, crs2) = (crs.serializeAndDeserialize, LatLng.serializeAndDeserialize)
+      assert(crs1 == crs2)
+      val t = Transform(crs1, crs2)
+      val expected = (141.7066666666667, -17.946666666666676)
+      val actual = t(expected._1, expected._2)
+      actual should be (expected)
+    }
+
+    {
+      val t = Transform(LatLng, crs)
+      val expected = (141.7154166666667,-17.52875000000001)
+      val actual = t(expected._1, expected._2)
+      assert(actual == expected)
+    }
+
+    {
+      val t = Transform(LatLng, crs.serializeAndDeserialize)
+      val expected = (141.7154166666667,-17.52875000000001)
+      val actual = t(expected._1, expected._2)
+      assert(actual == expected)
+    }
+
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/ingest/IngestSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/ingest/IngestSpec.scala
@@ -4,22 +4,21 @@ import geotrellis.vector._
 import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.spark.io.hadoop._
-import geotrellis.proj4.LatLng
+import geotrellis.proj4._
 
 import org.apache.hadoop.fs.Path
 import org.scalatest._
 
-/** Actually failes due to LatLon issue: https://github.com/geotrellis/geotrellis/issues/1341 */
-/*class IngestSpec extends FunSpec
+class IngestSpec extends FunSpec
   with Matchers
   with TestEnvironment {
   describe("Ingest") {
-    it("should ingest GeoTiff"){
+    it("should ingest GeoTiff") {
       val source = sc.hadoopGeoTiffRDD(new Path(inputHome, "all-ones.tif"))
-      Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme(LatLng, 512)){ (rdd, zoom) =>
-        zoom should be (11)
-        rdd.filter(!_._2.isNoDataTile).count should be (18)
+      Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme(LatLng, 512)) { (rdd, zoom) =>
+        zoom should be (10)
+        rdd.filter(!_._2.isNoDataTile).count should be (8)
       }
     }
   }
-}*/
+}

--- a/spark/src/test/scala/geotrellis/spark/tiling/ZoomedLayoutSchemeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/tiling/ZoomedLayoutSchemeSpec.scala
@@ -33,7 +33,7 @@ class ZoomedLayoutSchemeSpec extends FunSpec with Matchers {
       19 -> 0.298       // 1:1,000
     )
 
-  describe("ZoomedLayoutScheme") { 
+  describe("ZoomedLayoutScheme") {
     it("Cuts up the world in two for lowest zoom level") {
       val LayoutLevel(_, tileLayout) = ZoomedLayoutScheme(LatLng).levelForZoom(LatLng.worldExtent, 1)
       tileLayout.layoutCols should be (2)
@@ -90,6 +90,14 @@ class ZoomedLayoutSchemeSpec extends FunSpec with Matchers {
         val z = wmScheme.zoom(0, 0, cellSize)
         z should be (zoom + 1)
       }
+    }
+
+    it("can handle extremely south coordinates") {
+      val (lat1, lon1) = (-81.572438, -148.041443)
+      val (lat2, lon2) = (-81.572543, -148.009213)
+      val scheme = ZoomedLayoutScheme(LatLng, 256)
+      val z = scheme.zoom(lon1, lat1, CellSize(lon2 - lon1, lat2 - lat1))
+      z should be (6)
     }
   }
 }

--- a/vector/src/main/scala/geotrellis/vector/Extent.scala
+++ b/vector/src/main/scala/geotrellis/vector/Extent.scala
@@ -47,53 +47,39 @@ case class Extent(xmin: Double, ymin: Double, xmax: Double, ymax: Double) {
   if (xmin > xmax) { throw ExtentRangeError(s"Invalid Extent: xmin must be less than xmax (xmin=$xmin, xmax=$xmax)") }
   if (ymin > ymax) { throw ExtentRangeError(s"Invalid Extent: ymin must be less than ymax (ymin=$ymin, ymax=$ymax)") }
 
-  def jtsGeom =
-    factory.createPolygon(
-      factory.createLinearRing(
-        Array(
-          new jts.Coordinate(xmin, ymax),
-          new jts.Coordinate(xmax, ymax),
-          new jts.Coordinate(xmax, ymin),
-          new jts.Coordinate(xmin, ymin),
-          new jts.Coordinate(xmin, ymax)
-        )
-      ),
-      null
-    )
-
   def jtsEnvelope: com.vividsolutions.jts.geom.Envelope =
     new com.vividsolutions.jts.geom.Envelope(xmin, xmax, ymin, ymax)
 
+  val width: Double = xmax - xmin
+  val height: Double = ymax - ymin
 
-  val width = xmax - xmin
-  val height = ymax - ymin
-
-  def min = Point(xmin, ymin)
-  def max = Point(xmax, ymax)
+  def min: Point = Point(xmin, ymin)
+  def max: Point = Point(xmax, ymax)
 
   /**
    * The SW corner (xmin, ymin) as a Point.
    */
-  def southWest = Point(xmin, ymin)
+  def southWest: Point = Point(xmin, ymin)
 
   /**
    * The SE corner (xmax, ymin) as a Point.
    */
-  def southEast = Point(xmax, ymin)
+  def southEast: Point = Point(xmax, ymin)
 
   /**
    * The NE corner (xmax, ymax) as a Point.
    */
-  def northEast = Point(xmax, ymax)
+  def northEast: Point = Point(xmax, ymax)
 
   /**
    * The NW corner (xmin, ymax) as a Point.
    */
-  def northWest = Point(xmin, ymax)
+  def northWest: Point = Point(xmin, ymax)
 
-  def area = width * height
-  def minExtent = if(width < height) width else height
-  def maxExtent = if(width > height) width else height
+  def area: Double = width * height
+  def minExtent: Double = if(width < height) width else height
+  def maxExtent: Double = if(width > height) width else height
+  def isEmpty: Boolean = area == 0
 
   def center: Point =
     Point((xmin + xmax) / 2.0, (ymin + ymax) / 2.0)

--- a/vector/src/main/scala/geotrellis/vector/reproject/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/reproject/package.scala
@@ -35,7 +35,7 @@ package object reproject {
     def lineFeature[D](lf: LineFeature[D], transform: Transform): LineFeature[D] =
       LineFeature(apply(lf.geom, transform), lf.data)
 
-    def apply(p: Polygon, src: CRS, dest: CRS): Polygon = 
+    def apply(p: Polygon, src: CRS, dest: CRS): Polygon =
       apply(p, Transform(src, dest))
 
     def apply(p: Polygon, transform: Transform): Polygon =
@@ -89,7 +89,7 @@ package object reproject {
     def multiPolygonFeature[D](mpf: MultiPolygonFeature[D], transform: Transform): MultiPolygonFeature[D] =
       MultiPolygonFeature(apply(mpf.geom, transform: Transform), mpf.data)
 
-    def apply(gc: GeometryCollection, src: CRS, dest: CRS): GeometryCollection = 
+    def apply(gc: GeometryCollection, src: CRS, dest: CRS): GeometryCollection =
       GeometryCollection(
         gc.points.map{ apply(_, src, dest) },
         gc.lines.map{ apply(_, src, dest) },
@@ -148,93 +148,93 @@ package object reproject {
       }
   }
 
-  implicit class ReprojectTuple(t: (Double, Double)) { 
-    def reproject(src: CRS, dest: CRS): (Double, Double) = Reproject(t, src, dest) 
-    def reproject(transform: Transform): (Double, Double) = Reproject(t, transform) 
+  implicit class ReprojectTuple(t: (Double, Double)) {
+    def reproject(src: CRS, dest: CRS): (Double, Double) = Reproject(t, src, dest)
+    def reproject(transform: Transform): (Double, Double) = Reproject(t, transform)
   }
 
-  implicit class ReprojectPoint(p: Point) { 
-    def reproject(src: CRS, dest: CRS): Point = Reproject(p, src, dest) 
-    def reproject(transform: Transform): Point = Reproject(p, transform) 
+  implicit class ReprojectPoint(p: Point) {
+    def reproject(src: CRS, dest: CRS): Point = Reproject(p, src, dest)
+    def reproject(transform: Transform): Point = Reproject(p, transform)
   }
 
-  implicit class ReprojectPointFeature[D](pf: PointFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): PointFeature[D] = Reproject.pointFeature(pf, src, dest) 
-    def reproject(transform: Transform): PointFeature[D] = Reproject.pointFeature(pf, transform) 
+  implicit class ReprojectPointFeature[D](pf: PointFeature[D]) {
+    def reproject(src: CRS, dest: CRS): PointFeature[D] = Reproject.pointFeature(pf, src, dest)
+    def reproject(transform: Transform): PointFeature[D] = Reproject.pointFeature(pf, transform)
   }
 
-  implicit class ReprojectLine(l: Line) { 
-    def reproject(src: CRS, dest: CRS): Line = Reproject(l, src, dest) 
-    def reproject(transform: Transform): Line = Reproject(l, transform) 
+  implicit class ReprojectLine(l: Line) {
+    def reproject(src: CRS, dest: CRS): Line = Reproject(l, src, dest)
+    def reproject(transform: Transform): Line = Reproject(l, transform)
   }
 
-  implicit class ReprojectLineFeature[D](lf: LineFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): LineFeature[D] = Reproject.lineFeature(lf, src, dest) 
-    def reproject(transform: Transform): LineFeature[D] = Reproject.lineFeature(lf, transform) 
+  implicit class ReprojectLineFeature[D](lf: LineFeature[D]) {
+    def reproject(src: CRS, dest: CRS): LineFeature[D] = Reproject.lineFeature(lf, src, dest)
+    def reproject(transform: Transform): LineFeature[D] = Reproject.lineFeature(lf, transform)
   }
 
-  implicit class ReprojectPolygon(p: Polygon) { 
+  implicit class ReprojectPolygon(p: Polygon) {
     def reproject(src: CRS, dest: CRS): Polygon = Reproject(p, src, dest)
     def reproject(transform: Transform): Polygon = Reproject(p, transform)
   }
 
-  implicit class ReprojectExtent(e: Extent) { 
-    def reproject(src: CRS, dest: CRS): Extent = Reproject(e, src, dest) 
+  implicit class ReprojectExtent(e: Extent) {
+    def reproject(src: CRS, dest: CRS): Extent = Reproject(e, src, dest)
     def reproject(transform: Transform): Extent = Reproject(e, transform).envelope
   }
 
-  implicit class ReprojectPolygonFeature[D](pf: PolygonFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): PolygonFeature[D] = Reproject.polygonFeature(pf, src, dest) 
-    def reproject(transform: Transform): PolygonFeature[D] = Reproject.polygonFeature(pf, transform) 
+  implicit class ReprojectPolygonFeature[D](pf: PolygonFeature[D]) {
+    def reproject(src: CRS, dest: CRS): PolygonFeature[D] = Reproject.polygonFeature(pf, src, dest)
+    def reproject(transform: Transform): PolygonFeature[D] = Reproject.polygonFeature(pf, transform)
   }
 
-  implicit class ReprojectMultiPoint(mp: MultiPoint) { 
-    def reproject(src: CRS, dest: CRS): MultiPoint = Reproject(mp, src, dest) 
-    def reproject(transform: Transform): MultiPoint = Reproject(mp, transform) 
+  implicit class ReprojectMultiPoint(mp: MultiPoint) {
+    def reproject(src: CRS, dest: CRS): MultiPoint = Reproject(mp, src, dest)
+    def reproject(transform: Transform): MultiPoint = Reproject(mp, transform)
   }
 
-  implicit class ReprojectMultiPointFeature[D](mpf: MultiPointFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): MultiPointFeature[D] = Reproject.multiPointFeature(mpf, src, dest) 
+  implicit class ReprojectMultiPointFeature[D](mpf: MultiPointFeature[D]) {
+    def reproject(src: CRS, dest: CRS): MultiPointFeature[D] = Reproject.multiPointFeature(mpf, src, dest)
     def reproject(transform: Transform): MultiPointFeature[D] = Reproject.multiPointFeature(mpf, transform)
   }
 
-  implicit class ReprojectMutliLine(ml: MultiLine) { 
-    def reproject(src: CRS, dest: CRS): MultiLine = Reproject(ml, src, dest) 
-    def reproject(transform: Transform): MultiLine = Reproject(ml, transform) 
+  implicit class ReprojectMutliLine(ml: MultiLine) {
+    def reproject(src: CRS, dest: CRS): MultiLine = Reproject(ml, src, dest)
+    def reproject(transform: Transform): MultiLine = Reproject(ml, transform)
   }
 
-  implicit class ReprojectMutliLineFeature[D](mlf: MultiLineFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): MultiLineFeature[D] = Reproject.multiLineFeature(mlf, src, dest) 
-    def reproject(transform: Transform): MultiLineFeature[D] = Reproject.multiLineFeature(mlf, transform) 
+  implicit class ReprojectMutliLineFeature[D](mlf: MultiLineFeature[D]) {
+    def reproject(src: CRS, dest: CRS): MultiLineFeature[D] = Reproject.multiLineFeature(mlf, src, dest)
+    def reproject(transform: Transform): MultiLineFeature[D] = Reproject.multiLineFeature(mlf, transform)
   }
 
-  implicit class ReprojectMutliPolygon(mp: MultiPolygon) { 
-    def reproject(src: CRS, dest: CRS): MultiPolygon = Reproject(mp, src, dest) 
-    def reproject(transform: Transform): MultiPolygon = Reproject(mp, transform) 
+  implicit class ReprojectMutliPolygon(mp: MultiPolygon) {
+    def reproject(src: CRS, dest: CRS): MultiPolygon = Reproject(mp, src, dest)
+    def reproject(transform: Transform): MultiPolygon = Reproject(mp, transform)
   }
 
-  implicit class ReprojectMutliPolygonFeature[D](mpf: MultiPolygonFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): MultiPolygonFeature[D] = Reproject.multiPolygonFeature(mpf, src, dest) 
+  implicit class ReprojectMutliPolygonFeature[D](mpf: MultiPolygonFeature[D]) {
+    def reproject(src: CRS, dest: CRS): MultiPolygonFeature[D] = Reproject.multiPolygonFeature(mpf, src, dest)
     def reproject(transform: Transform): MultiPolygonFeature[D] = Reproject.multiPolygonFeature(mpf, transform)
   }
 
-  implicit class ReprojectGeometryCollection(gc: GeometryCollection) { 
-    def reproject(src: CRS, dest: CRS): GeometryCollection = Reproject(gc, src, dest) 
-    def reproject(transform: Transform): GeometryCollection = Reproject(gc, transform) 
+  implicit class ReprojectGeometryCollection(gc: GeometryCollection) {
+    def reproject(src: CRS, dest: CRS): GeometryCollection = Reproject(gc, src, dest)
+    def reproject(transform: Transform): GeometryCollection = Reproject(gc, transform)
   }
 
-  implicit class ReprojectGeometryCollectionFeature[D](gcf: GeometryCollectionFeature[D]) { 
-    def reproject(src: CRS, dest: CRS): GeometryCollectionFeature[D] = Reproject.geometryCollectionFeature(gcf, src, dest) 
+  implicit class ReprojectGeometryCollectionFeature[D](gcf: GeometryCollectionFeature[D]) {
+    def reproject(src: CRS, dest: CRS): GeometryCollectionFeature[D] = Reproject.geometryCollectionFeature(gcf, src, dest)
     def reproject(transform: Transform): GeometryCollectionFeature[D] = Reproject.geometryCollectionFeature(gcf, transform)
   }
 
-  implicit class ReprojectGeometry(g: Geometry) { 
-    def reproject(src: CRS, dest: CRS): Geometry = Reproject(g, src, dest) 
-    def reproject(transform: Transform): Geometry = Reproject(g, transform) 
+  implicit class ReprojectGeometry(g: Geometry) {
+    def reproject(src: CRS, dest: CRS): Geometry = Reproject(g, src, dest)
+    def reproject(transform: Transform): Geometry = Reproject(g, transform)
   }
 
-  implicit class ReprojectFeature[D](f: Feature[Geometry, D]) { 
-    def reproject(src: CRS, dest: CRS): Feature[Geometry, D] = Reproject.geometryFeature(f, src, dest) 
-    def reproject(transform: Transform): Feature[Geometry, D] = Reproject.geometryFeature(f, transform) 
+  implicit class ReprojectFeature[D](f: Feature[Geometry, D]) {
+    def reproject(src: CRS, dest: CRS): Feature[Geometry, D] = Reproject.geometryFeature(f, src, dest)
+    def reproject(transform: Transform): Feature[Geometry, D] = Reproject.geometryFeature(f, transform)
   }
 }


### PR DESCRIPTION
- GeoTiff tag reader was not reading the RowsPerStrip tag correctly when that tag was written as an Int instead of a Short
- GeoTiff reader was not reading Coordinate Systems with ModelType = Geographic correctly
- Projection used reference equality to compare units to Units.DEGREES, which doesn't work with serialization. Changed to structural equality.
- Added support for writing and reading AREA_OR_PIXEL and TIFFTAG_DATETIME metadata tags
- Fixed writing of Geographic CRSes to GeoTiff.

Fixes #1341