### PR TITLE
Store FastMapHistogram counts as longs

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/histogram/FastMapHistogramSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/histogram/FastMapHistogramSpec.scala
@@ -85,4 +85,15 @@ class FastMapHistogramSpec extends FunSpec with Matchers {
     }
   }
 
+  describe("adding large counts") {
+    it("should provide correct results for counts > Int.MaxValue") {
+      val h = FastMapHistogram ()
+      val shft : (Long,Long) => Long = (_ << _)
+      h.countItem(10, shft(1,40))
+
+      val count = h.itemCount(10)
+      count should equal (1099511627776L)
+      
+    }
+  }
 }


### PR DESCRIPTION
FastMapHistogram was storing items and counts in a single array, with element 2\*i holding the item and 2\*i+1 storing the count. Counts could roll over for values above Int.MaxValue. This change splits the items and counts into two arrays, where the latter now stores Long values.
