### PR TITLE
Streaming Histogram Fixes

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
@@ -30,6 +30,24 @@ class StreamingHistogramSpec extends FunSpec with Matchers {
     59049, 59049, 100000, 161051, 248832, 248832, 371293, 537824, 537824, 759375, 1048576,
     1419857, 1419857, 1889568, 2476099, 2147483647)
 
+  describe("quantile breaks") {
+    it("should not throw when there are more breaks than buckets") {
+      val h = StreamingHistogram()
+
+      Iterator
+        .continually(List(1,2,3))
+        .flatten
+        .take(10000)
+        .foreach({ i => h.countItem(i.toDouble) })
+
+      val breaks = h.quantileBreaks(50).toList
+
+      breaks.length should be (50)
+      breaks.max should be > (2.9)
+      breaks.min should be < (1.1)
+    }
+  }
+
   describe("mode calculation") {
     it("should return None if no items are counted") {
       val h = StreamingHistogram()


### PR DESCRIPTION
The following fixes are presented:

   - The use of 'higherEntry' (respectively 'lowerEntry') has been changed to
     'ceilingEntry' (respectively 'floorEntry').
   - 'minValue' and 'maxValue' now return the respective smallest and
     largest values encountered so far.
   - 'quantileBreaks' now works even when there are more breaks than
     buckets

### Other Issues ###
   - "Was not able to deal with longs".  I was not able to reproduce/understand this issue, so I have not done anything on it.
   - "Slow".  Since there is only a fixed number of buckets, the information content of data structure is fixed, therefore there is no profit in entering every value encountered into the histogram.  For example, if one can confirm that sampling only 1% of a large number of values still allows an accurate sense of the overall distribution, then the overhead associated with adding items to the histogram can be reduced by a factor of 100.  (This still offers an advantage over the regular integer histogram, because the overall size of the data structure stays fixed whereas the regular one will still grow linearly with the size of the dataset; the focus should be on estimating the distribution.)