### PR TITLE
Fix saveToS3 path template parsing 

### DIFF
--- a/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3.scala
@@ -16,7 +16,7 @@ import scalaz.stream._
 import scalaz.concurrent.Task
 
 
-object SaveToS3Methods {
+object SaveToS3 {
   /**
     * @param id           A Layer ID
     * @param pathTemplate The template used to convert a Layer ID and a SpatialKey into an S3 URI
@@ -45,7 +45,7 @@ object SaveToS3Methods {
   ): Unit = {
     val keyToPrefix: K => (String, String) = key => {
       val uri = new URI(keyToUri(key))
-      require(uri.getScheme == "s3", s"SaveToS3Methods only supports s3 scheme: $uri")
+      require(uri.getScheme == "s3", s"SaveToS3 only supports s3 scheme: $uri")
       val bucket = uri.getAuthority
       val prefix = uri.getPath.substring(1) // drop the leading / from the prefix
       (bucket, prefix)
@@ -88,15 +88,5 @@ object SaveToS3Methods {
       results.run.unsafePerformSync
       pool.shutdown()
     }
-  }
-}
-
-class SaveToS3Methods[K](rdd: RDD[(K, Array[Byte])]) {
-  /**
-    * @param keyToPath A function from K (a key) to an S3 URI
-    * @param s3Client  An S3 Client (real or mock) into-which to save the data
-    */
-  def saveToS3(keyToPath: K => String): Unit = {
-    SaveToS3Methods(keyToPath, rdd, { () => S3Client.default })
   }
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3.scala
@@ -40,9 +40,8 @@ object SaveToS3 {
     */
   def apply[K](
     rdd: RDD[(K, Array[Byte])],
+    keyToUri: K => String,
     s3Maker: () => S3Client = () => S3Client.default
-  )(
-    keyToUri: K => String
   ): Unit = {
     val keyToPrefix: K => (String, String) = key => {
       val uri = new URI(keyToUri(key))

--- a/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3Methods.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3Methods.scala
@@ -10,9 +10,8 @@ class SaveToS3Methods[K](val self: RDD[(K, Array[Byte])]) extends MethodExtensio
   /**
     * Saves each RDD value to an S3 key.
     *
-    * @param keyToPath A function from K (a key) to an S3 URI
+    * @param keyToUri A function from K (a key) to an S3 URI
     */
-  def saveToS3(keyToPath: K => String): Unit = {
-    SaveToS3(keyToPath, self, { () => S3Client.default })
-  }
+  def saveToS3(keyToUri: K => String): Unit =
+    SaveToS3(self)(keyToUri)
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3Methods.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3Methods.scala
@@ -1,0 +1,18 @@
+package geotrellis.spark.io.s3
+
+import geotrellis.util.MethodExtensions
+
+import org.apache.spark.rdd.RDD
+
+
+class SaveToS3Methods[K](val self: RDD[(K, Array[Byte])]) extends MethodExtensions[RDD[(K, Array[Byte])]] {
+
+  /**
+    * Saves each RDD value to an S3 key.
+    *
+    * @param keyToPath A function from K (a key) to an S3 URI
+    */
+  def saveToS3(keyToPath: K => String): Unit = {
+    SaveToS3(keyToPath, self, { () => S3Client.default })
+  }
+}

--- a/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3Methods.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3Methods.scala
@@ -13,5 +13,5 @@ class SaveToS3Methods[K](val self: RDD[(K, Array[Byte])]) extends MethodExtensio
     * @param keyToUri A function from K (a key) to an S3 URI
     */
   def saveToS3(keyToUri: K => String): Unit =
-    SaveToS3(self)(keyToUri)
+    SaveToS3(self, keyToUri)
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/package.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/package.scala
@@ -7,14 +7,5 @@ package object s3 {
   def makePath(chunks: String*) =
     chunks.filter(_.nonEmpty).mkString("/")
 
-  implicit class withSaveToS3Methods[K](rdd: RDD[(K, Array[Byte])]) {
-    /**
-      * Saves each RDD value to an S3 key.
-      *
-      * @param keyToPath A function from K (a key) to an S3 URI
-      */
-    def saveToS3(keyToPath: K => String): Unit = {
-      SaveToS3(keyToPath, rdd, { () => S3Client.default })
-    }
-  }
+  implicit class withSaveToS3Methods[K](rdd: RDD[(K, Array[Byte])]) extends SaveToS3Methods(rdd)
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/package.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/package.scala
@@ -7,5 +7,14 @@ package object s3 {
   def makePath(chunks: String*) =
     chunks.filter(_.nonEmpty).mkString("/")
 
-  implicit class withSaveToS3Methods[K](rdd: RDD[(K, Array[Byte])]) extends SaveToS3Methods[K](rdd)
+  implicit class withSaveToS3Methods[K](rdd: RDD[(K, Array[Byte])]) {
+    /**
+      * Saves each RDD value to an S3 key.
+      *
+      * @param keyToPath A function from K (a key) to an S3 URI
+      */
+    def saveToS3(keyToPath: K => String): Unit = {
+      SaveToS3(keyToPath, rdd, { () => S3Client.default })
+    }
+  }
 }

--- a/s3/src/test/scala/geotrellis/spark/io/s3/S3SaveImagesSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/S3SaveImagesSpec.scala
@@ -6,7 +6,7 @@ import geotrellis.spark.TestEnvironment
 import geotrellis.spark.render._
 import geotrellis.spark.testfiles.TestFiles
 import geotrellis.spark.io.s3._
-import geotrellis.spark.io.s3.SaveToS3Methods
+import geotrellis.spark.io.s3.SaveToS3
 
 import org.scalatest._
 
@@ -20,11 +20,11 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
       val template = "s3://mock-bucket/catalog/{name}/{z}/{x}/{y}.png"
       val id = LayerId("sample", 1)
       val bucket = "mock-bucket"
-      val keyToPath = SaveToS3Methods.spatialKeyToPath(id, template)
+      val keyToPath = SaveToS3.spatialKeyToPath(id, template)
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3Methods(keyToPath, rdd, maker)
+      SaveToS3(keyToPath, rdd, maker)
       rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
         mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.png") should be (bytes)
       }
@@ -34,11 +34,11 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
       val template = "s3://mock-bucket/catalog/{name}/{z}/{x}/{y}.jpg"
       val id = LayerId("sample", 1)
       val bucket = "mock-bucket"
-      val keyToPath = SaveToS3Methods.spatialKeyToPath(id, template)
+      val keyToPath = SaveToS3.spatialKeyToPath(id, template)
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3Methods(keyToPath, rdd, maker)
+      SaveToS3(keyToPath, rdd, maker)
       rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
         mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.jpg") should be (bytes)
       }
@@ -48,11 +48,11 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
       val template = "s3://mock-bucket/catalog/{name}/{z}/{x}/{y}.tiff"
       val id = LayerId("sample", 1)
       val bucket = "mock-bucket"
-      val keyToPath = SaveToS3Methods.spatialKeyToPath(id, template)
+      val keyToPath = SaveToS3.spatialKeyToPath(id, template)
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3Methods(keyToPath, rdd, maker)
+      SaveToS3(keyToPath, rdd, maker)
       rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
         mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.tiff") should be (bytes)
       }

--- a/s3/src/test/scala/geotrellis/spark/io/s3/S3SaveImagesSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/S3SaveImagesSpec.scala
@@ -24,7 +24,7 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3(keyToPath, rdd, maker)
+      SaveToS3(rdd, maker)(keyToPath)
       rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
         mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.png") should be (bytes)
       }
@@ -38,7 +38,7 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3(keyToPath, rdd, maker)
+      SaveToS3(rdd, maker)(keyToPath)
       rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
         mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.jpg") should be (bytes)
       }
@@ -52,7 +52,7 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3(keyToPath, rdd, maker)
+      SaveToS3(rdd, maker)(keyToPath)
       rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
         mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.tiff") should be (bytes)
       }

