### PR TITLE
Fixes to user defined float/double CellType parsing

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/CellTypeSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/CellTypeSpec.scala
@@ -19,5 +19,88 @@ class CellTypeSpec extends FunSpec with Matchers {
       IntCellType.intersect(FloatCellType) should be (IntCellType)
       FloatCellType.intersect(IntCellType) should be (IntCellType)
     }
+    def roundTrip(ct: CellType) {
+      val str = ct.toString
+      val ctp = CellType.fromString(str)
+      ctp should be (ct)
+    }
+
+    it("should serialize float64ud123") {
+      roundTrip(DoubleUserDefinedNoDataCellType(123))
+    }
+
+    it("should serialize float64ud123.3") {
+      roundTrip(DoubleUserDefinedNoDataCellType(123.3))
+    }
+
+    it("should serialize float64ud1e12") {
+      roundTrip(DoubleUserDefinedNoDataCellType(1e12))
+    }
+
+    it("should serialize float64ud-1e12") {
+      roundTrip(DoubleUserDefinedNoDataCellType(-1e12))
+    }
+
+    it("should serialize negative float64ud") {
+      roundTrip(DoubleUserDefinedNoDataCellType(-1.7E308))
+    }
+
+    it("should serialize Float.MinValue value float64ud") {
+      roundTrip(DoubleUserDefinedNoDataCellType(Double.MinValue))
+    }
+
+    it("should serialize Float.MaxValue value float64ud") {
+      roundTrip(DoubleUserDefinedNoDataCellType(Double.MaxValue))
+    }
+
+    it("should serialize float64udInfinity") {
+      roundTrip(DoubleUserDefinedNoDataCellType(Double.PositiveInfinity))
+    }
+
+    it("should serialize float64ud-Infinity") {
+      roundTrip(DoubleUserDefinedNoDataCellType(Double.NegativeInfinity))
+    }
+
+    it("should read float64udNaN as float64") {
+      CellType.fromString(DoubleUserDefinedNoDataCellType(Double.NaN).toString) should be (DoubleConstantNoDataCellType)
+    }
+
+    //----
+    it("should serialize float32ud123") {
+      roundTrip(FloatUserDefinedNoDataCellType(123f))
+    }
+
+    it("should serialize float32ud123.3") {
+      roundTrip(FloatUserDefinedNoDataCellType(123.3f))
+    }
+
+    it("should serialize float32ud1e12") {
+      roundTrip(FloatUserDefinedNoDataCellType(1e12f))
+    }
+
+    it("should serialize float32ud-1e12") {
+      roundTrip(FloatUserDefinedNoDataCellType(-1e12f))
+    }
+
+    it("should serialize Float.MinValue value float32ud") {
+      roundTrip(FloatUserDefinedNoDataCellType(Float.MinValue))
+    }
+
+    it("should serialize Float.MaxValue value float32ud") {
+      roundTrip(FloatUserDefinedNoDataCellType(Float.MaxValue))
+    }
+
+    it("should serialize float32udInfinity") {
+      roundTrip(FloatUserDefinedNoDataCellType(Float.PositiveInfinity))
+    }
+
+    it("should serialize float32ud-Infinity") {
+      roundTrip(FloatUserDefinedNoDataCellType(Float.NegativeInfinity))
+    }
+
+    it("should read float32udNaN as float32") {
+      CellType.fromString(FloatUserDefinedNoDataCellType(Float.NaN).toString) should be (FloatConstantNoDataCellType)
+    }
+
   }
 }

--- a/raster/src/main/scala/geotrellis/raster/CellType.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellType.scala
@@ -316,15 +316,21 @@ object CellType {
       }
       IntUserDefinedNoDataCellType(ndVal.toInt)
     case ct if ct.startsWith("float32ud") =>
-      val ndVal = new Regex("\\d*.?\\d+$").findFirstIn(ct).getOrElse {
-        throw new IllegalArgumentException(s"Cell type $name is not supported")
+      try {
+        val ndVal = ct.stripPrefix("float32ud").toDouble.toFloat
+        if (ndVal.isNaN) FloatConstantNoDataCellType
+        else FloatUserDefinedNoDataCellType(ndVal)
+      } catch {
+        case e: NumberFormatException => throw new IllegalArgumentException(s"Cell type $name is not supported")
       }
-      FloatUserDefinedNoDataCellType(ndVal.toFloat)
     case ct if ct.startsWith("float64ud") =>
-      val ndVal = new Regex("\\d*.?\\d+$").findFirstIn(ct).getOrElse {
-        throw new IllegalArgumentException(s"Cell type $name is not supported")
+      try {
+        val ndVal = ct.stripPrefix("float64ud").toDouble
+        if (ndVal.isNaN) DoubleConstantNoDataCellType
+        else DoubleUserDefinedNoDataCellType(ndVal)
+      } catch {
+        case e: NumberFormatException => throw new IllegalArgumentException(s"Cell type $name is not supported")
       }
-      DoubleUserDefinedNoDataCellType(ndVal.toDouble)
     case str =>
       throw new IllegalArgumentException(s"Cell type $name is not supported")
   }


### PR DESCRIPTION
Handle negative, +/-Infinity, NaN.
Specifically `float64udNaN` will parse as `float64` and `float32udNaN` will parse as `float32` 