### PR TITLE
Pass resampling method argument to merge in CutTiles.

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -103,17 +103,26 @@ object TileRDDReproject {
           }
         }
 
-    val (zoom, newMetadata) =
+    val (zoom, newMetadata, tilerResampleMethod) =
       targetLayout match {
         case Left(layoutScheme) =>
-          TileLayerMetadata.fromRdd(reprojectedTiles, destCrs, layoutScheme)
+          // If it's a floating layout scheme, the cell grid will line up and we always want to use nearest neighbor resampling
+          val (z, m) = TileLayerMetadata.fromRdd(reprojectedTiles, destCrs, layoutScheme)
+          layoutScheme match {
+            case _: FloatingLayoutScheme =>
+              val (z, m) = TileLayerMetadata.fromRdd(reprojectedTiles, destCrs, layoutScheme)
+              (z, m, NearestNeighbor)
+            case _ =>
+              (z, m, options.rasterReprojectOptions.method)
+          }
         case Right(layoutDefinition) =>
-          0 -> TileLayerMetadata.fromRdd(reprojectedTiles, destCrs, layoutDefinition)
+          val m = TileLayerMetadata.fromRdd(reprojectedTiles, destCrs, layoutDefinition)
+          (0, m, options.rasterReprojectOptions.method)
       }
 
     val tiled =
       reprojectedTiles
-        .tileToLayout(newMetadata, Tiler.Options(resampleMethod = options.rasterReprojectOptions.method, partitioner = bufferedTiles.partitioner))
+        .tileToLayout(newMetadata, Tiler.Options(resampleMethod = tilerResampleMethod, partitioner = bufferedTiles.partitioner))
 
     (zoom, ContextRDD(tiled, newMetadata))
   }

--- a/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
@@ -36,7 +36,7 @@ object CutTiles {
           .map  { spatialComponent =>
             val outKey = inKey.translate(spatialComponent)
             val newTile = tile.prototype(cellType, tileCols, tileRows)
-            (outKey, newTile.merge(mapTransform(outKey), extent, tile))
+            (outKey, newTile.merge(mapTransform(outKey), extent, tile, resampleMethod))
           }
       }
   }


### PR DESCRIPTION
We weren't passing the resample method to the merge call in CutTiles, which was an oversight. This fixes it. Reprojecting still forces NearestNeighbor for the `tileToLayout` call when using a FloatingLayoutScheme, since the cells will line up and the bilinear computation shouldn't happen because of potential floating point errors or NoData overriding behavior.