### PR TITLE
Fix nodata values in codecs

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -435,6 +435,8 @@ class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMu
     } else other match {
       case that : ArrayMultibandTile =>
         var result = true
+        result = (bandCount == that.bandCount)
+
         cfor(0)(result && _ < bandCount, _ + 1) { i =>
           if (band(i) != that.band(i)) result = false
         }

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -429,7 +429,7 @@ class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMu
     new ArrayMultibandTile(newBands)
   }
 
-  override def equals(other: Any): Boolean = {
+  override def equals(other: Any): Boolean = other match {
     case that : ArrayMultibandTile =>
       var result = (bandCount == that.bandCount)
 

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -430,7 +430,7 @@ class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMu
   }
 
   override def equals(other: Any): Boolean = other match {
-    case that : ArrayMultibandTile =>
+    case that: ArrayMultibandTile =>
       var result = (bandCount == that.bandCount)
 
       cfor(0)(result && _ < bandCount, _ + 1) { i =>

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -71,7 +71,7 @@ object ArrayMultibandTile {
 /**
   * The [[ArrayMultibandTile]] type.
   */
-class ArrayMultibandTile(private val _bands: Array[Tile]) extends MultibandTile with MacroMultibandCombiners {
+class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMultibandCombiners {
   val bandCount = _bands.size
 
   assert(bandCount > 0, "Band count must be greater than 0")

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -71,7 +71,7 @@ object ArrayMultibandTile {
 /**
   * The [[ArrayMultibandTile]] type.
   */
-class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMultibandCombiners {
+class ArrayMultibandTile(private val _bands: Array[Tile]) extends MultibandTile with MacroMultibandCombiners {
   val bandCount = _bands.size
 
   assert(bandCount > 0, "Band count must be greater than 0")
@@ -427,5 +427,26 @@ class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMu
     })
 
     new ArrayMultibandTile(newBands)
+  }
+
+  override def equals(other: Any) = {
+    if (other == null) {
+      false
+    } else other match {
+      case that : ArrayMultibandTile =>
+        case class NotEqualException() extends Exception()
+        var result = true
+        try {
+          for (b <- 0 until bandCount) {
+            if (band(b) != that.band(b)) throw NotEqualException()
+          }
+        } catch {
+          case e : NotEqualException =>
+            result = false
+        }
+        result
+      case _ =>
+        false
+    }
   }
 }

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -434,12 +434,11 @@ class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMu
       false
     } else other match {
       case that : ArrayMultibandTile =>
-        var i = 0
-        while (i < bandCount) {
-          if (band(i) != that.band(i)) return false
-          i += 1
+        var result = true
+        cfor(0)(result && _ < bandCount, _ + 1) { i =>
+          if (band(i) != that.band(i)) result = false
         }
-        true
+        result
       case _ =>
         false
     }

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -429,22 +429,17 @@ class ArrayMultibandTile(private val _bands: Array[Tile]) extends MultibandTile 
     new ArrayMultibandTile(newBands)
   }
 
-  override def equals(other: Any) = {
+  override def equals(other: Any): Boolean = {
     if (other == null) {
       false
     } else other match {
       case that : ArrayMultibandTile =>
-        case class NotEqualException() extends Exception()
-        var result = true
-        try {
-          for (b <- 0 until bandCount) {
-            if (band(b) != that.band(b)) throw NotEqualException()
-          }
-        } catch {
-          case e : NotEqualException =>
-            result = false
+        var i = 0
+        while (i < bandCount) {
+          if (band(i) != that.band(i)) return false
+          i += 1
         }
-        result
+        true
       case _ =>
         false
     }

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -430,19 +430,14 @@ class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMu
   }
 
   override def equals(other: Any): Boolean = {
-    if (other == null) {
-      false
-    } else other match {
-      case that : ArrayMultibandTile =>
-        var result = true
-        result = (bandCount == that.bandCount)
+    case that : ArrayMultibandTile =>
+      var result = (bandCount == that.bandCount)
 
-        cfor(0)(result && _ < bandCount, _ + 1) { i =>
-          if (band(i) != that.band(i)) result = false
-        }
-        result
-      case _ =>
-        false
-    }
+      cfor(0)(result && _ < bandCount, _ + 1) { i =>
+        if (band(i) != that.band(i)) result = false
+      }
+      result
+    case _ =>
+      false
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/TileCodecs.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/TileCodecs.scala
@@ -105,7 +105,7 @@ trait TileCodecs {
       rec.put("rows", tile.rows)
       rec.put("cells", java.util.Arrays.asList(tile.array:_*))
       tile.cellType match {
-        case IntConstantNoDataCellType => rec.put("noDataValue", 0)
+        case IntConstantNoDataCellType => rec.put("noDataValue", Int.MinValue)
         case IntUserDefinedNoDataCellType(nd) => rec.put("noDataValue", nd)
         case IntCellType => rec.put("noDataValue", null)
         case _ => sys.error(s"Cell type ${tile.cellType} was unexpected")
@@ -245,7 +245,7 @@ trait TileCodecs {
       rec.put("rows", tile.rows)
       rec.put("cells", ByteBuffer.wrap(tile.array))
       tile.cellType match {
-        case ByteConstantNoDataCellType => rec.put("noDataValue", 0)
+        case ByteConstantNoDataCellType => rec.put("noDataValue", Byte.MinValue)
         case ByteUserDefinedNoDataCellType(nd) => rec.put("noDataValue", nd.toInt)
         case ByteCellType => rec.put("noDataValue", null)
         case _ => sys.error(s"Cell type ${tile.cellType} was unexpected")

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/TileCodecs.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/TileCodecs.scala
@@ -105,7 +105,7 @@ trait TileCodecs {
       rec.put("rows", tile.rows)
       rec.put("cells", java.util.Arrays.asList(tile.array:_*))
       tile.cellType match {
-        case IntConstantNoDataCellType => rec.put("noDataValue", Int.MinValue)
+        case IntConstantNoDataCellType => rec.put("noDataValue", NODATA)
         case IntUserDefinedNoDataCellType(nd) => rec.put("noDataValue", nd)
         case IntCellType => rec.put("noDataValue", null)
         case _ => sys.error(s"Cell type ${tile.cellType} was unexpected")
@@ -245,7 +245,7 @@ trait TileCodecs {
       rec.put("rows", tile.rows)
       rec.put("cells", ByteBuffer.wrap(tile.array))
       tile.cellType match {
-        case ByteConstantNoDataCellType => rec.put("noDataValue", Byte.MinValue)
+        case ByteConstantNoDataCellType => rec.put("noDataValue", byteNODATA.toInt)
         case ByteUserDefinedNoDataCellType(nd) => rec.put("noDataValue", nd.toInt)
         case ByteCellType => rec.put("noDataValue", null)
         case _ => sys.error(s"Cell type ${tile.cellType} was unexpected")

--- a/spark/src/test/scala/geotrellis/spark/io/avro/AvroTools.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/avro/AvroTools.scala
@@ -40,8 +40,8 @@ object AvroTools {
       doCheck(noDataParsed)
     }
     def extractNoData(json: String): Option[Any] = {
-      JSON.parseFull(json) map {
-        case m: Map[String,Any] => m("noDataValue")
+      JSON.parseFull(json) flatMap {
+        case m: Map[String,Any] => m.get("noDataValue")
       }
     }
     def doCheck(noData: Option[Any]): Unit = ()

--- a/spark/src/test/scala/geotrellis/spark/io/avro/AvroTools.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/avro/AvroTools.scala
@@ -1,14 +1,172 @@
 package geotrellis.spark.io.avro
 
 import org.scalatest._
+import Matchers._
+
+import geotrellis.raster._
 
 trait AvroTools { self: Matchers =>
+  import AvroTools._
+
   def roundTrip[T](thing: T)(implicit codec: AvroRecordCodec[T]): Unit = {
     val bytes = AvroEncoder.toBinary(thing)
     val fromBytes = AvroEncoder.fromBinary[T](bytes)
-    fromBytes should be equals thing
+    fromBytes shouldBe thing
     val json = AvroEncoder.toJson(thing)
     val fromJson = AvroEncoder.fromJson[T](json)
-    fromJson should be equals thing
+    fromJson shouldBe thing
   }
+
+  def roundTripWithNoDataCheck[T <% NoDataValueChecker[T]](thing: T)(implicit codec: AvroRecordCodec[T]): Unit = {
+    val bytes = AvroEncoder.toBinary(thing)
+    val fromBytes = AvroEncoder.fromBinary[T](bytes)
+    fromBytes shouldBe thing
+    val json = AvroEncoder.toJson(thing)
+    thing.checkNoData(json)
+    val fromJson = AvroEncoder.fromJson[T](json)
+    fromJson shouldBe thing
+  }
+}
+
+object AvroTools {
+  import scala.util.parsing.json._
+  trait NoDataValueChecker[T] {
+    def checkNoData(json: String): Unit = {
+      val noDataParsed: Option[Any] = extractNoData(json)
+      doCheck(noDataParsed)
+    }
+    def extractNoData(json: String): Option[Any] = {
+      JSON.parseFull(json) map {
+        case m: Map[String,Any] => m("noDataValue")
+      }
+    }
+    def doCheck(noData: Option[Any]): Unit = ()
+  }
+  implicit def shortNoDataChecker(tile: ShortArrayTile): NoDataValueChecker[ShortArrayTile] = shortNoDataChecker(tile.cellType)
+  
+  def shortNoDataChecker(cellType: CellType): NoDataValueChecker[ShortArrayTile] = new NoDataValueChecker[ShortArrayTile] {
+    override def doCheck(nodata: Option[Any]): Unit = {
+      cellType match {
+        case ShortConstantNoDataCellType => nodata shouldBe Some(Map("int" -> shortNODATA.toInt))
+        case ShortUserDefinedNoDataCellType(nd) => nodata shouldBe Some(Map("int" -> nd))
+        case ShortCellType => nodata shouldBe Some(null)
+        case _ => sys.error(s"Cell type ${cellType} was unexpected")
+      }
+    }
+  }
+
+  implicit def uShortNoDataChecker(tile: UShortArrayTile): NoDataValueChecker[UShortArrayTile] = uShortNoDataChecker(tile.cellType)
+
+  def uShortNoDataChecker(cellType: CellType): NoDataValueChecker[UShortArrayTile] = new NoDataValueChecker[UShortArrayTile] {
+    override def doCheck(nodata: Option[Any]): Unit = {
+      cellType match {
+        case UShortConstantNoDataCellType => nodata shouldBe Some(Map("int" -> ushortNODATA.toInt))
+        case UShortUserDefinedNoDataCellType(nd) => nodata shouldBe Some(Map("int" -> nd))
+        case UShortCellType => nodata shouldBe Some(null)
+        case _ => sys.error(s"Cell type ${cellType} was unexpected")
+      }
+    }
+  }
+
+  implicit def intNoDataChecker(tile: IntArrayTile): NoDataValueChecker[IntArrayTile] = intNoDataChecker(tile.cellType)
+
+  def intNoDataChecker(cellType: CellType): NoDataValueChecker[IntArrayTile] = new NoDataValueChecker[IntArrayTile] {
+    override def doCheck(nodata: Option[Any]): Unit = {
+      cellType match {
+        case IntConstantNoDataCellType => nodata shouldBe Some(Map("int" -> NODATA))
+        case IntUserDefinedNoDataCellType(nd) => nodata shouldBe Some(Map("int" -> nd))
+        case IntCellType => nodata shouldBe Some(null)
+        case _ => sys.error(s"Cell type ${cellType} was unexpected")
+      }
+    }
+  }
+
+  implicit def floatNoDataChecker(tile: FloatArrayTile): NoDataValueChecker[FloatArrayTile] = floatNoDataChecker(tile.cellType)
+
+  def floatNoDataChecker(cellType: CellType): NoDataValueChecker[FloatArrayTile] = new NoDataValueChecker[FloatArrayTile] {
+    override def doCheck(nodata: Option[Any]): Unit = {
+      cellType match {
+        case FloatConstantNoDataCellType => nodata shouldBe Some(Map("boolean" -> true))
+        case FloatUserDefinedNoDataCellType(nd) =>
+          // nodata shouldBe Some(Map("float" -> nd)) // doesn't work: double number != float number
+          // nodata shouldBe Some(Map("float" -> nd.toDouble)) // doesn't work: (2.2f).toDouble ==> 2.200000047683716
+          nodata.toString shouldBe Some(Map("float" -> nd)).toString
+        case FloatCellType => nodata shouldBe Some(Map("boolean" -> false))
+        case _ => sys.error(s"Cell type ${cellType} was unexpected")
+      }
+    }
+  }
+
+  implicit def doubleNoDataChecker(tile: DoubleArrayTile): NoDataValueChecker[DoubleArrayTile] = doubleNoDataChecker(tile.cellType)
+
+  def doubleNoDataChecker(cellType: CellType): NoDataValueChecker[DoubleArrayTile] = new NoDataValueChecker[DoubleArrayTile] {
+    override def doCheck(nodata: Option[Any]): Unit = {
+      cellType match {
+        case DoubleConstantNoDataCellType => nodata shouldBe Some(Map("boolean" -> true))
+        case DoubleUserDefinedNoDataCellType(nd) => nodata shouldBe Some(Map("double" -> nd))
+        case DoubleCellType => nodata shouldBe Some(Map("boolean" -> false))
+        case _ => sys.error(s"Cell type ${cellType} was unexpected")
+      }
+    }
+  }
+
+  implicit def byteNoDataChecker(tile: ByteArrayTile): NoDataValueChecker[ByteArrayTile] = byteNoDataChecker(tile.cellType)
+
+  def byteNoDataChecker(cellType: CellType): NoDataValueChecker[ByteArrayTile] = new NoDataValueChecker[ByteArrayTile] {
+    override def doCheck(nodata: Option[Any]): Unit = {
+      cellType match {
+        case ByteConstantNoDataCellType => nodata shouldBe Some(Map("int" -> byteNODATA))
+        case ByteUserDefinedNoDataCellType(nd) => nodata shouldBe Some(Map("int" -> nd))
+        case ByteCellType => nodata shouldBe Some(null)
+        case _ => sys.error(s"Cell type ${cellType} was unexpected")
+      }
+    }
+  }
+
+  implicit def ubyteNoDataChecker(tile: UByteArrayTile): NoDataValueChecker[UByteArrayTile] = ubyteNoDataChecker(tile.cellType)
+
+  def ubyteNoDataChecker(cellType: CellType): NoDataValueChecker[UByteArrayTile] = new NoDataValueChecker[UByteArrayTile] {
+    override def doCheck(nodata: Option[Any]): Unit = {
+      cellType match {
+        case UByteConstantNoDataCellType => nodata shouldBe Some(Map("int" -> ubyteNODATA))
+        case UByteUserDefinedNoDataCellType(nd) => nodata shouldBe Some(Map("int" -> nd))
+        case UByteCellType => nodata shouldBe Some(null)
+        case _ => sys.error(s"Cell type ${cellType} was unexpected")
+      }
+    }
+  }
+
+  implicit def bitNoDataChecker(tile: BitArrayTile): NoDataValueChecker[BitArrayTile] = bitNoDataChecker(tile.cellType)
+
+  def bitNoDataChecker(cellType: CellType): NoDataValueChecker[BitArrayTile] = new NoDataValueChecker[BitArrayTile] {
+    override def doCheck(nodata: Option[Any]): Unit = {
+      nodata shouldBe None
+    }
+  }
+
+  implicit def multibandNoDataChecker(tile: MultibandTile): NoDataValueChecker[MultibandTile] =
+    new NoDataValueChecker[MultibandTile] {
+      override def checkNoData(json: String): Unit = {
+        JSON.parseFull(json) foreach {
+            case m: Map[String, Seq[Map[String, Any]]] =>
+              m("bands") foreach { case bandWrapper : Map[String, Map[String, Any]] =>
+                bandWrapper(bandWrapper.keys.head) match { case band: Map[String,Any] =>
+                  val nodata = band.get("noDataValue")
+                  tile.cellType match {
+                    case ct: ShortCells =>   shortNoDataChecker(ct).doCheck(nodata)
+                    case ct: UShortCells =>  uShortNoDataChecker(ct).doCheck(nodata)
+                    case ct: IntCells =>     intNoDataChecker(ct).doCheck(nodata)
+                    case ct: FloatCells =>   floatNoDataChecker(ct).doCheck(nodata)
+                    case ct: DoubleCells =>  doubleNoDataChecker(ct).doCheck(nodata)
+                    case ct: ByteCells =>    byteNoDataChecker(ct).doCheck(nodata)
+                    case ct: UByteCells =>   ubyteNoDataChecker(ct).doCheck(nodata)
+                    case ct: BitCells =>     bitNoDataChecker(ct).doCheck(nodata)
+                    case _ => sys.error(s"Cell type ${tile.cellType} was unexpected")
+                  }
+                }
+              }
+          }
+      }
+    }
+
 }

--- a/spark/src/test/scala/geotrellis/spark/io/avro/TileCodecsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/avro/TileCodecsSpec.scala
@@ -31,7 +31,7 @@ class TileCodecsSpec extends FunSpec with Matchers with AvroTools  {
     }
 
     it("encodes ArrayMultibandTile"){
-      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,1,5)
+      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,10,15)
       val thing = ArrayMultibandTile(tiles): MultibandTile
       roundTripWithNoDataCheck(thing)
 //      val bytes = AvroEncoder.toBinary(thing)
@@ -63,7 +63,7 @@ class TileCodecsSpec extends FunSpec with Matchers with AvroTools  {
       roundTripWithNoDataCheck(DoubleArrayTile.fill(53232322.4,10,15, DoubleCellType))
     }
     it("encodes ArrayMultibandTile"){
-      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,1,5, DoubleCellType)
+      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,10,15, DoubleCellType)
       val thing = ArrayMultibandTile(tiles): MultibandTile
       roundTripWithNoDataCheck(thing)
     }
@@ -92,7 +92,7 @@ class TileCodecsSpec extends FunSpec with Matchers with AvroTools  {
       roundTripWithNoDataCheck(DoubleArrayTile.fill(53232322.4,10,15, DoubleUserDefinedNoDataCellType(2.2)))
     }
     it("encodes ArrayMultibandTile"){
-      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,1,5, DoubleUserDefinedNoDataCellType(42.23))
+      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,10,15, DoubleUserDefinedNoDataCellType(42.23))
       val thing = ArrayMultibandTile(tiles): MultibandTile
       roundTripWithNoDataCheck(thing)
     }

--- a/spark/src/test/scala/geotrellis/spark/io/avro/TileCodecsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/avro/TileCodecsSpec.scala
@@ -4,35 +4,36 @@ import geotrellis.spark.io.avro.codecs.TileCodecs
 import org.scalatest._
 import TileCodecs._
 import geotrellis.raster._
+import geotrellis.spark.io.avro.AvroTools._
 
 class TileCodecsSpec extends FunSpec with Matchers with AvroTools  {
   describe("TileCodecs") {
     it("encodes ByteArrayTile"){
-      roundTrip(ByteArrayTile.fill(127,10,15))
+      roundTripWithNoDataCheck(ByteArrayTile.fill(127,10,15))
     }
     it("encodes UByteArrayTile"){
-      roundTrip(UByteArrayTile.fill(127,10,15))
+      roundTripWithNoDataCheck(UByteArrayTile.fill(127,10,15))
     }
     it("encodes ShortArrayTile"){
-      roundTrip(ShortArrayTile.fill(45,10,15))
+      roundTripWithNoDataCheck(ShortArrayTile.fill(45,10,15))
     }
     it("encodes UShortArrayTile"){
-      roundTrip(UShortArrayTile.fill(45,10,15))
+      roundTripWithNoDataCheck(UShortArrayTile.fill(45,10,15))
     }
     it("encodes IntArrayTile"){
-      roundTrip(IntArrayTile.fill(45,10,15))
+      roundTripWithNoDataCheck(IntArrayTile.fill(45,10,15))
     }
     it("encodes FloatArrayTile"){
-      roundTrip(FloatArrayTile.fill(532.4f,10,15))
+      roundTripWithNoDataCheck(FloatArrayTile.fill(532.4f,10,15))
     }
     it("encodes DoubleArrayTile"){
-      roundTrip(DoubleArrayTile.fill(53232322.4,10,15))
+      roundTripWithNoDataCheck(DoubleArrayTile.fill(53232322.4,10,15))
     }
 
     it("encodes ArrayMultibandTile"){
-      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,10,15)
+      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,1,5)
       val thing = ArrayMultibandTile(tiles): MultibandTile
-      roundTrip(thing)
+      roundTripWithNoDataCheck(thing)
 //      val bytes = AvroEncoder.toBinary(thing)
 //      val fromBytes = AvroEncoder.fromBinary[MultibandTile](bytes)
 //      fromBytes should be equals (thing)
@@ -41,59 +42,59 @@ class TileCodecsSpec extends FunSpec with Matchers with AvroTools  {
 
   describe("No NoData TileCodecs") {
     it("encodes ByteArrayTile"){
-      roundTrip(ByteArrayTile.fill(127,10,15, ByteCellType))
+      roundTripWithNoDataCheck(ByteArrayTile.fill(127,10,15, ByteCellType))
     }
     it("encodes UByteArrayTile"){
-      roundTrip(UByteArrayTile.fill(127,10,15, UByteCellType))
+      roundTripWithNoDataCheck(UByteArrayTile.fill(127,10,15, UByteCellType))
     }
     it("encodes ShortArrayTile"){
-      roundTrip(ShortArrayTile.fill(45,10,15, ShortCellType))
+      roundTripWithNoDataCheck(ShortArrayTile.fill(45,10,15, ShortCellType))
     }
     it("encodes UShortArrayTile"){
-      roundTrip(UShortArrayTile.fill(45,10,15, UShortCellType))
+      roundTripWithNoDataCheck(UShortArrayTile.fill(45,10,15, UShortCellType))
     }
     it("encodes IntArrayTile"){
-      roundTrip(IntArrayTile.fill(45,10,15, IntCellType))
+      roundTripWithNoDataCheck(IntArrayTile.fill(45,10,15, IntCellType))
     }
     it("encodes FloatArrayTile"){
-      roundTrip(FloatArrayTile.fill(532.4f,10,15, FloatCellType))
+      roundTripWithNoDataCheck(FloatArrayTile.fill(532.4f,10,15, FloatCellType))
     }
     it("encodes DoubleArrayTile"){
-      roundTrip(DoubleArrayTile.fill(53232322.4,10,15, DoubleCellType))
+      roundTripWithNoDataCheck(DoubleArrayTile.fill(53232322.4,10,15, DoubleCellType))
     }
     it("encodes ArrayMultibandTile"){
-      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,10,15, DoubleCellType)
+      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,1,5, DoubleCellType)
       val thing = ArrayMultibandTile(tiles): MultibandTile
-      roundTrip(thing)
+      roundTripWithNoDataCheck(thing)
     }
   }
 
   describe("UserDefined TileCodecs") {
     it("encodes ByteArrayTile"){
-      roundTrip(ByteArrayTile.fill(127,10,15, ByteUserDefinedNoDataCellType(123)))
+      roundTripWithNoDataCheck(ByteArrayTile.fill(127,10,15, ByteUserDefinedNoDataCellType(123)))
     }
     it("encodes UByteArrayTile"){
-      roundTrip(UByteArrayTile.fill(127,10,15, UByteUserDefinedNoDataCellType(123)))
+      roundTripWithNoDataCheck(UByteArrayTile.fill(127,10,15, UByteUserDefinedNoDataCellType(123)))
     }
     it("encodes ShortArrayTile"){
-      roundTrip(ShortArrayTile.fill(45,10,15, ShortUserDefinedNoDataCellType(123)))
+      roundTripWithNoDataCheck(ShortArrayTile.fill(45,10,15, ShortUserDefinedNoDataCellType(123)))
     }
     it("encodes UShortArrayTile"){
-      roundTrip(UShortArrayTile.fill(45,10,15, UShortUserDefinedNoDataCellType(123)))
+      roundTripWithNoDataCheck(UShortArrayTile.fill(45,10,15, UShortUserDefinedNoDataCellType(123)))
     }
     it("encodes IntArrayTile"){
-      roundTrip(IntArrayTile.fill(45,10,15, IntUserDefinedNoDataCellType(123)))
+      roundTripWithNoDataCheck(IntArrayTile.fill(45,10,15, IntUserDefinedNoDataCellType(123)))
     }
     it("encodes FloatArrayTile"){
-      roundTrip(FloatArrayTile.fill(532.4f,10,15, FloatUserDefinedNoDataCellType(2.2F)))
+      roundTripWithNoDataCheck(FloatArrayTile.fill(532.4f,10,15, FloatUserDefinedNoDataCellType(2.2F)))
     }
     it("encodes DoubleArrayTile"){
-      roundTrip(DoubleArrayTile.fill(53232322.4,10,15, DoubleUserDefinedNoDataCellType(2.2)))
+      roundTripWithNoDataCheck(DoubleArrayTile.fill(53232322.4,10,15, DoubleUserDefinedNoDataCellType(2.2)))
     }
     it("encodes ArrayMultibandTile"){
-      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,10,15, DoubleUserDefinedNoDataCellType(42.23))
+      val tiles= for (i <- 0 to 3) yield DoubleArrayTile.fill(53232322.4,1,5, DoubleUserDefinedNoDataCellType(42.23))
       val thing = ArrayMultibandTile(tiles): MultibandTile
-      roundTrip(thing)
+      roundTripWithNoDataCheck(thing)
     }
   }
 }


### PR DESCRIPTION
There is an inconsistency between encode and decode methods of ArrayTileCodecs for int and byte types: when encoding, it writes zero, but when decoding it expects min value for a type.