### PR TITLE
Add ability to handle fallback colors on indexed pngs

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/render/PngRenderMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/PngRenderMethods.scala
@@ -21,7 +21,7 @@ trait PngRenderMethods extends MethodExtensions[Tile] {
     new PngEncoder(Settings(RgbaPngEncoding, PaethFilter)).writeByteArray(self)
 
   def renderPng(colorMap: ColorMap): Png = {
-    val colorEncoding = PngColorEncoding(colorMap.colors, colorMap.options.noDataColor)
+    val colorEncoding = PngColorEncoding(colorMap.colors, colorMap.options.noDataColor, colorMap.options.fallbackColor)
     val convertedColorMap = colorEncoding.convertColorMap(colorMap)
     renderPng(colorEncoding, convertedColorMap)
   }

--- a/raster/src/main/scala/geotrellis/raster/render/png/PngColorEncoding.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/png/PngColorEncoding.scala
@@ -35,7 +35,7 @@ case class RgbPngEncoding(transparent: Int) extends PngColorEncoding(2, 3) {
 // indexed color, using separate rgb and alpha channels
 case class IndexedPngEncoding(rgbs: Array[Int], as: Array[Int]) extends PngColorEncoding(3, 1) {
  def convertColorMap(colorMap: ColorMap): ColorMap =
-   colorMap.mapColorsToIndex().withNoDataColor(255)
+   colorMap.mapColorsToIndex().withNoDataColor(255).withFallbackColor(254)
 }
 
 // greyscale and color rasters with an alpha byte
@@ -50,13 +50,16 @@ case object RgbaPngEncoding extends PngColorEncoding(6, 4) {
 }
 
 object PngColorEncoding {
-  def apply(colors: Vector[Int], noDataColor: Int): PngColorEncoding = {
+  def apply(colors: Vector[Int], noDataColor: Int, fallbackColor: Int): PngColorEncoding = {
     val len = colors.length
-    if(len <= 256) {
-      val indices = (0 until len).toArray
+
+    // indexed PNGs can have up to 254 mapped colors (to leave room for nodata and fallback)
+    if(len <= 254) {
+      // PNG header lookup array
       val rgbs = new Array[Int](256)
       val as = new Array[Int](256)
 
+      // Produce the array to be stored in the PNG header for color lookup
       var i = 0
       while (i < len) {
         val c = colors(i)
@@ -65,6 +68,11 @@ object PngColorEncoding {
         i += 1
       }
 
+      // Fallback index
+      rgbs(254) = fallbackColor.toARGB
+      as(254) = fallbackColor.alpha
+
+      // NoData index
       rgbs(255) = noDataColor.toARGB
       as(255) = noDataColor.alpha
       IndexedPngEncoding(rgbs, as)
@@ -78,6 +86,10 @@ object PngColorEncoding {
         grey &&= c.isGrey
         i += 1
       }
+      opaque &&= fallbackColor.isOpaque
+      grey &&= fallbackColor.isGrey
+      opaque &&= noDataColor.isOpaque
+      grey &&= noDataColor.isGrey
 
       if (grey && opaque) {
         GreyPngEncoding(noDataColor.int)


### PR DESCRIPTION
I noticed that fallback colors were being handled improperly in indexed PNGs. Logic was added to handle those cases and tests constructed to ensure that both nodata and fallback cases are handled appropriately.