### PR TITLE
Add ETL option to specify upper zoom limit for raster layer ingestion

### DIFF
--- a/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
@@ -128,7 +128,7 @@ case class Etl(args: Seq[String], @transient modules: Seq[TypedModule] = Etl.def
         val reprojected = rdd.reproject(destCrs)
         val (zoom: Int, md: TileLayerMetadata[K]) = scheme match {
           case Left(layoutScheme) => maxZoom match {
-              case Some(zoom) =>  TileLayerMetadata.fromRdd(reprojected, ZoomedLayoutScheme(destCrs, conf.tileSize()), maxZoom)
+              case Some(zoom) =>  TileLayerMetadata.fromRdd(reprojected, ZoomedLayoutScheme(destCrs, conf.tileSize()), zoom)
               case _ => TileLayerMetadata.fromRdd(reprojected, layoutScheme)
             }
           case Right(layoutDefinition) =>
@@ -140,7 +140,7 @@ case class Etl(args: Seq[String], @transient modules: Seq[TypedModule] = Etl.def
 
       case BufferedReproject =>
         val (_, md) = maxZoom match {
-          case Some(zoom) =>  TileLayerMetadata.fromRdd(rdd, ZoomedLayoutScheme(destCrs, conf.tileSize()), maxZoom)
+          case Some(zoom) =>  TileLayerMetadata.fromRdd(rdd, ZoomedLayoutScheme(destCrs, conf.tileSize()), zoom)
           case _ => TileLayerMetadata.fromRdd(rdd, FloatingLayoutScheme(conf.tileSize()))
         }
         val amd = adjustCellType(md)

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/EtlConf.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/EtlConf.scala
@@ -79,6 +79,10 @@ class EtlConf(args: Seq[String]) extends ScallopConf(args){
                       descr = "pyramid layer on save (default: false)",
                       default = Some(false))
 
+  val maxZoom      = opt[Int]("maxZoom",
+                      descr = "max zoom level for layer tiles",
+                      default = Some(0))
+
   val outputProps  = props[String]('O',
                       descr = "parameters for output module")
 

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/EtlConf.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/EtlConf.scala
@@ -80,8 +80,7 @@ class EtlConf(args: Seq[String]) extends ScallopConf(args){
                       default = Some(false))
 
   val maxZoom      = opt[Int]("maxZoom",
-                      descr = "max zoom level for layer tiles",
-                      default = Some(0))
+                      descr = "max zoom level for layer tiles")(maxZoomConverter)
 
   val outputProps  = props[String]('O',
                       descr = "parameters for output module")
@@ -187,4 +186,23 @@ object EtlConf {
     val tag = typeTag[ReprojectMethod]
     val argType = org.rogach.scallop.ArgType.SINGLE
   }
+
+  def maxZoomConverter = new ValueConverter[Int] {
+    val wrong = Left("Zoom should be an integer greater than 0")
+    def parse(s : List[(String, List[String])]) = s match {
+      case (_, str :: Nil) :: Nil  =>
+        Try {str.toInt } match {
+          case Success(cs) => {
+            if (str.toInt > 0) Right(Some(str.toInt)) else wrong
+          }
+          case Failure(_) => wrong
+        }
+      case Nil  =>
+        Right(None)
+      case _ => wrong
+    }
+    val tag = typeTag[Int]
+    val argType = org.rogach.scallop.ArgType.SINGLE
+  }
+
 }

--- a/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
@@ -168,17 +168,39 @@ object TileLayerMetadata {
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
 
+  /**
+    * Compose Extents from given raster tiles and use [[ZoomedLayoutScheme]] to create the [[LayoutDefinition]].
+    */
   def fromRdd[
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
-  ](rdd: RDD[(K, V)], crs: CRS, scheme: ZoomedLayoutScheme, maxZoom: Option[Int] = None):
-  (Int, TileLayerMetadata[K2]) = {
-    val (extent, cellType, cellSize, bounds) = collectMetadata(rdd)
-    val LayoutLevel(zoom, layout) = maxZoom match {
-      case Some(zoom) => scheme.levelForZoom(maxZoom.get)
-      case _ => scheme.levelFor(extent, cellSize)
-    }
+  ](rdd: RDD[(K, V)], crs: CRS, scheme: ZoomedLayoutScheme):
+    (Int, TileLayerMetadata[K2]) =
+      _fromRdd[K, V, K2](rdd, crs, scheme, None)
+
+  /**
+    * Compose Extents from given raster tiles using [[ZoomedLayoutScheme]] and a maximum zoom value.
+    */
+  def fromRdd[
+    K: (? => TilerKeyMethods[K, K2]) ,
+    V <: CellGrid,
+    K2: SpatialComponent: Boundable
+  ](rdd: RDD[(K, V)], crs: CRS, scheme: ZoomedLayoutScheme, maxZoom: Int):
+    (Int, TileLayerMetadata[K2]) =
+      _fromRdd[K, V, K2](rdd, crs, scheme, Some(maxZoom))
+
+  private def _fromRdd[
+    K: (? => TilerKeyMethods[K, K2]) ,
+    V <: CellGrid,
+    K2: SpatialComponent: Boundable
+  ](rdd: RDD[(K, V)], crs: CRS, scheme: ZoomedLayoutScheme, maxZoom: Option[Int]):
+    (Int, TileLayerMetadata[K2]) = {
+      val (extent, cellType, cellSize, bounds) = collectMetadata(rdd)
+      val LayoutLevel(zoom, layout) = maxZoom match {
+        case Some(zoom) => scheme.levelForZoom(maxZoom.get)
+        case _ => scheme.levelFor(extent, cellSize)
+      }
     val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
@@ -199,7 +221,23 @@ object TileLayerMetadata {
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
-  ](rdd: RDD[(K, V)], scheme: ZoomedLayoutScheme, maxZoom: Option[Int] = None):
+  ](rdd: RDD[(K, V)],  scheme: ZoomedLayoutScheme):
+    (Int, TileLayerMetadata[K2]) =
+      _fromRdd[K, V, K2](rdd, scheme, None)
+
+  def fromRdd[
+    K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
+    V <: CellGrid,
+    K2: SpatialComponent: Boundable
+  ](rdd: RDD[(K, V)], scheme: ZoomedLayoutScheme, maxZoom: Int):
+    (Int, TileLayerMetadata[K2]) =
+      _fromRdd[K, V, K2](rdd, scheme, Some(maxZoom))
+
+  private def _fromRdd[
+    K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
+    V <: CellGrid,
+    K2: SpatialComponent: Boundable
+  ](rdd: RDD[(K, V)], scheme: ZoomedLayoutScheme, maxZoom: Option[Int]):
   (Int, TileLayerMetadata[K2]) = {
     val (extent, cellType, cellSize, bounds, crs) = collectMetadataWithCRS(rdd)
     val LayoutLevel(zoom, layout) = maxZoom match {

--- a/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
@@ -161,42 +161,50 @@ object TileLayerMetadata {
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
-  ](rdd: RDD[(K, V)], crs: CRS, scheme: LayoutScheme, maxZoom: Option[Int] = None): (Int, TileLayerMetadata[K2]) = {
+  ](rdd: RDD[(K, V)], crs: CRS, scheme: LayoutScheme): (Int, TileLayerMetadata[K2]) = {
     val (extent, cellType, cellSize, bounds) = collectMetadata(rdd)
-    val LayoutLevel(zoom, layout) = {
-      maxZoom match {
-        case Some(zoom) =>
-          scheme match {
-            case zoomedLayoutScheme: ZoomedLayoutScheme =>
-              zoomedLayoutScheme.levelForZoom(maxZoom.get)
-            case _ => throw new RuntimeException("ZoomedLayoutScheme required when setting a max zoom level")
-          }
-        case None =>
-          scheme.levelFor(extent, cellSize)
-      }
+    val LayoutLevel(zoom, layout) = scheme.levelFor(extent, cellSize)
+    val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
+    (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
+  }
+
+  def fromRdd[
+    K: (? => TilerKeyMethods[K, K2]) ,
+    V <: CellGrid,
+    K2: SpatialComponent: Boundable
+  ](rdd: RDD[(K, V)], crs: CRS, scheme: ZoomedLayoutScheme, maxZoom: Option[Int] = None):
+  (Int, TileLayerMetadata[K2]) = {
+    val (extent, cellType, cellSize, bounds) = collectMetadata(rdd)
+    val LayoutLevel(zoom, layout) = maxZoom match {
+      case Some(zoom) => scheme.levelForZoom(maxZoom.get)
+      case _ => scheme.levelFor(extent, cellSize)
     }
     val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
 
+  def fromRdd[
+    K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
+    V <: CellGrid,
+    K2: SpatialComponent: Boundable
+  ](rdd: RDD[(K, V)], scheme: LayoutScheme): (Int, TileLayerMetadata[K2]) = {
+    val (extent, cellType, cellSize, bounds, crs) = collectMetadataWithCRS(rdd)
+    val LayoutLevel(zoom, layout) = scheme.levelFor(extent, cellSize)
+    val GridBounds(colMin, rowMin, colMax, rowMax) = layout.mapTransform(extent)
+    val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
+    (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
+  }
 
   def fromRdd[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
-  ](rdd: RDD[(K, V)], scheme: LayoutScheme, maxZoom: Option[Int] = None): (Int, TileLayerMetadata[K2]) = {
+  ](rdd: RDD[(K, V)], scheme: ZoomedLayoutScheme, maxZoom: Option[Int] = None):
+  (Int, TileLayerMetadata[K2]) = {
     val (extent, cellType, cellSize, bounds, crs) = collectMetadataWithCRS(rdd)
-    val LayoutLevel(zoom, layout) = {
-      maxZoom match {
-        case Some(zoom) =>
-          scheme match {
-            case zoomedLayoutScheme: ZoomedLayoutScheme =>
-              zoomedLayoutScheme.levelForZoom(maxZoom.get)
-            case _ => throw new RuntimeException("ZoomedLayoutScheme required when setting a max zoom level")
-          }
-        case None =>
-          scheme.levelFor(extent, cellSize)
-      }
+    val LayoutLevel(zoom, layout) = maxZoom match {
+      case Some(zoom) => scheme.levelForZoom(maxZoom.get)
+      case _ => scheme.levelFor(extent, cellSize)
     }
     val GridBounds(colMin, rowMin, colMax, rowMax) = layout.mapTransform(extent)
     val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))

--- a/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
@@ -161,20 +161,23 @@ object TileLayerMetadata {
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
-  ](rdd: RDD[(K, V)], crs: CRS, scheme: LayoutScheme): (Int, TileLayerMetadata[K2]) = {
+  ](rdd: RDD[(K, V)], crs: CRS, scheme: LayoutScheme, maxZoom: Int = 0): (Int, TileLayerMetadata[K2]) = {
     val (extent, cellType, cellSize, bounds) = collectMetadata(rdd)
-    val LayoutLevel(zoom, layout) = scheme.levelFor(extent, cellSize)
+    val LayoutLevel(zoom, layout) = (if (maxZoom > 0) scheme.asInstanceOf[ZoomedLayoutScheme].levelForZoom(maxZoom)
+      else scheme.levelFor(extent, cellSize))
     val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
+
 
   def fromRdd[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
-  ](rdd: RDD[(K, V)], scheme: LayoutScheme): (Int, TileLayerMetadata[K2]) = {
+  ](rdd: RDD[(K, V)], scheme: LayoutScheme, maxZoom: Int = 0): (Int, TileLayerMetadata[K2]) = {
     val (extent, cellType, cellSize, bounds, crs) = collectMetadataWithCRS(rdd)
-    val LayoutLevel(zoom, layout) = scheme.levelFor(extent, cellSize)
+    val LayoutLevel(zoom, layout) = (if (maxZoom > 0) scheme.asInstanceOf[ZoomedLayoutScheme].levelForZoom(maxZoom)
+      else scheme.levelFor(extent, cellSize))
     val GridBounds(colMin, rowMin, colMax, rowMax) = layout.mapTransform(extent)
     val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))


### PR DESCRIPTION
This PR addresses https://github.com/geotrellis/geotrellis/issues/1484 by adding an optional "maxZoom" argument to ETLConf (with a default value of 0), and modifies both the Etl and TileLayerMetadata classes to handle that option.

In testing with the Chattanooga demo however, setting maxZoom levels above 10 often led to the ingestion process being killed due to lack of memory.  Increasing VM memory to 6 GB, and the memory available to the ingestion process to 4 GB, allowed the ingestion process to succeed up to zoom level 12.