### PR TITLE
Add ability to specify number of streaming buckets

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/histogram/StreamingHistogramSpec.scala
@@ -270,4 +270,13 @@ class StreamingHistogramSpec extends FunSpec with Matchers {
 
   }
 
+  it("should allow the bucket count to be parameterized") {
+    val tile = IntArrayTile(1 to 250*250 toArray, 250, 250)
+
+    val default = tile.histogramDouble()
+    val custom = tile.histogramDouble(200)
+
+    default.statistics should not be (custom.statistics)
+  }
+
 }

--- a/raster/src/main/scala/geotrellis/raster/summary/SummaryMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/SummaryMethods.scala
@@ -30,7 +30,7 @@ trait SummaryMethods extends MethodExtensions[Tile] {
     * Create a histogram from double values in a raster.
     */
   def histogramDouble(numBuckets: Int): Histogram[Double] =
-    StreamingHistogram.fromTile(self)
+    StreamingHistogram.fromTile(self, numBuckets)
 
   /**
     * Generate quantile class breaks for a given raster.


### PR DESCRIPTION
A paramater was unused in for streaming histograms, this should rectify that