--- a/s3/src/test/scala/geotrellis/spark/io/s3/S3SaveImagesSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/S3SaveImagesSpec.scala
@@ -24,7 +24,7 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3(rdd, maker)(keyToPath)
+      SaveToS3(rdd, keyToPath, maker)
       rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
         mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.png") should be (bytes)
       }
@@ -38,7 +38,7 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3(rdd, maker)(keyToPath)
+      SaveToS3(rdd, keyToPath, maker)
       rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
         mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.jpg") should be (bytes)
       }
@@ -52,7 +52,7 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3(rdd, maker)(keyToPath)
+      SaveToS3(rdd, keyToPath, maker)
       rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
         mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.tiff") should be (bytes)
       }

--- a/s3/src/test/scala/geotrellis/spark/io/s3/S3SaveImagesSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/S3SaveImagesSpec.scala
@@ -11,8 +11,9 @@ import geotrellis.spark.io.s3.SaveToS3Methods
 import org.scalatest._
 
 
-class S3SaveImagesSpec extends FunSpec with TestEnvironment {
+class S3SaveImagesSpec extends FunSpec with TestEnvironment with Matchers {
   lazy val sample = TestFiles.generateSpatial("all-ones")
+  val  mockClient = new MockS3Client()
 
   describe("Saving of Rendered Tiles to S3") {
     it ("should work with PNGs") {
@@ -23,7 +24,10 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment {
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3Methods(bucket, keyToPath, rdd, maker)
+      SaveToS3Methods(keyToPath, rdd, maker)
+      rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
+        mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.png") should be (bytes)
+      }
     }
 
     it ("should work with JPEGs") {
@@ -34,7 +38,10 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment {
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3Methods(bucket, keyToPath, rdd, maker)
+      SaveToS3Methods(keyToPath, rdd, maker)
+      rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
+        mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.jpg") should be (bytes)
+      }
     }
 
     it ("should work with GeoTIFFs") {
@@ -45,7 +52,10 @@ class S3SaveImagesSpec extends FunSpec with TestEnvironment {
       val rdd = sample.renderPng()
       val maker = { () => new MockS3Client() }
 
-      SaveToS3Methods(bucket, keyToPath, rdd, maker)
+      SaveToS3Methods(keyToPath, rdd, maker)
+      rdd.collect().foreach { case (SpatialKey(col, row), bytes) =>
+        mockClient.readBytes(bucket, s"catalog/sample/1/$col/$row.tiff") should be (bytes)
+      }
     }
   }
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/SpatialRenderOutput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/SpatialRenderOutput.scala
@@ -63,7 +63,7 @@ class SpatialRenderOutput extends OutputPlugin[SpatialKey, Tile, TileLayerMetada
       images.saveToS3(keyToPath)
     }
     else {
-      val keyToPath = SaveToHadoopMethods.spatialKeyToPath(id, props("path"))
+      val keyToPath = SaveToHadoop.spatialKeyToPath(id, props("path"))
       images.saveToHadoop(keyToPath)
     }
   }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/SpatialRenderOutput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/SpatialRenderOutput.scala
@@ -59,7 +59,7 @@ class SpatialRenderOutput extends OutputPlugin[SpatialKey, Tile, TileLayerMetada
       }
 
     if (useS3) {
-      val keyToPath = SaveToS3Methods.spatialKeyToPath(id, props("path"))
+      val keyToPath = SaveToS3.spatialKeyToPath(id, props("path"))
       images.saveToS3(keyToPath)
     }
     else {

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/MoreSaveToHadoopMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/MoreSaveToHadoopMethods.scala
@@ -12,20 +12,17 @@ import org.apache.spark.rdd.RDD
 class MoreSaveToHadoopMethods[K, V](rdd: RDD[(K, V)]) {
   /** Sets up saving to Hadoop, but returns an RDD so that writes can be chained.
     *
-    * @param scheme    URI scheme, used to get a hadoop FileSystem object
-    * @param path      maps each key to full hadoop supported path
+    * @param keyToUri      maps each key to full hadoop supported path
     * @param getBytes  K and V both provided in case K contains required information, like extent.
     */
-  def setupSaveToHadoop(scheme: String, path: K => String, getBytes: (K,V) => Array[Byte]): RDD[(K, V)] = {
-    rdd.mapPartitions { partition =>
-      val fs = FileSystem.get(new URI(scheme + ":/"), new Configuration)
-      for ( (key, tile) <- partition ) yield {
-        val tilePath = new Path(path(key))
-        val out = fs.create(tilePath)
-        try { out.write(getBytes(key, tile)) }
-        finally { out.close() }
-        (key, tile)
-      }
-    }
-  }
+  def setupSaveToHadoop(keyToUri: K => String)(getBytes: (K, V) => Array[Byte]): RDD[(K, V)] =
+    SaveToHadoop.setup(rdd, keyToUri, getBytes)
+
+  /** Saves to Hadoop, but returns a count of records saved.
+    *
+    * @param keyToUri      maps each key to full hadoop supported path
+    * @param getBytes  K and V both provided in case K contains required information, like extent.
+    */
+  def saveToHadoop(keyToUri: K => String)(getBytes: (K, V) => Array[Byte]): Long =
+    SaveToHadoop(rdd, keyToUri, getBytes)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/SaveToHadoop.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/SaveToHadoop.scala
@@ -1,0 +1,64 @@
+package geotrellis.spark.io.hadoop
+
+import geotrellis.spark.render._
+import geotrellis.spark.{LayerId, SpatialKey}
+
+import java.net.URI
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.rdd.RDD
+
+import scala.collection.concurrent.TrieMap
+
+object SaveToHadoop {
+  /**
+    * @param id           A Layer ID
+    * @param pathTemplate The template used to convert a Layer ID and a SpatialKey into a Hadoop URI
+    *
+    * @return             A functon which takes a spatial key and returns a Hadoop URI
+    */
+  def spatialKeyToPath(id: LayerId, pathTemplate: String): (SpatialKey => String) = {
+    // Return λ
+    { key =>
+      pathTemplate
+        .replace("{x}", key.col.toString)
+        .replace("{y}", key.row.toString)
+        .replace("{z}", id.zoom.toString)
+        .replace("{name}", id.name)
+    }
+  }
+
+  /** Sets up saving to Hadoop, but returns an RDD so that writes can be chained.
+    *
+    * @param keyToUri A function from K (a key) to a Hadoop URI
+    */
+  def setup[K](rdd: RDD[(K, Array[Byte])])(
+    keyToUri: K => String
+  ): RDD[(K, Array[Byte])] = {
+    rdd.mapPartitions { partition =>
+      var fsCache = TrieMap.empty[String, FileSystem]
+
+      for ( row @ (key, data) <- partition ) yield {
+        val path = keyToUri(key)
+        val uri = new URI(path)
+        val fs = fsCache.getOrElseUpdate(
+          uri.getScheme,
+          FileSystem.get(uri, rdd.context.hadoopConfiguration))
+        val out = fs.create(new Path(path))
+        try { out.write(data) }
+        finally { out.close() }
+        row
+      }
+    }
+  }
+
+  /** Saves to Hadoop FileSystem, returns an count of records saved.
+    *
+    * @param keyToUri A function from K (a key) to a Hadoop URI
+    */
+  def apply[K](rdd: RDD[(K, Array[Byte])])(
+    keyToUri: K => String
+  ): Long =
+    setup(rdd)(keyToUri).count
+
+}

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/SaveToHadoopMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/SaveToHadoopMethods.scala
@@ -11,12 +11,12 @@ import org.apache.spark.rdd.RDD
 
 class SaveToHadoopMethods[K](rdd: RDD[(K, Array[Byte])]) {
 
-  /** Saves to Hadoop FileSystem, returns an count of records saved.
+  /** Saves to Hadoop FileSystem, returns a count of records saved.
     * 
     * @param keyToUri A function from K (a key) to a Hadoop URI
     */
   def saveToHadoop(keyToUri: K => String): Long =
-    SaveToHadoop(rdd)(keyToUri)
+    SaveToHadoop(rdd, keyToUri)
 
   /** Sets up saving to Hadoop, but returns an RDD so that writes can be chained.
     *
@@ -24,5 +24,5 @@ class SaveToHadoopMethods[K](rdd: RDD[(K, Array[Byte])]) {
     * @param keyToUri A function from K (a key) to a Hadoop URI
     */
   def setupSaveToHadoop(keyToUri: K => String): RDD[(K, Array[Byte])] =
-    SaveToHadoop.setup(rdd)(keyToUri)
+    SaveToHadoop.setup(rdd, keyToUri)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/SaveToHadoopMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/SaveToHadoopMethods.scala
@@ -9,67 +9,20 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.rdd.RDD
 
 
-object SaveToHadoopMethods {
-  /**
-    * @param id           A Layer ID
-    * @param pathTemplate The template used to convert a Layer ID and a SpatialKey into a Hadoop URI
-    *
-    * @return             A functon which takes a spatial key and returns a Hadoop URI
-    */
-  def spatialKeyToPath(id: LayerId, pathTemplate: String): (SpatialKey => String) = {
-    // Return λ
-    { key =>
-      pathTemplate
-        .replace("{x}", key.col.toString)
-        .replace("{y}", key.row.toString)
-        .replace("{z}", id.zoom.toString)
-        .replace("{name}", id.name)
-    }
-  }
-}
-
 class SaveToHadoopMethods[K](rdd: RDD[(K, Array[Byte])]) {
 
-  /**
-    * @param keyToPath A function from K (a key) to a Hadoop URI
+  /** Saves to Hadoop FileSystem, returns an count of records saved.
+    * 
+    * @param keyToUri A function from K (a key) to a Hadoop URI
     */
-  def saveToHadoop(keyToPath: K => String): Unit = {
-    val scheme = new URI(keyToPath(rdd.first._1)).getScheme
-
-    saveToHadoop(scheme, keyToPath, rdd)
-  }
-
-  /**
-    * @param scheme    URI scheme, used to get a hadoop FileSystem object
-    * @param keyToPath A function from K (a key) to a Hadoop URI
-    * @param rdd       An RDD of key, image pairs
-    */
-  def saveToHadoop(
-    scheme: String,
-    keyToPath: K => String,
-    rdd: RDD[(K, Array[Byte])]
-  ): Unit = {
-    setupSaveToHadoop(scheme, keyToPath).foreach { x => }
-  }
+  def saveToHadoop(keyToUri: K => String): Long =
+    SaveToHadoop(rdd)(keyToUri)
 
   /** Sets up saving to Hadoop, but returns an RDD so that writes can be chained.
     *
     * @param scheme    URI scheme, used to get a hadoop FileSystem object
-    * @param keyToPath A function from K (a key) to a Hadoop URI
+    * @param keyToUri A function from K (a key) to a Hadoop URI
     */
-  def setupSaveToHadoop(
-    scheme: String,
-    keyToPath: K => String
-  ): RDD[(K, Array[Byte])] = {
-    rdd.mapPartitions { partition =>
-      val fs = FileSystem.get(new URI(scheme + ":/"), new Configuration)
-      for ( (key, data) <- partition ) yield {
-        val tilePath = new Path(keyToPath(key))
-        val out = fs.create(tilePath)
-        try { out.write(data) }
-        finally { out.close() }
-        (key, data)
-      }
-    }
-  }
+  def setupSaveToHadoop(keyToUri: K => String): RDD[(K, Array[Byte])] =
+    SaveToHadoop.setup(rdd)(keyToUri)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriter.scala
@@ -28,6 +28,6 @@ class HadoopSlippyTileWriter[T](uri: String, extension: String)(getBytes: (Spati
     val lExtension = extension
     val scheme = new Path("/Users").getFileSystem(sc.hadoopConfiguration).getScheme
     val keyToPath = { key: SpatialKey => new File(lUri, s"$lZoom/${key.col}/${key.row}.${lExtension}").getPath }
-    rdd.setupSaveToHadoop(scheme, keyToPath, getBytes)
+    rdd.setupSaveToHadoop(keyToPath)(getBytes)
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/render/SaveImagesSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/render/SaveImagesSpec.scala
@@ -18,21 +18,21 @@ class SaveImagesSpec extends FunSpec with TestEnvironment {
     it ("should work with PNGs") {
       val template = s"file:${tmpdir}/testFiles/catalog/{name}/{z}/{x}/{y}.png"
       val id = LayerId("sample", 1)
-      val keyToPath = SaveToHadoopMethods.spatialKeyToPath(id, template)
+      val keyToPath = SaveToHadoop.spatialKeyToPath(id, template)
       sample.renderPng().saveToHadoop(keyToPath)
     }
 
     it ("should work with JPGs") {
       val template = s"file:${tmpdir}/testFiles/catalog/{name}/{z}/{x}/{y}.jpg"
       val id = LayerId("sample", 1)
-      val keyToPath = SaveToHadoopMethods.spatialKeyToPath(id, template)
+      val keyToPath = SaveToHadoop.spatialKeyToPath(id, template)
       sample.renderJpg().saveToHadoop(keyToPath)
     }
 
     it ("should work with GeoTiffs") {
       val template = s"file:${tmpdir}/testFiles/catalog/{name}/{z}/{x}/{y}.tiff"
       val id = LayerId("sample", 1)
-      val keyToPath = SaveToHadoopMethods.spatialKeyToPath(id, template)
+      val keyToPath = SaveToHadoop.spatialKeyToPath(id, template)
       sample.renderGeoTiff().saveToHadoop(keyToPath)
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/render/SaveImagesSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/render/SaveImagesSpec.scala
@@ -8,32 +8,54 @@ import geotrellis.spark.testfiles.TestFiles
 import geotrellis.spark.io.hadoop._
 
 import org.scalatest._
-
+import org.apache.hadoop.fs._
+import org.apache.hadoop.conf._
+import org.apache.commons.io.IOUtils
+import java.net.URI
 
 class SaveImagesSpec extends FunSpec with TestEnvironment {
   lazy val sample = TestFiles.generateSpatial("all-ones")
   val tmpdir = System.getProperty("java.io.tmpdir")
+  val fs = FileSystem.get(new URI(tmpdir), new Configuration)
+  def readFile(path: String): Array[Byte] = {
+    IOUtils.toByteArray(fs.open(new Path(path)))
+  }
 
   describe("Saving of Rendered Tiles to Hadoop") {
     it ("should work with PNGs") {
       val template = s"file:${tmpdir}/testFiles/catalog/{name}/{z}/{x}/{y}.png"
       val id = LayerId("sample", 1)
       val keyToPath = SaveToHadoop.spatialKeyToPath(id, template)
-      sample.renderPng().saveToHadoop(keyToPath)
+      val rdd = sample.renderPng()
+      rdd.saveToHadoop(keyToPath)
+      rdd.collect().foreach { case key @ (SpatialKey(col, row), bytes) =>
+        val path = s"file:${tmpdir}/testFiles/catalog/sample/1/$col/$row.png"
+        readFile(path) should be (bytes)
+      }
     }
 
     it ("should work with JPGs") {
       val template = s"file:${tmpdir}/testFiles/catalog/{name}/{z}/{x}/{y}.jpg"
       val id = LayerId("sample", 1)
       val keyToPath = SaveToHadoop.spatialKeyToPath(id, template)
-      sample.renderJpg().saveToHadoop(keyToPath)
+      val rdd = sample.renderJpg()
+      rdd.saveToHadoop(keyToPath)
+      rdd.collect().foreach { case key @ (SpatialKey(col, row), bytes) =>
+        val path = s"file:${tmpdir}/testFiles/catalog/sample/1/$col/$row.jpg"
+        readFile(path) should be (bytes)
+      }
     }
 
     it ("should work with GeoTiffs") {
       val template = s"file:${tmpdir}/testFiles/catalog/{name}/{z}/{x}/{y}.tiff"
       val id = LayerId("sample", 1)
       val keyToPath = SaveToHadoop.spatialKeyToPath(id, template)
-      sample.renderGeoTiff().saveToHadoop(keyToPath)
+      val rdd = sample.renderGeoTiff()
+      rdd.saveToHadoop(keyToPath)
+      rdd.collect().foreach { case key @ (SpatialKey(col, row), bytes) =>
+        val path = s"file:${tmpdir}/testFiles/catalog/sample/1/$col/$row.tiff"
+        readFile(path) should be (bytes)
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes incorrect parsing of URI template when saving to s3, adds tests to cover the failures.

Also changes `SaveToS3Methods` object to `SaveToS3` to better describe what it does. Extension method `.saveToS3()`  remains unchanged.