### PR TITLE
SparkContext temporal GeoTiff format args

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopSparkContextMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopSparkContextMethods.scala
@@ -53,13 +53,22 @@ trait HadoopSparkContextMethods {
   def hadoopTemporalGeoTiffRDD(path: Path, tiffExtension: String): RDD[(TemporalProjectedExtent, Tile)] =
     hadoopTemporalGeoTiffRDD(path, Seq(tiffExtension))
 
-  def hadoopTemporalGeoTiffRDD(path: Path, tiffExtensions: Seq[String]): RDD[(TemporalProjectedExtent, Tile)] =
+  def hadoopTemporalGeoTiffRDD(
+    path: Path,
+    tiffExtensions: Seq[String] = defaultTiffExtensions,
+    timeTag: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_TAG_DEFAULT,
+    timeFormat: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT
+  ): RDD[(TemporalProjectedExtent, Tile)] = {
+    val conf = sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions)
+    TemporalGeoTiffInputFormat.setTimeTag(conf, timeTag)
+    TemporalGeoTiffInputFormat.setTimeFormat(conf, timeFormat)
     sc.newAPIHadoopRDD(
-      sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions),
+      conf,
       classOf[TemporalGeoTiffInputFormat],
       classOf[TemporalProjectedExtent],
       classOf[Tile]
     )
+  }
 
   def hadoopMultibandGeoTiffRDD(path: String): RDD[(ProjectedExtent, MultibandTile)] =
     hadoopMultibandGeoTiffRDD(new Path(path), defaultTiffExtensions)
@@ -87,13 +96,22 @@ trait HadoopSparkContextMethods {
   def hadoopTemporalMultibandGeoTiffRDD(path: String, tiffExtensions: Seq[String]): RDD[(TemporalProjectedExtent, MultibandTile)] =
     hadoopTemporalMultibandGeoTiffRDD(new Path(path), tiffExtensions)
 
-  def hadoopTemporalMultibandGeoTiffRDD(path: Path, tiffExtensions: Seq[String] = defaultTiffExtensions): RDD[(TemporalProjectedExtent, MultibandTile)] =
+  def hadoopTemporalMultibandGeoTiffRDD(
+    path: Path,
+    tiffExtensions: Seq[String] = defaultTiffExtensions,
+    timeTag: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_TAG_DEFAULT,
+    timeFormat: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT
+  ): RDD[(TemporalProjectedExtent, MultibandTile)] = {
+    val conf = sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions)
+    TemporalGeoTiffInputFormat.setTimeTag(conf, timeTag)
+    TemporalGeoTiffInputFormat.setTimeFormat(conf, timeFormat)
     sc.newAPIHadoopRDD(
-      sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions),
+      conf,
       classOf[TemporalMultibandGeoTiffInputFormat],
       classOf[TemporalProjectedExtent],
       classOf[MultibandTile]
     )
+  }
 
   def newJob: Job =
     Job.getInstance(sc.hadoopConfiguration)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalGeoTiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalGeoTiffInputFormat.scala
@@ -13,7 +13,9 @@ import org.joda.time.format._
 
 object TemporalGeoTiffInputFormat {
   final val GEOTIFF_TIME_TAG = "GEOTIFF_TIME_TAG"
+  final val GEOTIFF_TIME_TAG_DEFAULT = "TIFFTAG_DATETIME"
   final val GEOTIFF_TIME_FORMAT = "GEOTIFF_TIME_FORMAT"
+  final val GEOTIFF_TIME_FORMAT_DEFAULT = "YYYY:MM:dd HH:mm:ss"
 
   def setTimeTag(job: JobContext, timeTag: String): Unit =
     setTimeTag(job.getConfiguration, timeTag)
@@ -28,11 +30,11 @@ object TemporalGeoTiffInputFormat {
     conf.set(GEOTIFF_TIME_FORMAT, timeFormat)
 
   def getTimeTag(job: JobContext) =
-    job.getConfiguration.get(GEOTIFF_TIME_TAG, "TIFFTAG_DATETIME")
+    job.getConfiguration.get(GEOTIFF_TIME_TAG, GEOTIFF_TIME_TAG_DEFAULT )
 
   def getTimeFormatter(job: JobContext): DateTimeFormatter = {
     val df = job.getConfiguration.get(GEOTIFF_TIME_FORMAT)
-    if(df == null) { DateTimeFormat.forPattern("YYYY:MM:dd HH:mm:ss") }
+    if(df == null) { DateTimeFormat.forPattern(GEOTIFF_TIME_FORMAT_DEFAULT) }
     else { DateTimeFormat.forPattern(df) }
   }
 }


### PR DESCRIPTION
To read temporal GeoTiffs we need to specify the tag and date format, which is not standard. Without this fix there is no way to do this outside using `TemporalGeoTiffInputFormat`. This PR adds the two required arguments to the extension methods on `SparkContext` with default values.