### PR TITLE
Add detail to avro exception message

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/avro/AvroEncoder.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/AvroEncoder.scala
@@ -53,7 +53,13 @@ object AvroEncoder {
     val reader = new GenericDatumReader[GenericRecord](writerSchema, schema)
     val decoder = DecoderFactory.get().binaryDecoder(decompress(bytes), null)
     val rec = reader.read(null.asInstanceOf[GenericRecord], decoder)
-    format.decode(rec)
+    try {
+      format.decode(rec)
+    } catch {
+      case e: AvroTypeException =>
+        throw new AvroTypeException(e.getMessage + ". " +
+          "If attempting to read multiband tiles, a Reader[K, MultibandTile] is required rather than Reader[K, Tile]. Check to ensure your Reader instance is properly configured.")
+    }
   }
 
   def toJson[T: AvroRecordCodec](thing: T): String = {
@@ -75,6 +81,12 @@ object AvroEncoder {
     val reader = new GenericDatumReader[GenericRecord](schema)
     val decoder = DecoderFactory.get().jsonDecoder(schema, json)
     val rec = reader.read(null.asInstanceOf[GenericRecord], decoder)
-    format.decode(rec)
+    try {
+      format.decode(rec)
+    } catch {
+      case e: AvroTypeException =>
+        throw new AvroTypeException(e.getMessage + ". " +
+          "If attempting to read multiband tiles, a Reader[K, MultibandTile] is required rather than Reader[K, Tile]. Check to ensure your Reader instance is properly configured.")
+    }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/avro/AvroEncoder.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/AvroEncoder.scala
@@ -52,13 +52,13 @@ object AvroEncoder {
 
     val reader = new GenericDatumReader[GenericRecord](writerSchema, schema)
     val decoder = DecoderFactory.get().binaryDecoder(decompress(bytes), null)
-    val rec = reader.read(null.asInstanceOf[GenericRecord], decoder)
     try {
+      val rec = reader.read(null.asInstanceOf[GenericRecord], decoder)
       format.decode(rec)
     } catch {
       case e: AvroTypeException =>
         throw new AvroTypeException(e.getMessage + ". " +
-          "If attempting to read multiband tiles, a Reader[K, MultibandTile] is required rather than Reader[K, Tile]. Check to ensure your Reader instance is properly configured.")
+          "This can be caused by using a type parameter which doesn't match the object being deserialized.")
     }
   }
 
@@ -80,13 +80,13 @@ object AvroEncoder {
 
     val reader = new GenericDatumReader[GenericRecord](schema)
     val decoder = DecoderFactory.get().jsonDecoder(schema, json)
-    val rec = reader.read(null.asInstanceOf[GenericRecord], decoder)
     try {
+      val rec = reader.read(null.asInstanceOf[GenericRecord], decoder)
       format.decode(rec)
     } catch {
       case e: AvroTypeException =>
         throw new AvroTypeException(e.getMessage + ". " +
-          "If attempting to read multiband tiles, a Reader[K, MultibandTile] is required rather than Reader[K, Tile]. Check to ensure your Reader instance is properly configured.")
+          "This can be caused by using a type parameter which doesn't match the object being deserialized.")
     }
   }
 }


### PR DESCRIPTION
This PR adds a little bit of information necessary to properly understand why the Avro decoding process fails in some circumstances and is a response to #1477

The new error looks something like:
```scala
org.apache.avro.AvroTypeException: Found geotrellis.raster.ByteArrayTile, expecting geotrellis.raster.ArrayMultibandTile, missing required field bands. If attempting to read multiband tiles, use a Reader[K, MultibandTile] rather than Reader[K, Tile]
```