### PR TITLE
Handle entire layers of `NODATA`

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/render/ColorRampSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/render/ColorRampSpec.scala
@@ -19,19 +19,33 @@ package geotrellis.raster.render
 import org.scalatest._
 
 class ColorRampSpec extends FunSpec with Matchers {
-  describe("spread") {
-    val colors: Vector[Int] = Vector(0xFF0000, 0x0000FF)
+  val colors: Vector[Int] = Vector(0xFF0000, 0x0000FF)
+  val ramp: ColorRamp = ColorRamp(colors)
 
-    it("should not bail when n = 0") {
-      ColorRamp.spread(colors, 0) should be (Vector.empty[Int])
+  describe("ColorRamp") {
+    describe("toColorMap") {
+      it("should yield an empty ColorMap when given an empty breaks Array - GH #1487") {
+        val m: ColorMap = ramp.toColorMap(
+          Array.empty[Double],
+          ColorMap.Options.DEFAULT
+        )
+
+        m.colors.length should be (0)
+      }
     }
 
-    it("should not bail when n < 0") {
-      ColorRamp.spread(colors, -1) should be (Vector.empty[Int])
-    }
+    describe("spread") {
+      it("should not bail when n = 0") {
+        ColorRamp.spread(colors, 0) should be (Vector.empty[Int])
+      }
 
-    it("should give non-empty results for n > 0") {
-      ColorRamp.spread(colors, 2) shouldNot be (Vector.empty[Int])
+      it("should not bail when n < 0") {
+        ColorRamp.spread(colors, -1) should be (Vector.empty[Int])
+      }
+
+      it("should give non-empty results for n > 0") {
+        ColorRamp.spread(colors, 2) shouldNot be (Vector.empty[Int])
+      }
     }
   }
 }

--- a/raster-test/src/test/scala/geotrellis/raster/render/ColorRampSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/render/ColorRampSpec.scala
@@ -34,6 +34,12 @@ class ColorRampSpec extends FunSpec with Matchers {
       }
     }
 
+    describe("stops") {
+      it("stops(0) should yield an empty ColorRamp") {
+        ramp.stops(0).colors.length should be (0)
+      }
+    }
+
     describe("spread") {
       it("should not bail when n = 0") {
         ColorRamp.spread(colors, 0) should be (Vector.empty[Int])
@@ -45,6 +51,32 @@ class ColorRampSpec extends FunSpec with Matchers {
 
       it("should give non-empty results for n > 0") {
         ColorRamp.spread(colors, 2) shouldNot be (Vector.empty[Int])
+      }
+    }
+
+    describe("chooseColors") {
+      it("should be empty when given an empty Vector") {
+        ColorRamp.chooseColors(Vector.empty[Int], 10) should be (Vector.empty[Int])
+      }
+
+      it("should be empty when given 0") {
+        ColorRamp.chooseColors(colors, 0) should be (Vector.empty[Int])
+      }
+    }
+
+    describe("(when empty)") {
+      val e: ColorRamp = ColorRamp(Vector.empty[Int])
+
+      it("setAlphaGradient should yield an empty ColorRamp") {
+        e.setAlphaGradient().colors.length should be (0)
+      }
+
+      it("setAlpha should yield an empty ColorRamp") {
+        e.setAlpha(0).colors.length should be (0)
+      }
+
+      it("stops should give an empty ColorRamp") {
+        e.stops(100).colors.length should be (0)
       }
     }
   }

--- a/raster-test/src/test/scala/geotrellis/raster/render/ColorRampSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/render/ColorRampSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.render
+
+import org.scalatest._
+
+class ColorRampSpec extends FunSpec with Matchers {
+  describe("spread") {
+    val colors: Vector[Int] = Vector(0xFF0000, 0x0000FF)
+
+    it("should not bail when n = 0") {
+      ColorRamp.spread(colors, 0) should be (Vector.empty[Int])
+    }
+
+    it("should not bail when n < 0") {
+      ColorRamp.spread(colors, -1) should be (Vector.empty[Int])
+    }
+
+    it("should give non-empty results for n > 0") {
+      ColorRamp.spread(colors, 2) shouldNot be (Vector.empty[Int])
+    }
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/render/ColorRamp.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorRamp.scala
@@ -138,7 +138,7 @@ object ColorRamp {
      * will still perform as expected and refuse to colour NODATA locations,
      * thanks to the `noDataColor` field in `ColorMap.Options`.
      */
-    if (n == 0) return Vector.empty[Int]
+    if (n < 1) return Vector.empty[Int]
 
     val colors2 = new Array[Int](n)
     colors2(0) = colors(0)

--- a/raster/src/main/scala/geotrellis/raster/render/ColorRamp.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorRamp.scala
@@ -128,8 +128,7 @@ object ColorRamp {
     /* The requested spread matches the original */
     if (colors.length == n) return colors
 
-    /* 2016 May 20 @ 14:21
-     * In the case of a Layer comprised entirely of NODATA, a call to
+    /* In the case of a Layer comprised entirely of NODATA, a call to
      * `classBreaksDouble` will yield an empty `Array`. That propagates here,
      * where an attempt to index below results in a bounds exception.
      *

--- a/raster/src/main/scala/geotrellis/raster/render/ColorRamp.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorRamp.scala
@@ -125,7 +125,20 @@ object ColorRamp {
     * @param n       Length of list to return
     */
   def spread(colors: Vector[Int], n: Int): Vector[Int] = {
+    /* The requested spread matches the original */
     if (colors.length == n) return colors
+
+    /* 2016 May 20 @ 14:21
+     * In the case of a Layer comprised entirely of NODATA, a call to
+     * `classBreaksDouble` will yield an empty `Array`. That propagates here,
+     * where an attempt to index below results in a bounds exception.
+     *
+     * Guarding on this condition and returning an empty `Vector` instead
+     * is still valid; a `ColorMap` that contains an empty `colors` field
+     * will still perform as expected and refuse to colour NODATA locations,
+     * thanks to the `noDataColor` field in `ColorMap.Options`.
+     */
+    if (n == 0) return Vector.empty[Int]
 
     val colors2 = new Array[Int](n)
     colors2(0) = colors(0)


### PR DESCRIPTION
## TODO
- [x] Guard on asking for a colour spread of 0 colours in `ColorRamp.spread`
- [x] Pass current tests
- [x] Write new tests to test the guarding
- [x] Test `geotrellis-admin` with a snapshot of `geotrellis` with this fix
- [x] Add tests to make sure empty `ColorRamp` methods don't throw exceptions

## Background

What we initially thought to be a problem with either `geotrellis-admin` or my ingesting process turned out to be an issue with how `ColorMap`s are created by `geotrellis-raster`. 

### Symptoms
The following is output from the `geotrellis-admin` server inside `docker-compose`:
```
adminserver_1  | [ERROR] [05/20/2016 16:52:04.572] [geotrellis-admin-server-akka.actor.default-dispatcher-5] [akka://geotrellis-admin-server/user/geotrellis-admin-service] Error during processing of request HttpRequest(GET,http://adminserver:8080/gt/tms/nlcd-tms-epsg3857-testing3/3/2/2?colorRamp=blue-to-yellow-to-red-heatmap&breaks=4d7ed1b2-7d99-48e7-bba9-ee963fcef49f&opacity=100,List(Host: adminserver:8080, Connection: close, User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0, Accept-Language: en-US, en;q=0.5, Accept-Encoding: gzip, deflate, DNT: 1, Referer: http://localhost:8090/, Cookie: CSRF-Token-RRKAZ=HPp-TrMarTjw5tv1ojV7FeVCpf0wciEF; firstVisit=1463754555964),Empty,HTTP/1.0)
adminserver_1  | java.lang.ArrayIndexOutOfBoundsException: 0
adminserver_1  |     at geotrellis.raster.render.ColorRamp$.spread(ColorRamp.scala:131)
adminserver_1  |     at geotrellis.raster.render.ColorRamp.stops(ColorRamp.scala:11)
adminserver_1  |     at geotrellis.raster.render.ColorMap$.apply(ColorMap.scala:94)
adminserver_1  |     at geotrellis.raster.render.ColorRamp.toColorMap(ColorRamp.scala:82)
adminserver_1  |     at geotrellis.admin.server.AdminRoutes$$anonfun$serveTile$1$$anonfun$apply$13$$anonfun$apply$14$$anonfun$apply$15.apply(AdminActor.scala:274)
adminserver_1  |     at geotrellis.admin.server.AdminRoutes$$anonfun$serveTile$1$$anonfun$apply$13$$anonfun$apply$14$$anonfun$apply$15.apply(AdminActor.scala:272)
...
```
I was seeing this any time I zoomed in or out while trying to read tiles from my recently ingested layer `nlcd-tms-epsg3857-testing3`.  Note that for this layer, while the values are int8, [we seem to have agreed](https://github.com/azavea/azavea-data-hub/issues/4) that the `NODATA` value for this data set is 0 instead of `Int.MinValue`. 

I have only ingested about 1/50th of the full dataset, and incidently we think the data I did ingest was entirely `NODATA`. 

### Diagnosis

From `geotrellis.admin.server.AdminRoutes.breaks`:

```scala
   /** Calculate and store class breaks for a layer, and yield a UUID that                                 
     * references the saved breaks. Necessary for a `/tms/...` call.                                      
     */
   def breaks = pathPrefix(Segment / IntNumber) { (layer, numBreaks) =>
     import DefaultJsonProtocol._
     complete {
       val data = reader.read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](layerId(layer))

       val breaks: Array[Double] = data.classBreaksDouble(numBreaks)
       val uuid: String = java.util.UUID.randomUUID.toString
       breaksStore(uuid)(breaks)
 
       JsObject("classBreaks" -> JsString(uuid))
     }
   } 
```
It turns out that `classBreaksDouble` yields an empty `Array` when `data` here is entirely `NODATA`. 

When serving a tile, the server attempts to contruct a `ColorMap` and then render a PNG. The empty class breaks from above propagate to here (`geotrellis.raster.render.ColorRamp`):
```scala
   def spread(colors: Vector[Int], n: Int): Vector[Int] = {
     if (colors.length == n) return colors

     val colors2 = new Array[Int](n)
     colors2(0) = colors(0)  // <-- This throws an exception because n = 0.

     val b = n - 1
     val color = colors.length - 1
     var i = 1
     while (i < n) {
       colors2(i) = colors(math.round(i.toDouble * color / b).toInt)
       i += 1
     }
     colors2.toVector
   }
```
The line indicated throws an exception.

### Considerations
**Assertion**: A layer of all `NODATA` exists in the set of valid layers at a given resolution (or as the identity element of the monoid of layers at some resolution), thus a user should be able to view a layer of entirely `NODATA` without being inundated with exceptions.

**Question**: Is it better to catch the empty class breaks like I'm doing, or alter the behaviour of the `classBreaks` method? For instance, to return a breaks Array of the length the requested, populated entirely with 0s.

