### PR TITLE
Fix possible weird rdd readers behaviour on empty queryKeyBounds

### DIFF
--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloRDDReader.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloRDDReader.scala
@@ -25,6 +25,7 @@ object AccumuloRDDReader {
     filterIndexOnly: Boolean,
     writerSchema: Option[Schema] = None
   )(implicit sc: SparkContext, instance: AccumuloInstance): RDD[(K, V)] = {
+    if(queryKeyBounds.isEmpty) return sc.emptyRDD[(K, V)]
 
     val codec = KryoWrapper(KeyValueRecordCodec[K, V])
     val includeKey = (key: K) => queryKeyBounds.includeKey(key)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
@@ -31,6 +31,8 @@ trait S3RDDReader {
     writerSchema: Option[Schema] = None,
     numPartitions: Option[Int] = None
   )(implicit sc: SparkContext): RDD[(K, V)] = {
+    if(queryKeyBounds.isEmpty) return sc.emptyRDD[(K, V)]
+
     val ranges = if (queryKeyBounds.length > 1)
       MergeQueue(queryKeyBounds.flatMap(decomposeBounds))
     else

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
@@ -26,6 +26,8 @@ object FileRDDReader {
     writerSchema: Option[Schema] = None,
     numPartitions: Option[Int] = None
   )(implicit sc: SparkContext): RDD[(K, V)] = {
+    if(queryKeyBounds.isEmpty) return sc.emptyRDD[(K, V)]
+    
     val ranges = if (queryKeyBounds.length > 1)
       MergeQueue(queryKeyBounds.flatMap(decomposeBounds))
     else

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDReader.scala
@@ -51,6 +51,8 @@ object HadoopRDDReader extends LazyLogging {
     indexFilterOnly: Boolean,
     writerSchema: Option[Schema] = None)
   (implicit sc: SparkContext): RDD[(K, V)] = {
+    if(queryKeyBounds.isEmpty) return sc.emptyRDD[(K, V)]
+
     val dataPath = path.suffix(HadoopCatalogConfig.SEQFILE_GLOB)
 
     logger.debug(s"Loading from $dataPath")


### PR DESCRIPTION
Bug was found in Accumulo RDD Reader:
```scala
InputFormatBase.setRanges(job, ranges)
```

Empty ranges (empty list) means to scan full table.

* How to achieve this situation: to query by keys that are not intersecting with ingested.
* Why this bug was not noticed (probably some other reasons / mb just had no such case): https://github.com/geotrellis/geotrellis/blob/master/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloRDDReader.scala#L54
* How i noticed it: experimented on temporal ingest, and found that i always have lots of spark tasks while querying by not ingested time.

Probably that's a good idea just to return an empty RDD on empty query bounds, though using a return is a bit dirty.