### PR TITLE
ColorMap => String

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/render/ColorMapSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/render/ColorMapSpec.scala
@@ -70,6 +70,23 @@ class ColorMapSpec extends FunSpec with Matchers
     }
   }
 
+  describe("ColorMaps to-and-from Strings") {
+    val s = "23:cc00ccff;30:aa00aaff;120:ff0000ff"
+    val sD = "23.0:cc00ccff;30.0:aa00aaff;120.0:ff0000ff"
+
+    it("fromString should parse correctly") {
+      ColorMap.fromString(s) shouldBe defined
+    }
+
+    it("(int) fromString and breaksString should form an isomorphism") {
+      ColorMap.fromString(s).get.breaksString shouldBe s
+    }
+
+    it("(double) fromString and breaksString should form an isomorphism") {
+      ColorMap.fromStringDouble(sD).get.breaksString shouldBe sD
+    }
+  }
+
   describe("PNG Color Mapping") {
     it("should correctly map values to colors") {
       val limits = Array(25,50,80,100)

--- a/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
@@ -264,7 +264,7 @@ class IntColorMap(breaksToColors: Map[Int, Int], val options: Options = Options.
     new IntCachedColorMap(orderedColors, ch, options)
   }
 
-  lazy val breaksString: String = {
+  def breaksString: String = {
     breaksToColors
       .toStream
       .map({ case (k,v) => s"${k}:${Integer.toHexString(v)}"})
@@ -381,7 +381,7 @@ class DoubleColorMap(breaksToColors: Map[Double, Int], val options: Options = Op
   def withBoundaryType(classBoundaryType: ClassBoundaryType): ColorMap =
     new DoubleColorMap(breaksToColors, options.copy(classBoundaryType = classBoundaryType))
 
-  lazy val breaksString: String = {
+  def breaksString: String = {
     breaksToColors
       .toStream
       .map({ case (k,v) => s"${k}:${Integer.toHexString(v)}"})

--- a/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
@@ -206,8 +206,6 @@ class IntColorMap(breaksToColors: Map[Int, Int], val options: Options = Options.
 
   private lazy val orderedColors: Vector[Int] = orderedBreaks.map(breaksToColors(_))
   lazy val colors = orderedColors
-  lazy val breaksMap = breaksToColors
-  lazy val breaksMapDouble = Map.empty[Double,Int]
 
   private val zCheck: (Int, Int) => Boolean =
     options.classBoundaryType match {
@@ -282,9 +280,6 @@ class IntCachedColorMap(val colors: Vector[Int], h: Histogram[Int], val options:
     extends ColorMap {
   val noDataColor = options.noDataColor
 
-  lazy val breaksMap = Map.empty[Int,Int]
-  lazy val breaksMapDouble = Map.empty[Double,Int]
-
   def map(z: Int): Int = { if(isNoData(z)) noDataColor else h.itemCount(z).toInt }
 
   def mapDouble(z: Double): Int = map(d2i(z))
@@ -334,8 +329,6 @@ class DoubleColorMap(breaksToColors: Map[Double, Int], val options: Options = Op
 
   private val orderedColors: Vector[Int] = orderedBreaks.map(breaksToColors(_))
   lazy val colors = orderedColors
-  lazy val breaksMap = Map.empty[Int,Int]
-  lazy val breaksMapDouble = breaksToColors
 
   private val zCheck: (Double, Int) => Boolean =
     options.classBoundaryType match {

--- a/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
@@ -143,6 +143,15 @@ object ColorMap {
     }.toOption
   }
 
+  /** Retrieve a "breaks string" from [[ColorMap]] data.
+    * The opposite of the [[fromString]] methods.
+    */
+  def breaksString[T <: AnyVal](breaksToColors: Map[T, Int]): String = {
+    breaksToColors
+      .toStream
+      .map({ case (k,v) => s"${k}:${Integer.toHexString(v)}"})
+      .mkString(";")
+  }
 }
 
 import ColorMap.Options
@@ -187,6 +196,10 @@ trait ColorMap extends Serializable {
   def withNoDataColor(color: Int): ColorMap
   def withFallbackColor(color: Int): ColorMap
   def withBoundaryType(classBoundaryType: ClassBoundaryType): ColorMap
+
+  // Temporary hack?
+  def breaksMap: Map[Int, Int]
+  def breaksMapDouble: Map[Double, Int]
 }
 
 class IntColorMap(breaksToColors: Map[Int, Int], val options: Options = Options.DEFAULT) extends ColorMap {
@@ -202,6 +215,8 @@ class IntColorMap(breaksToColors: Map[Int, Int], val options: Options = Options.
 
   private lazy val orderedColors: Vector[Int] = orderedBreaks.map(breaksToColors(_))
   lazy val colors = orderedColors
+  lazy val breaksMap = breaksToColors
+  lazy val breaksMapDouble = Map.empty[Double,Int]
 
   private val zCheck: (Int, Int) => Boolean =
     options.classBoundaryType match {
@@ -269,6 +284,9 @@ class IntCachedColorMap(val colors: Vector[Int], h: Histogram[Int], val options:
     extends ColorMap {
   val noDataColor = options.noDataColor
 
+  lazy val breaksMap = Map.empty[Int,Int]
+  lazy val breaksMapDouble = Map.empty[Double,Int]
+
   def map(z: Int): Int = { if(isNoData(z)) noDataColor else h.itemCount(z).toInt }
 
   def mapDouble(z: Double): Int = map(d2i(z))
@@ -310,6 +328,8 @@ class DoubleColorMap(breaksToColors: Map[Double, Int], val options: Options = Op
 
   private val orderedColors: Vector[Int] = orderedBreaks.map(breaksToColors(_))
   lazy val colors = orderedColors
+  lazy val breaksMap = Map.empty[Int,Int]
+  lazy val breaksMapDouble = breaksToColors
 
   private val zCheck: (Double, Int) => Boolean =
     options.classBoundaryType match {

--- a/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
@@ -188,7 +188,7 @@ trait ColorMap extends Serializable {
   def withBoundaryType(classBoundaryType: ClassBoundaryType): ColorMap
 
   /** Retrieve a "breaks string" from [[ColorMap]] data.
-    * The opposite of the [[fromString]] methods.
+    * The opposite of the [[ColorMap.fromString]] methods.
     */
   def breaksString: String
 }


### PR DESCRIPTION
## TODO
- [x] Basic functionality
- [x] Move `breaksString` into trait and inherit
- [x] Special definition for `IntCachedColorMap`
- [x] Tests

## Motivation
When using the `render` output module in the ETL process, one must provide a `breaks` argument, or all tiles will be rendered grayscale. Example:

```console
--output render -O encoding=png path=file:///home/colin/tiles/{name}/{z}-{x}-{y}.png breaks="23:cc00ccff;30:aa00aaff;120:ff0000ff"
```
The problem is that for datasets which don't have well-defined colour breaks ahead of time like `nlcd`, there's no way to know what your break string should be for input into ETL. A `ColorMap` object can be created easily given `RDD.colorBreaks` and then rendered to a PNG within Scala code, but there is no way to know what `String` would represent that `ColorMap` from the outside. This chicken-and-egg problem requires a greater fix to how ETL accepts breaks information from the outside, but this is a start. 
