### PR TITLE
Remove references to UIntCells

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/CellType.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellType.scala
@@ -93,11 +93,6 @@ sealed trait IntCells extends DataType { self: CellType =>
   val isFloatingPoint: Boolean = false
   val name = "int32"
 }
-sealed trait UIntCells extends DataType { self: CellType =>
-  val bits: Int = 32
-  val isFloatingPoint: Boolean = true
-  val name = "uint32"
-}
 sealed trait FloatCells extends DataType { self: CellType =>
   val bits: Int = 32
   val isFloatingPoint: Boolean = true
@@ -159,13 +154,6 @@ case object IntConstantNoDataCellType
     extends IntCells with ConstantNoData
 case class IntUserDefinedNoDataCellType(noDataValue: Int)
     extends IntCells with UserDefinedNoData[Int]
-
-case object UIntCellType
-    extends UIntCells with NoNoData
-case object UIntConstantNoDataCellType
-    extends UIntCells with ConstantNoData
-case class UIntUserDefinedNoDataCellType(noDataValue: Int)
-    extends UIntCells with UserDefinedNoData[Int]
 
 case object FloatCellType
     extends FloatCells with NoNoData
@@ -233,11 +221,6 @@ object CellType {
         throw new IllegalArgumentException(s"Cell type $name is not supported")
       }
       IntUserDefinedNoDataCellType(ndVal.toInt)
-    case ct if ct.startsWith("uint32ud") =>
-      val ndVal = new Regex("\\d+$").findFirstIn(ct).getOrElse {
-        throw new IllegalArgumentException(s"Cell type $name is not supported")
-      }
-      UIntUserDefinedNoDataCellType(ndVal.toInt)
     case ct if ct.startsWith("float32ud") =>
       val ndVal = new Regex("\\d*.?\\d+$").findFirstIn(ct).getOrElse {
         throw new IllegalArgumentException(s"Cell type $name is not supported")

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
@@ -15,33 +15,42 @@ object GeoTiffTile {
     decompressor: Decompressor,
     segmentLayout: GeoTiffSegmentLayout,
     compression: Compression,
-    cellType: CellType
+    cellType: CellType,
+    bandType: Option[BandType] = None
   ): GeoTiffTile = {
-    cellType match {
-      case ct: BitCells =>
-        new BitGeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
-      // Bytes
-      case ct: ByteCells =>
-        new ByteGeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
-      // UBytes
-      case ct: UByteCells =>
-        new UByteGeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
-      // Shorts
-      case ct: ShortCells =>
-        new Int16GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
-      // UShorts
-      case ct: UShortCells =>
-        new UInt16GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
-      case ct: IntCells =>
-        new Int32GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
-      case ct: UIntCells =>
-        new UInt32GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
-      case ct: FloatCells =>
-        new Float32GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
-      case ct: DoubleCells =>
-        new Float64GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+    bandType match {
+      case Some(UInt32BandType) =>
+        cellType match {
+          case ct: FloatCells =>
+            new UInt32GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+          case _ =>
+            throw new IllegalArgumentException("UInt32BandType should always resolve to Float celltype")
+        }
+      case _ =>
+        cellType match {
+          case ct: BitCells =>
+            new BitGeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+          // Bytes
+          case ct: ByteCells =>
+            new ByteGeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+          // UBytes
+          case ct: UByteCells =>
+            new UByteGeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+          // Shorts
+          case ct: ShortCells =>
+            new Int16GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+          // UShorts
+          case ct: UShortCells =>
+            new UInt16GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+          case ct: IntCells =>
+            new Int32GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+          case ct: FloatCells =>
+            new Float32GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+          case ct: DoubleCells =>
+            new Float64GeoTiffTile(compressedBytes, decompressor, segmentLayout, compression, ct)
+        }
+      }
     }
-  }
 
   /** Convert a tile to a GeoTiffTile. Defaults to Striped GeoTIFF format. */
   def apply(tile: Tile): GeoTiffTile =

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffMultibandTile.scala
@@ -12,7 +12,7 @@ class UInt32GeoTiffMultibandTile(
   compression: Compression,
   bandCount: Int,
   hasPixelInterleave: Boolean,
-  val cellType: UIntCells with NoDataHandling
+  val cellType: FloatCells with NoDataHandling
 ) extends GeoTiffMultibandTile(compressedBytes, decompressor, segmentLayout, compression, bandCount, hasPixelInterleave)
     with UInt32GeoTiffSegmentCollection {
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffTile.scala
@@ -9,7 +9,7 @@ class UInt32GeoTiffTile(
   val decompressor: Decompressor,
   segmentLayout: GeoTiffSegmentLayout,
   compression: Compression,
-  val cellType: UIntCells with NoDataHandling
+  val cellType: FloatCells with NoDataHandling
 ) extends GeoTiffTile(segmentLayout, compression) with UInt32GeoTiffSegmentCollection {
   def mutable: MutableArrayTile = {
     val arr = Array.ofDim[Float](cols * rows)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
@@ -73,7 +73,8 @@ object GeoTiffReader {
           info.decompressor,
           info.segmentLayout,
           info.compression,
-          info.cellType
+          info.cellType,
+          Some(info.bandType)
         )
       } else {
         GeoTiffMultibandTile(
@@ -83,7 +84,8 @@ object GeoTiffReader {
           info.compression,
           info.bandCount,
           info.hasPixelInterleave,
-          info.cellType
+          info.cellType,
+          Some(info.bandType)
         ).band(0)
       }
 
@@ -115,7 +117,8 @@ object GeoTiffReader {
         info.compression,
         info.bandCount,
         info.hasPixelInterleave,
-        info.cellType
+        info.cellType,
+        Some(info.bandType)
       )
 
     new MultibandGeoTiff(if(decompress) geoTiffTile.toArrayTile else geoTiffTile, info.extent, info.crs, info.tags, info.options)
@@ -175,11 +178,11 @@ object GeoTiffReader {
         IntCellType
       // UInt32
       case (UInt32BandType, Some(nd)) if (nd.toLong > 0L && nd.toLong <= 4294967295L) =>
-        UIntUserDefinedNoDataCellType(nd.toInt)
+        FloatUserDefinedNoDataCellType(nd.toFloat)
       case (UInt32BandType, Some(nd)) if (nd.toLong == 0L) =>
-        IntConstantNoDataCellType
+        FloatConstantNoDataCellType
       case (UInt32BandType, _) =>
-        UIntCellType
+        FloatCellType
       // Float32
       case (Float32BandType, Some(nd)) if (isData(nd) & Float.MinValue.toDouble <= nd & Float.MaxValue.toDouble >= nd) =>
         FloatUserDefinedNoDataCellType(nd.toFloat)

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -31,14 +31,6 @@ package object raster
   type SinglebandRaster = Raster[Tile]
   type MultibandRaster = Raster[MultibandTile]
 
-  // Implicit conversion for unsigned integer celltypes; they are represented as 32bit floats
-  implicit def unsignedIntIsFloat(uintCellType: UIntCells with NoDataHandling) =
-    uintCellType match {
-      case UIntCellType => FloatCellType
-      case UIntConstantNoDataCellType => FloatConstantNoDataCellType
-      case UIntUserDefinedNoDataCellType(nd) => FloatUserDefinedNoDataCellType(nd)
-    }
-
   // Implicit method extension for core types
 
   implicit class withRasterExtentRasterizeMethods(val self: RasterExtent) extends MethodExtensions[RasterExtent]


### PR DESCRIPTION
This PR removes references to UIntCells at a slight cost to elegance of code in GeoTiffReader and GeoTiffTile/GeoTiffMultibandTile