### PR TITLE
Fix avro field constructor compatibility

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/ingest/Pyramid.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/Pyramid.scala
@@ -53,7 +53,7 @@ object Pyramid extends Logging {
           val GridBounds(colMin, rowMin, colMax, rowMax ) = mp(sourceKeyBoundsAsExtent)
           KeyBounds(
             kb.minKey.setComponent(SpatialKey(colMin, rowMin)),
-            kb.minKey.setComponent(SpatialKey(colMax, rowMax)))
+            kb.maxKey.setComponent(SpatialKey(colMax, rowMax)))
       }
 
     val nextMetadata =

--- a/spark/src/main/scala/geotrellis/spark/io/kryo/KryoRegistrator.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/kryo/KryoRegistrator.scala
@@ -209,7 +209,7 @@ class KryoRegistrator extends SparkKryoRegistrator {
     kryo.register(scala.None.getClass)
 
     /* Special Handling: Avro */
-    kryo.register(new Field("a", Schema.create(Type.NULL), null, null: Object).order.getClass)
+    kryo.register(new Field("a", Schema.create(Type.NULL), null, null).order.getClass)
     classOf[org.apache.avro.Schema]
       .getDeclaredClasses
       .foreach({ c => kryo.register(c) })


### PR DESCRIPTION
Hadoop 2.6.x and 2.7.x depend on `avro 1.7.4`. We have newer `1.8.0` version and we use new, constructor function https://github.com/geotrellis/geotrellis/blob/master/spark/src/main/scala/geotrellis/spark/io/kryo/KryoRegistrator.scala#L212 which is available only in `avro 1.8.0`. That may cause a problem during ingest which looks like that: 

```
Exception in thread "main" java.lang.NoSuchMethodError: org.apache.avro.Schema$Field.<init>(Ljava/lang/String;Lorg/apache/avro/Schema;Ljava/lang/String;Ljava/lang/Object;)V
	at geotrellis.spark.io.kryo.KryoRegistrator.registerClasses(KryoRegistrator.scala:212)
```

Due to tested compatibility we can use the old constructor.