### PR TITLE
Handle Special Characters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,8 @@ lazy val vectorTest = Project("vector-test", file("vector-test")).
   dependsOn(vector, vectorTestkit)
 
 lazy val proj4 = Project("proj4", file("proj4")).
-  settings(commonSettings: _*)
+  settings(commonSettings: _*).
+  settings(javacOptions ++= Seq("-encoding", "UTF-8"))
 
 lazy val raster = Project("raster", file("raster")).
   dependsOn(util, macros, vector).


### PR DESCRIPTION
`geotrellis/proj4/src/main/java/org/osgeo/proj4j/util/PolarCoordinate.java` line 18 contains both a lambda and a phi (the actual greek characters, not the words), which results in the following compilation error on some systems: "unmappable character for encoding ASCII".

This change prevents that error.