### PR TITLE
Fix month and year calculations

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/index/ZCurveKeyIndexMethod.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/ZCurveKeyIndexMethod.scala
@@ -44,14 +44,14 @@ object ZCurveKeyIndexMethod extends ZCurveKeyIndexMethod {
     byMilliseconds(1000L * 60 * 60 * 24 * days)
 
   def byMonth(): KeyIndexMethod[SpaceTimeKey] =
-    byMilliseconds(1000L * 60 * 60 * 30)
+    byMilliseconds(1000L * 60 * 60 * 24 * 30)
 
   def byMonths(months: Int): KeyIndexMethod[SpaceTimeKey] =
-    byMilliseconds(1000L * 60 * 60 * 30 * months)
+    byMilliseconds(1000L * 60 * 60 * 24 * 30 * months)
 
   def byYear(): KeyIndexMethod[SpaceTimeKey] =
-    byMilliseconds(1000L * 60 * 60 * 365)
+    byMilliseconds(1000L * 60 * 60 * 24 * 365)
 
   def byYears(years: Int): KeyIndexMethod[SpaceTimeKey] =
-    byMilliseconds(1000L * 60 * 60 * 365 * years)
+    byMilliseconds(1000L * 60 * 60 * 24 * 365 * years)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/index/zcurve/ZSpaceTimeKeyIndex.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/zcurve/ZSpaceTimeKeyIndex.scala
@@ -35,16 +35,16 @@ object ZSpaceTimeKeyIndex {
     byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * days)
 
   def byMonth(keyBounds: KeyBounds[SpaceTimeKey]): ZSpaceTimeKeyIndex =
-    byMilliseconds(keyBounds, 1000L * 60 * 60 * 30)
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * 30)
 
   def byMonths(keyBounds: KeyBounds[SpaceTimeKey], months: Int): ZSpaceTimeKeyIndex =
-    byMilliseconds(keyBounds, 1000L * 60 * 60 * 30 * months)
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * 30 * months)
 
   def byYear(keyBounds: KeyBounds[SpaceTimeKey]): ZSpaceTimeKeyIndex =
-    byMilliseconds(keyBounds, 1000L * 60 * 60 * 365)
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * 365)
 
   def byYears(keyBounds: KeyBounds[SpaceTimeKey], years: Int): ZSpaceTimeKeyIndex =
-    byMilliseconds(keyBounds, 1000L * 60 * 60 * 365 * years)
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * 365 * years)
 }
 
 class ZSpaceTimeKeyIndex(val keyBounds: KeyBounds[SpaceTimeKey], val temporalResolution: Long) extends KeyIndex[SpaceTimeKey] {


### PR DESCRIPTION
The operand 24 was missing in byMonth/byYear methods.