### PR TITLE
Add local publishing script for Scala 2.11

### DIFF
--- a/scripts/publish-local-211.sh
+++ b/scripts/publish-local-211.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Publish local for Scala 2.11
+./sbt -211 "project macros" publish-local && \
+./sbt -211 "project vector" publish-local && \
+./sbt -211 "project proj4" publish-local && \
+./sbt -211 "project raster" publish-local && \
+./sbt -211 "project spark" publish-local && \
+./sbt -211 "project s3" publish-local && \
+./sbt -211 "project accumulo" publish-local && \
+./sbt -211 "project spark-etl" publish-local && \
+./sbt -211 "project shapefile" publish-local && \
+./sbt -211 "project slick" publish-local && \
+./sbt -211 "project util" publish-local && \
+./sbt -211 "project raster-testkit" publish-local && \
+./sbt -211 "project vector-testkit" publish-local && \
+./sbt -211 "project spark-testkit" publish-local


### PR DESCRIPTION
For local publishing when you know you only need it for Scala 2.11. Faster than using `publish-local-crossversion.sh`.