### PR TITLE
Remove avro schema from Kryo registration.

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/kryo/KryoRegistrator.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/kryo/KryoRegistrator.scala
@@ -18,9 +18,6 @@ package geotrellis.spark.io.kryo
 
 import org.apache.spark.serializer.{ KryoRegistrator => SparkKryoRegistrator }
 
-import org.apache.avro.Schema
-import org.apache.avro.Schema.{Field, Type}
-
 import com.esotericsoftware.kryo.Kryo
 import de.javakaffee.kryoserializers._
 
@@ -207,12 +204,6 @@ class KryoRegistrator extends SparkKryoRegistrator {
     kryo.register(scala.math.Ordering.Int.getClass)
     kryo.register(scala.math.Ordering.Long.getClass)
     kryo.register(scala.None.getClass)
-
-    /* Special Handling: Avro */
-    kryo.register(new Field("a", Schema.create(Type.NULL), null, null).order.getClass)
-    classOf[org.apache.avro.Schema]
-      .getDeclaredClasses
-      .foreach({ c => kryo.register(c) })
 
     UnmodifiableCollectionsSerializer.registerSerializers( kryo )
     SynchronizedCollectionsSerializer.registerSerializers( kryo )

--- a/spark/src/test/scala/geotrellis/spark/TestRegistrator.scala
+++ b/spark/src/test/scala/geotrellis/spark/TestRegistrator.scala
@@ -2,6 +2,8 @@ package geotrellis.spark
 
 import geotrellis.spark.io.kryo.{ KryoRegistrator => NormalKryoRegistrator }
 
+import org.apache.avro.Schema
+import org.apache.avro.Schema.{Field, Type}
 import com.esotericsoftware.kryo.Kryo
 
 import scala.util.Properties
@@ -32,6 +34,12 @@ class TestRegistrator extends NormalKryoRegistrator {
       kryo.register(classOf[scala.math.Ordering$$anon$9])
       kryo.register(classOf[scala.math.Ordering$$anonfun$by$1])
       kryo.register(classOf[scala.reflect.ClassTag$$anon$1])
+
+    /* Special Handling: Avro */
+      kryo.register(new Field("a", Schema.create(Type.NULL), null, null: Object).order.getClass)
+    classOf[org.apache.avro.Schema]
+      .getDeclaredClasses
+      .foreach({ c => kryo.register(c) })
 
       kryo.setRegistrationRequired(true)
     }


### PR DESCRIPTION
We don't have control over the avro version, so the registration process can cause conflicts. See gitter chat below: 

pomadchin 11:37
@lossyrob you want to remove it form registration? now we have to add these lines manually on the client side? hm

lossyrob 11:42
you don’t have to add them
it just means that the schema will be encoded with a string to identify the class
which causes a little bit of bloat
for serialization
but if a client wants to solve that, then yeah the would have to register the schema themselves with Kryo
which makes sense, because it’s a client side dependency
if we don’t have control over the Avro they are using, then we shouldn’t register it

pomadchin 11:43


lossyrob 11:43
unless we explicitly state, “this is the avro version you have to use"
but then that’s a bit out of their control becasue taht is deteremined by the hadoop version
so it’s a bit of dependency hell