### PR TITLE
rdd.collectMetadata[K] covers all cases

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
@@ -180,9 +180,9 @@ object TileLayerMetadata {
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
-  ](rdd: RDD[(K, V)], layoutDefinition: LayoutDefinition): (Int, TileLayerMetadata[K2]) = {
+  ](rdd: RDD[(K, V)], layoutDefinition: LayoutDefinition): TileLayerMetadata[K2] = {
     val (extent, cellType, cellSize, bounds, crs) = collectMetadataWithCRS(rdd)
     val kb = bounds.setSpatialBounds(KeyBounds(layoutDefinition.mapTransform(extent)))
-    (0, TileLayerMetadata(cellType, layoutDefinition, extent, crs, kb))
+    TileLayerMetadata(cellType, layoutDefinition, extent, crs, kb)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -130,12 +130,22 @@ package object spark
   implicit class withCollectMetadataMethods[K1, V <: CellGrid](rdd: RDD[(K1, V)]) extends Serializable {
     def collectMetadata[K2: Boundable: SpatialComponent](crs: CRS, layoutScheme: LayoutScheme)
         (implicit ev: K1 => TilerKeyMethods[K1, K2]): (Int, TileLayerMetadata[K2]) = {
-      TileLayerMetadata.fromRdd(rdd, crs, layoutScheme)
+      TileLayerMetadata.fromRdd[K1, V, K2](rdd, crs, layoutScheme)
     }
 
     def collectMetadata[K2: Boundable: SpatialComponent](crs: CRS, layout: LayoutDefinition)
         (implicit ev: K1 => TilerKeyMethods[K1, K2]): TileLayerMetadata[K2] = {
-      TileLayerMetadata.fromRdd(rdd, crs, layout)
+      TileLayerMetadata.fromRdd[K1, V, K2](rdd, crs, layout)
     }
-  }
+
+    def collectMetadata[K2: Boundable: SpatialComponent](layoutScheme: LayoutScheme)
+        (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): (Int, TileLayerMetadata[K2]) = {
+      TileLayerMetadata.fromRdd[K1, V, K2](rdd, layoutScheme)
+    }
+
+    def collectMetadata[K2: Boundable: SpatialComponent](layout: LayoutDefinition)
+        (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): TileLayerMetadata[K2] = {
+      TileLayerMetadata.fromRdd[K1, V, K2](rdd, layout)
+    }
+ }
 }


### PR DESCRIPTION
This patch includes a fix to API, `TileLayerMetadata.fomRdd[K1, V, K](layoutDefinition)` now returns `TileLayerMetadata[K]` instead of `(Int, TileLayerMetadata[K])`. This is both consistent with the other invocation and more correct since layoutDefinition bypasses the zoom level generation process.

Also `rdd.collectMetadata[K](layoutScheme)` and `rdd.collectMetadata[K](layoutDefinition)` are added to cover those cases when `crs` must be collected.