### PR TITLE
Shortcut out of reproject if it's the same CRS

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterReprojectMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterReprojectMethods.scala
@@ -1,11 +1,10 @@
 package geotrellis.raster.reproject
 
-import geotrellis.raster._
 import geotrellis.proj4._
+import geotrellis.raster._
 import geotrellis.raster.resample.ResampleMethod
 import geotrellis.vector.Extent
 import geotrellis.util.MethodExtensions
-
 
 trait RasterReprojectMethods[+T <: Raster[_]] extends MethodExtensions[T] {
   import Reproject.Options
@@ -15,14 +14,17 @@ trait RasterReprojectMethods[+T <: Raster[_]] extends MethodExtensions[T] {
   def reproject(targetRasterExtent: RasterExtent, transform: Transform, inverseTransform: Transform): T =
     reproject(targetRasterExtent, transform, inverseTransform, Options.DEFAULT)
 
-  def reproject(src: CRS, dest: CRS, options: Options): T = {
-    val transform = Transform(src, dest)
-    val inverseTransform = Transform(dest, src)
+  def reproject(src: CRS, dest: CRS, options: Options): T =
+    if(src == dest) {
+      self
+    } else {
+      val transform = Transform(src, dest)
+      val inverseTransform = Transform(dest, src)
 
-    val targetRasterExtent = ReprojectRasterExtent(self.rasterExtent, transform, options = options)
+      val targetRasterExtent = ReprojectRasterExtent(self.rasterExtent, transform, options = options)
 
-    reproject(targetRasterExtent, transform, inverseTransform, options)
-  }
+      reproject(targetRasterExtent, transform, inverseTransform, options)
+    }
 
   def reproject(src: CRS, dest: CRS): T =
     reproject(src, dest, Options.DEFAULT)

--- a/raster/src/main/scala/geotrellis/raster/reproject/ReprojectRasterExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/ReprojectRasterExtent.scala
@@ -80,7 +80,11 @@ object ReprojectRasterExtent {
     apply(ge, transform, Options.DEFAULT)
 
   def apply(ge: GridExtent, src: CRS, dest: CRS, options: Options): GridExtent =
-    apply(ge, Transform(src, dest), options)
+    if(src == dest) {
+      ge
+    } else {
+      apply(ge, Transform(src, dest), options)
+    }
 
   def apply(ge: GridExtent, src: CRS, dest: CRS): GridExtent =
     apply(ge, src, dest, Options.DEFAULT)
@@ -101,7 +105,11 @@ object ReprojectRasterExtent {
     apply(re, transform, Options.DEFAULT)
 
   def apply(re: RasterExtent, src: CRS, dest: CRS, options: Options): RasterExtent =
-    apply(re, Transform(src, dest), options)
+    if(src == dest) {
+      re
+    } else {
+      apply(re, Transform(src, dest), options)
+    }
 
   def apply(re: RasterExtent, src: CRS, dest: CRS): RasterExtent =
     apply(re, src, dest, Options.DEFAULT)

--- a/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
@@ -169,7 +169,6 @@ object TileLayerMetadata {
     K2: SpatialComponent: Boundable
   ](rdd: RDD[(K, V)], scheme: LayoutScheme): (Int, TileLayerMetadata[K2]) = {
     val (extent, cellType, cellSize, bounds, crs) = collectMetadataWithCRS(rdd)
-
     val LayoutLevel(zoom, layout) = scheme.levelFor(extent, cellSize)
     val GridBounds(colMin, rowMin, colMax, rowMax) = layout.mapTransform(extent)
     val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))

--- a/spark/src/test/scala/geotrellis/spark/TestRegistrator.scala
+++ b/spark/src/test/scala/geotrellis/spark/TestRegistrator.scala
@@ -34,6 +34,7 @@ class TestRegistrator extends NormalKryoRegistrator {
       kryo.register(classOf[scala.math.Ordering$$anon$9])
       kryo.register(classOf[scala.math.Ordering$$anonfun$by$1])
       kryo.register(classOf[scala.reflect.ClassTag$$anon$1])
+      kryo.register(classOf[Array[Boolean]])
 
     /* Special Handling: Avro */
       kryo.register(new Field("a", Schema.create(Type.NULL), null, null: Object).order.getClass)

--- a/spark/src/test/scala/geotrellis/spark/tiling/LayoutDefinitionSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/tiling/LayoutDefinitionSpec.scala
@@ -1,0 +1,20 @@
+package geotrellis.spark.tiling
+
+import geotrellis.raster._
+import geotrellis.vector.Extent
+
+import org.scalatest._
+
+class LayoutDefinitionSpec extends FunSpec with Matchers {
+  describe("LayoutDefinition"){
+    it("should not buffer the extent of a grid that fits within it's bounds"){
+      val e = Extent(-31.4569758,  27.6350020, 40.2053192,  80.7984255)
+      val cs = CellSize(0.08332825, 0.08332825)
+      val tileSize = 256
+      val ld = LayoutDefinition(GridExtent(e, cs), tileSize, tileSize)
+      val ld2 = LayoutDefinition(GridExtent(ld.extent, cs), ld.tileCols, ld.tileRows)
+
+      ld2.extent should be (ld.extent)
+    }
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/tiling/MapKeyTransformSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/tiling/MapKeyTransformSpec.scala
@@ -29,6 +29,17 @@ class MapKeyTransformSpec extends FunSpec with Matchers {
       gb should be (GridBounds(0, 4, 0, 4))
     }
 
+    it("should give the gridbounds of the entire layout if given the extent of that layout") {
+      val ld =
+        LayoutDefinition(
+          Extent(-31.456975828130908, 16.80232947236449, 53.8711521718691, 80.7984254723645),
+          TileLayout(4,3,256,256)
+        )
+
+      val gb = ld.mapTransform(ld.extent)
+      gb should be (GridBounds(0, 0, 3, 2))
+    }
+
     it("should resepect border conditions for single tile") {
       val mp = MapKeyTransform(Extent(0.0, 0.0, 1.0, 1.0), 1, 1)
       assert(mp(Extent(0,0,1,1)) === GridBounds(0, 0, 0, 0))


### PR DESCRIPTION
This set of changes shortcuts out of reprojection if the CRS's are the same. There's some floating point errors that can happen if you send what should be a no-op through reprojection, which can have undesirable consequences.