### PR TITLE
[WIP] GeoTiff Stream Reader Development

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import UnidocKeys._
 
 lazy val commonSettings = Seq(
-  version := "10.1-SNAPSHOT",
+  version := "10.1.1-SNAPSHOT",
   scalaVersion := Version.scala,
   crossScalaVersions := Version.crossScala,
   description := Info.description,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import UnidocKeys._
 
 lazy val commonSettings = Seq(
-  version := "10.1.1-SNAPSHOT",
+  version := "10.1.1.1-SNAPSHOT",
   scalaVersion := Version.scala,
   crossScalaVersions := Version.crossScala,
   description := Info.description,
@@ -65,9 +65,7 @@ lazy val root = Project("geotrellis", file(".")).
     sparkEtl,
     s3,
     accumulo,
-    slick,
-    util,
-    macros
+    slick
   ).
   settings(commonSettings: _*).
   settings(

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import UnidocKeys._
 
 lazy val commonSettings = Seq(
-  version := "10.1.1.1-SNAPSHOT",
+  version := Version.geotrellis,
   scalaVersion := Version.scala,
   crossScalaVersions := Version.crossScala,
   description := Info.description,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import UnidocKeys._
 
 lazy val commonSettings = Seq(
-  version := Version.geotrellis,
+  version := "10.1-SNAPSHOT",
   scalaVersion := Version.scala,
   crossScalaVersions := Version.crossScala,
   description := Info.description,
@@ -65,7 +65,9 @@ lazy val root = Project("geotrellis", file(".")).
     sparkEtl,
     s3,
     accumulo,
-    slick
+    slick,
+    util,
+    macros
   ).
   settings(commonSettings: _*).
   settings(

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -49,7 +49,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading an ESRI generated Float32 geotiff with 0 NoData value") {
     it("matches an arg produced from geotrellis.gdal reader of that tif") {
-      val tile = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri.tif")).convert(FloatConstantNoDataCellType)
+      val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath("us_ext_clip_esri.tif")).convert(FloatConstantNoDataCellType)
 
       val expectedTile =
         ArgReader.read(geoTiffPath("us_ext_clip_esri.json")).tile
@@ -65,7 +65,7 @@ class GeoTiffReaderSpec extends FunSpec
       val path = "slope.tif"
       val argPath = s"$baseDataPath/data/slope.json"
 
-      val tile = SinglebandGeoTiff.compressed(s"$baseDataPath/$path").convert(FloatConstantNoDataCellType)
+      val tile = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/$path").convert(FloatConstantNoDataCellType)
 
       val expectedTile =
         ArgReader.read(argPath).tile
@@ -77,56 +77,56 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading modelTransformation.tiff") {
     val path = "modelTransformation.tiff"
-    val compressed: SinglebandGeoTiff = SinglebandGeoTiff.compressed(geoTiffPath(path))
-    val tile = compressed.tile
+    val streamCompressed: SinglebandGeoTiff = SinglebandGeoTiff.streamCompressed(geoTiffPath(path))
+    val tile = streamCompressed.tile
     val bounds = tile.gridBounds
     bounds.width should be (1121)
 
     import Tolerance._
-    compressed.crs should be (CRS.fromName("EPSG:4326"))
-    if(compressed.extent.min.distance(Point(59.9955397,  30.0044603))>0.0001) {
-      compressed.extent.min should be (Point(59.9955397,  30.0044603))
+    streamCompressed.crs should be (CRS.fromName("EPSG:4326"))
+    if(streamCompressed.extent.min.distance(Point(59.9955397,  30.0044603))>0.0001) {
+      streamCompressed.extent.min should be (Point(59.9955397,  30.0044603))
     }
 
-    if(compressed.extent.max.distance(Point(69.9955397,  40.0044603))>0.0001) {
-      compressed.extent.max should be (Point(69.9955397,  40.0044603))
+    if(streamCompressed.extent.max.distance(Point(69.9955397,  40.0044603))>0.0001) {
+      streamCompressed.extent.max should be (Point(69.9955397,  40.0044603))
     }
 
   }
 
-  describe("reading compressed file must yield same image array as uncompressed file") {
+  describe("reading streamCompressed file must yield same image array as uncompressed file") {
 
-    it("must read econic_lzw.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_lzw.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
-
-      assertEqual(decomp.tile, uncomp.tile)
-    }
-
-    it("must read econic_zlib.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
+    it("must read econic_lzw.tif and match unstreamCompressed file") {
+      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_lzw.tif"))
+      val uncomp = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
-    it("must read econic_zlib_tiled.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib_tiled.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
+    it("must read econic_zlib.tif and match unstreamCompressed file") {
+      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_zlib.tif"))
+      val uncomp = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
-    it("must read econic_zlib_tiled_bandint.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib_tiled_bandint.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
+    it("must read econic_zlib_tiled.tif and match unstreamCompressed file") {
+      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_zlib_tiled.tif"))
+      val uncomp = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
-    it("must read all-ones.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("all-ones.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(geoTiffPath("all-ones-no-comp.tif"))
+    it("must read econic_zlib_tiled_bandint.tif and match unstreamCompressed file") {
+      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_zlib_tiled_bandint.tif"))
+      val uncomp = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif")
+
+      assertEqual(decomp.tile, uncomp.tile)
+    }
+
+    it("must read all-ones.tif and match unstreamCompressed file") {
+      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("all-ones.tif"))
+      val uncomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("all-ones-no-comp.tif"))
 
       assertEqual(decomp.tile, uncomp.tile)
     }
@@ -135,8 +135,8 @@ class GeoTiffReaderSpec extends FunSpec
   describe("reading tiled file must yield same image as strip files") {
 
     it("must read us_ext_clip_esri.tif and match strip file") {
-      val tiled = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri.tif"))
-      val striped = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri_stripes.tif"))
+      val tiled = SinglebandGeoTiff.streamCompressed(geoTiffPath("us_ext_clip_esri.tif"))
+      val striped = SinglebandGeoTiff.streamCompressed(geoTiffPath("us_ext_clip_esri_stripes.tif"))
 
       assertEqual(tiled.tile, striped.tile)
     }
@@ -145,22 +145,22 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading bit rasters") {
     it("should match bit tile the ArrayTile pulled out of the resulting GeoTiffTile") {
-      val expected = SinglebandGeoTiff.compressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile.toArrayTile
+      val expected = SinglebandGeoTiff.streamCompressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile
+      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile.toArrayTile
 
       assertEqual(actual, expected)
       assertEqual(expected, actual)
     }
 
     it("must read bilevel_tiled.tif and match strip file") {
-      val tiled = SinglebandGeoTiff.compressed(geoTiffPath("bilevel_tiled.tif"))
-      val striped = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif"))
+      val tiled = SinglebandGeoTiff.streamCompressed(geoTiffPath("bilevel_tiled.tif"))
+      val striped = SinglebandGeoTiff.streamCompressed(geoTiffPath("bilevel.tif"))
 
       assertEqual(tiled.tile, striped.tile)
     }
 
     it("should match bit and byte-converted rasters") {
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).tile
+      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("bilevel.tif")).tile
       val expected = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile.convert(BitCellType)
 
       assertEqual(actual, expected)
@@ -272,7 +272,7 @@ class GeoTiffReaderSpec extends FunSpec
   describe("reads GeoTiff CRS correctly") {
 
     it("should read slope.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(s"$baseDataPath/slope.tif")crs
+      val crs = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/slope.tif")crs
 
       val correctCRS = CRS.fromString("+proj=utm +zone=10 +datum=NAD27 +units=m +no_defs")
 
@@ -280,7 +280,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read aspect.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(s"$baseDataPath/aspect.tif").crs
+      val crs = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/aspect.tif").crs
 
       val correctProj4String = "+proj=lcc +lat_1=36.16666666666666 +lat_2=34.33333333333334 +lat_0=33.75 +lon_0=-79 +x_0=609601.22 +y_0=0 +datum=NAD83 +units=m +no_defs"
 
@@ -290,7 +290,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read econic.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif").crs
+      val crs = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif").crs
 
       val correctProj4String = "+proj=eqdc +lat_0=33.76446202777777 +lon_0=-117.4745428888889 +lat_1=33.90363402777778 +lat_2=33.62529002777778 +x_0=0 +y_0=0 +datum=NAD27 +units=m +no_defs"
 
@@ -300,7 +300,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read bilevel.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).crs
+      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("bilevel.tif")).crs
 
       val correctProj4String = "+proj=tmerc +lat_0=0 +lon_0=-3.45233333 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +units=m +no_defs"
 
@@ -310,7 +310,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read all-ones.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("all-ones.tif")).crs
+      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("all-ones.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
 
@@ -318,14 +318,14 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read colormap.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("colormap.tif")).crs
+      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("colormap.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
       crs should equal(correctCRS)
     }
 
     it("should read us_ext_clip_esri.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri.tif")).crs
+      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("us_ext_clip_esri.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
 
@@ -333,7 +333,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read ndvi-web-mercator.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("ndvi-web-mercator.tif")).crs
+      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("ndvi-web-mercator.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs")
 
@@ -341,7 +341,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read ny-state-plane.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("ny-state-plane.tif")).crs
+      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("ny-state-plane.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=tmerc +lat_0=40 +lon_0=-74.33333333333333 +k=0.999966667 +x_0=152400.3048006096 +y_0=0 +datum=NAD27 +units=us-ft +no_defs ")
 
@@ -349,7 +349,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read alaska-polar-3572.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("alaska-polar-3572.tif")).crs
+      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("alaska-polar-3572.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=laea +lat_0=90 +lon_0=-150 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ")
       crs.toProj4String should equal(correctCRS.toProj4String)
@@ -362,7 +362,7 @@ class GeoTiffReaderSpec extends FunSpec
     val MeanEpsilon = 1e-8
 
     def testMinMaxAndMean(min: Double, max: Double, mean: Double, file: String) {
-      val SinglebandGeoTiff(tile, extent, _, _, _) = SinglebandGeoTiff.compressed(s"$baseDataPath/$file")
+      val SinglebandGeoTiff(tile, extent, _, _, _) = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/$file")
 
       tile.polygonalMax(extent, extent.toPolygon) should be (max)
       tile.polygonalMin(extent, extent.toPolygon) should be (min)
@@ -388,7 +388,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff without GeoKey Directory correctly") {
-      val SinglebandGeoTiff(tile, extent, crs, _, _) = SinglebandGeoTiff.compressed(geoTiffPath("no-geokey-dir.tif"))
+      val SinglebandGeoTiff(tile, extent, crs, _, _) = SinglebandGeoTiff.streamCompressed(geoTiffPath("no-geokey-dir.tif"))
 
       crs should be (LatLng)
       extent should be (Extent(307485, 3911490, 332505, 3936510))
@@ -401,7 +401,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff with tags") {
-      val tags = SinglebandGeoTiff.compressed(geoTiffPath("tags.tif")).tags.headTags
+      val tags = SinglebandGeoTiff.streamCompressed(geoTiffPath("tags.tif")).tags.headTags
 
       tags("TILE_COL") should be ("6")
       tags("units") should be ("kg m-2 s-1")
@@ -411,7 +411,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff with no extent data correctly") {
-      val Raster(tile, extent) = SinglebandGeoTiff.compressed(geoTiffPath("tags.tif")).raster
+      val Raster(tile, extent) = SinglebandGeoTiff.streamCompressed(geoTiffPath("tags.tif")).raster
 
       extent should be (Extent(0, 0, tile.cols, tile.rows))
     }
@@ -452,7 +452,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff with ZLIB compression and needs exact segment sizes") {
-      val geoTiff = SinglebandGeoTiff.compressed(geoTiffPath("nex-pr-tile.tif"))
+      val geoTiff = SinglebandGeoTiff.streamCompressed(geoTiffPath("nex-pr-tile.tif"))
 
       val tile = geoTiff.tile
       cfor(0)(_ < tile.rows, _ + 1) { row =>
@@ -464,13 +464,13 @@ class GeoTiffReaderSpec extends FunSpec
 
     it("should read clipped GeoTiff with byte NODATA value") {
       // Conversions carried out for both of these; first for byte -> float, second for user defined no data to constant
-      val geoTiff = SinglebandGeoTiff.compressed(geoTiffPath("nodata-tag-byte.tif")).convert(FloatConstantNoDataCellType)
-      val geoTiff2 = SinglebandGeoTiff.compressed(geoTiffPath("nodata-tag-float.tif")).convert(FloatConstantNoDataCellType)
+      val geoTiff = SinglebandGeoTiff.streamCompressed(geoTiffPath("nodata-tag-byte.tif")).convert(FloatConstantNoDataCellType)
+      val geoTiff2 = SinglebandGeoTiff.streamCompressed(geoTiffPath("nodata-tag-float.tif")).convert(FloatConstantNoDataCellType)
       assertEqual(geoTiff.toArrayTile, geoTiff2)
     }
 
     it("should read NODATA string with length = 4") {
-      val geoTiff = SinglebandGeoTiff.compressed(s"$baseDataPath/sbn/SBN_inc_percap-nodata-clip.tif")
+      val geoTiff = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/sbn/SBN_inc_percap-nodata-clip.tif")
       geoTiff.tile.cellType should be (ByteConstantNoDataCellType)
     }
   }
@@ -480,7 +480,7 @@ class GeoTiffReaderSpec extends FunSpec
     val path = temp.getPath()
 
     it("must read a tif, change the pixel sample type, write it out, and then read the correct in") {
-      val gt = SinglebandGeoTiff.compressed(s"$baseDataPath/slope.tif")
+      val gt = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/slope.tif")
       var headTags = gt.tags.headTags
       assert(headTags(Tags.AREA_OR_POINT) == "AREA")
       headTags -= Tags.AREA_OR_POINT
@@ -489,20 +489,20 @@ class GeoTiffReaderSpec extends FunSpec
       val gt2 = gt.copy(tags = tags)
       writer.GeoTiffWriter.write(gt2, path)
       addToPurge(path)
-      val gt3 = SinglebandGeoTiff.compressed(path)
+      val gt3 = SinglebandGeoTiff.streamCompressed(path)
 
       gt3.tags.headTags.get(Tags.AREA_OR_POINT) should be (Some("POINT"))
     }
 
     it("must read a tif, set a datetime, write it out, and then read the correct in") {
-      val gt = SinglebandGeoTiff.compressed(s"$baseDataPath/reproject/nlcd_tile_wsg84.tif")
+      val gt = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/reproject/nlcd_tile_wsg84.tif")
       var headTags = gt.tags.headTags
       headTags += ((Tags.TIFFTAG_DATETIME, "1988:02:18 13:59:59"))
       val tags = Tags(headTags, gt.tags.bandTags)
       val gt2 = gt.copy(tags = tags)
       writer.GeoTiffWriter.write(gt2, path)
       addToPurge(path)
-      val gt3 = SinglebandGeoTiff.compressed(path)
+      val gt3 = SinglebandGeoTiff.streamCompressed(path)
       assert(gt3.crs == LatLng)
 
       gt3.tags.headTags.get(Tags.TIFFTAG_DATETIME) should be (Some("1988:02:18 13:59:59"))
@@ -511,8 +511,22 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("handling special CRS cases") {
     it("can handle an ESRI written GeoTiff in WebMercator") {
-      val tif = SinglebandGeoTiff.compressed(s"$baseDataPath/propval_bg_01_01.tif")
+      val tif = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/propval_bg_01_01.tif")
       tif.crs should be (WebMercator)
+    }
+  }
+
+  describe("reading a tiff file with GeoTiffStreamReader") {
+    it("can load the file") {
+      val tif = GeoTiffStreamReader.readSingleband("../data/test.TIF")
+      tif.extent should be (Extent(394800.0, 4346070.0, 627030.0, 4582500.0))
+    }
+  }
+  
+  describe("reading a singleband tif with streamCompressed") {
+    it("can load the file") {
+      val tif = SinglebandGeoTiff.streamCompressed("../data/test.TIF")
+      tif.extent should be (Extent(394800.0, 4346070.0, 627030.0, 4582500.0))
     }
   }
 }
@@ -522,16 +536,16 @@ class PackBitsGeoTiffReaderSpec extends FunSpec
     with GeoTiffTestUtils {
 
   describe("Reading geotiffs with PACKBITS compression") {
-    it("must read econic_packbits.tif and match uncompressed file") {
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("econic_packbits.tif")).tile
-      val expected = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif").tile
+    it("must read econic_packbits.tif and match unstreamCompressed file") {
+      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_packbits.tif")).tile
+      val expected = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif").tile
 
       assertEqual(actual, expected)
     }
 
-    it("must read previously erroring packbits compression .tif and match uncompressed file") {
-      val expected = SinglebandGeoTiff.compressed(geoTiffPath("packbits-error-uncompressed.tif")).tile
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("packbits-error.tif")).tile
+    it("must read previously erroring packbits compression .tif and match unstreamCompressed file") {
+      val expected = SinglebandGeoTiff.streamCompressed(geoTiffPath("packbits-error-uncompressed.tif")).tile
+      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("packbits-error.tif")).tile
 
       assertEqual(actual, expected)
     }

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -515,21 +515,9 @@ class GeoTiffReaderSpec extends FunSpec
       tif.crs should be (WebMercator)
     }
   }
-
-  describe("reading a tiff file with GeoTiffStreamReader") {
-    it("can load the file") {
-      val tif = GeoTiffStreamReader.readSingleband("../data/test.TIF")
-      tif.extent should be (Extent(394800.0, 4346070.0, 627030.0, 4582500.0))
-    }
-  }
-  
-  describe("reading a singleband tif with streamCompressed") {
-    it("can load the file") {
-      val tif = SinglebandGeoTiff.streamCompressed("../data/test.TIF")
-      tif.extent should be (Extent(394800.0, 4346070.0, 627030.0, 4582500.0))
-    }
-  }
 }
+
+
 
 class PackBitsGeoTiffReaderSpec extends FunSpec
     with RasterMatchers

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -49,7 +49,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading an ESRI generated Float32 geotiff with 0 NoData value") {
     it("matches an arg produced from geotrellis.gdal reader of that tif") {
-      val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath("us_ext_clip_esri.tif")).convert(FloatConstantNoDataCellType)
+      val tile = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri.tif")).convert(FloatConstantNoDataCellType)
 
       val expectedTile =
         ArgReader.read(geoTiffPath("us_ext_clip_esri.json")).tile
@@ -65,7 +65,7 @@ class GeoTiffReaderSpec extends FunSpec
       val path = "slope.tif"
       val argPath = s"$baseDataPath/data/slope.json"
 
-      val tile = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/$path").convert(FloatConstantNoDataCellType)
+      val tile = SinglebandGeoTiff.compressed(s"$baseDataPath/$path").convert(FloatConstantNoDataCellType)
 
       val expectedTile =
         ArgReader.read(argPath).tile
@@ -77,56 +77,56 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading modelTransformation.tiff") {
     val path = "modelTransformation.tiff"
-    val streamCompressed: SinglebandGeoTiff = SinglebandGeoTiff.streamCompressed(geoTiffPath(path))
-    val tile = streamCompressed.tile
+    val compressed: SinglebandGeoTiff = SinglebandGeoTiff.streamCompressed(geoTiffPath(path))
+    val tile = compressed.tile
     val bounds = tile.gridBounds
     bounds.width should be (1121)
 
     import Tolerance._
-    streamCompressed.crs should be (CRS.fromName("EPSG:4326"))
-    if(streamCompressed.extent.min.distance(Point(59.9955397,  30.0044603))>0.0001) {
-      streamCompressed.extent.min should be (Point(59.9955397,  30.0044603))
+    compressed.crs should be (CRS.fromName("EPSG:4326"))
+    if(compressed.extent.min.distance(Point(59.9955397,  30.0044603))>0.0001) {
+      compressed.extent.min should be (Point(59.9955397,  30.0044603))
     }
 
-    if(streamCompressed.extent.max.distance(Point(69.9955397,  40.0044603))>0.0001) {
-      streamCompressed.extent.max should be (Point(69.9955397,  40.0044603))
+    if(compressed.extent.max.distance(Point(69.9955397,  40.0044603))>0.0001) {
+      compressed.extent.max should be (Point(69.9955397,  40.0044603))
     }
 
   }
 
-  describe("reading streamCompressed file must yield same image array as uncompressed file") {
+  describe("reading compressed file must yield same image array as uncompressed file") {
 
-    it("must read econic_lzw.tif and match unstreamCompressed file") {
-      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_lzw.tif"))
-      val uncomp = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif")
-
-      assertEqual(decomp.tile, uncomp.tile)
-    }
-
-    it("must read econic_zlib.tif and match unstreamCompressed file") {
-      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_zlib.tif"))
-      val uncomp = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif")
+    it("must read econic_lzw.tif and match uncompressed file") {
+      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_lzw.tif"))
+      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
-    it("must read econic_zlib_tiled.tif and match unstreamCompressed file") {
-      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_zlib_tiled.tif"))
-      val uncomp = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif")
+    it("must read econic_zlib.tif and match uncompressed file") {
+      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib.tif"))
+      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
-    it("must read econic_zlib_tiled_bandint.tif and match unstreamCompressed file") {
-      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_zlib_tiled_bandint.tif"))
-      val uncomp = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif")
+    it("must read econic_zlib_tiled.tif and match uncompressed file") {
+      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib_tiled.tif"))
+      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
-    it("must read all-ones.tif and match unstreamCompressed file") {
-      val decomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("all-ones.tif"))
-      val uncomp = SinglebandGeoTiff.streamCompressed(geoTiffPath("all-ones-no-comp.tif"))
+    it("must read econic_zlib_tiled_bandint.tif and match uncompressed file") {
+      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib_tiled_bandint.tif"))
+      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
+
+      assertEqual(decomp.tile, uncomp.tile)
+    }
+
+    it("must read all-ones.tif and match uncompressed file") {
+      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("all-ones.tif"))
+      val uncomp = SinglebandGeoTiff.compressed(geoTiffPath("all-ones-no-comp.tif"))
 
       assertEqual(decomp.tile, uncomp.tile)
     }
@@ -135,8 +135,8 @@ class GeoTiffReaderSpec extends FunSpec
   describe("reading tiled file must yield same image as strip files") {
 
     it("must read us_ext_clip_esri.tif and match strip file") {
-      val tiled = SinglebandGeoTiff.streamCompressed(geoTiffPath("us_ext_clip_esri.tif"))
-      val striped = SinglebandGeoTiff.streamCompressed(geoTiffPath("us_ext_clip_esri_stripes.tif"))
+      val tiled = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri.tif"))
+      val striped = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri_stripes.tif"))
 
       assertEqual(tiled.tile, striped.tile)
     }
@@ -145,22 +145,22 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading bit rasters") {
     it("should match bit tile the ArrayTile pulled out of the resulting GeoTiffTile") {
-      val expected = SinglebandGeoTiff.streamCompressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile
-      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile.toArrayTile
+      val expected = SinglebandGeoTiff.compressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile
+      val actual = SinglebandGeoTiff.compressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile.toArrayTile
 
       assertEqual(actual, expected)
       assertEqual(expected, actual)
     }
 
     it("must read bilevel_tiled.tif and match strip file") {
-      val tiled = SinglebandGeoTiff.streamCompressed(geoTiffPath("bilevel_tiled.tif"))
-      val striped = SinglebandGeoTiff.streamCompressed(geoTiffPath("bilevel.tif"))
+      val tiled = SinglebandGeoTiff.compressed(geoTiffPath("bilevel_tiled.tif"))
+      val striped = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif"))
 
       assertEqual(tiled.tile, striped.tile)
     }
 
     it("should match bit and byte-converted rasters") {
-      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("bilevel.tif")).tile
+      val actual = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).tile
       val expected = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile.convert(BitCellType)
 
       assertEqual(actual, expected)
@@ -272,7 +272,7 @@ class GeoTiffReaderSpec extends FunSpec
   describe("reads GeoTiff CRS correctly") {
 
     it("should read slope.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/slope.tif")crs
+      val crs = SinglebandGeoTiff.compressed(s"$baseDataPath/slope.tif")crs
 
       val correctCRS = CRS.fromString("+proj=utm +zone=10 +datum=NAD27 +units=m +no_defs")
 
@@ -280,7 +280,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read aspect.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/aspect.tif").crs
+      val crs = SinglebandGeoTiff.compressed(s"$baseDataPath/aspect.tif").crs
 
       val correctProj4String = "+proj=lcc +lat_1=36.16666666666666 +lat_2=34.33333333333334 +lat_0=33.75 +lon_0=-79 +x_0=609601.22 +y_0=0 +datum=NAD83 +units=m +no_defs"
 
@@ -290,7 +290,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read econic.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif").crs
+      val crs = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif").crs
 
       val correctProj4String = "+proj=eqdc +lat_0=33.76446202777777 +lon_0=-117.4745428888889 +lat_1=33.90363402777778 +lat_2=33.62529002777778 +x_0=0 +y_0=0 +datum=NAD27 +units=m +no_defs"
 
@@ -300,7 +300,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read bilevel.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("bilevel.tif")).crs
+      val crs = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).crs
 
       val correctProj4String = "+proj=tmerc +lat_0=0 +lon_0=-3.45233333 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +units=m +no_defs"
 
@@ -310,7 +310,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read all-ones.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("all-ones.tif")).crs
+      val crs = SinglebandGeoTiff.compressed(geoTiffPath("all-ones.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
 
@@ -318,14 +318,14 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read colormap.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("colormap.tif")).crs
+      val crs = SinglebandGeoTiff.compressed(geoTiffPath("colormap.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
       crs should equal(correctCRS)
     }
 
     it("should read us_ext_clip_esri.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("us_ext_clip_esri.tif")).crs
+      val crs = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
 
@@ -333,7 +333,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read ndvi-web-mercator.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("ndvi-web-mercator.tif")).crs
+      val crs = SinglebandGeoTiff.compressed(geoTiffPath("ndvi-web-mercator.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs")
 
@@ -341,7 +341,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read ny-state-plane.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("ny-state-plane.tif")).crs
+      val crs = SinglebandGeoTiff.compressed(geoTiffPath("ny-state-plane.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=tmerc +lat_0=40 +lon_0=-74.33333333333333 +k=0.999966667 +x_0=152400.3048006096 +y_0=0 +datum=NAD27 +units=us-ft +no_defs ")
 
@@ -349,7 +349,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read alaska-polar-3572.tif CS correctly") {
-      val crs = SinglebandGeoTiff.streamCompressed(geoTiffPath("alaska-polar-3572.tif")).crs
+      val crs = SinglebandGeoTiff.compressed(geoTiffPath("alaska-polar-3572.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=laea +lat_0=90 +lon_0=-150 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ")
       crs.toProj4String should equal(correctCRS.toProj4String)
@@ -362,7 +362,7 @@ class GeoTiffReaderSpec extends FunSpec
     val MeanEpsilon = 1e-8
 
     def testMinMaxAndMean(min: Double, max: Double, mean: Double, file: String) {
-      val SinglebandGeoTiff(tile, extent, _, _, _) = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/$file")
+      val SinglebandGeoTiff(tile, extent, _, _, _) = SinglebandGeoTiff.compressed(s"$baseDataPath/$file")
 
       tile.polygonalMax(extent, extent.toPolygon) should be (max)
       tile.polygonalMin(extent, extent.toPolygon) should be (min)
@@ -388,7 +388,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff without GeoKey Directory correctly") {
-      val SinglebandGeoTiff(tile, extent, crs, _, _) = SinglebandGeoTiff.streamCompressed(geoTiffPath("no-geokey-dir.tif"))
+      val SinglebandGeoTiff(tile, extent, crs, _, _) = SinglebandGeoTiff.compressed(geoTiffPath("no-geokey-dir.tif"))
 
       crs should be (LatLng)
       extent should be (Extent(307485, 3911490, 332505, 3936510))
@@ -401,7 +401,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff with tags") {
-      val tags = SinglebandGeoTiff.streamCompressed(geoTiffPath("tags.tif")).tags.headTags
+      val tags = SinglebandGeoTiff.compressed(geoTiffPath("tags.tif")).tags.headTags
 
       tags("TILE_COL") should be ("6")
       tags("units") should be ("kg m-2 s-1")
@@ -411,7 +411,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff with no extent data correctly") {
-      val Raster(tile, extent) = SinglebandGeoTiff.streamCompressed(geoTiffPath("tags.tif")).raster
+      val Raster(tile, extent) = SinglebandGeoTiff.compressed(geoTiffPath("tags.tif")).raster
 
       extent should be (Extent(0, 0, tile.cols, tile.rows))
     }
@@ -452,7 +452,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff with ZLIB compression and needs exact segment sizes") {
-      val geoTiff = SinglebandGeoTiff.streamCompressed(geoTiffPath("nex-pr-tile.tif"))
+      val geoTiff = SinglebandGeoTiff.compressed(geoTiffPath("nex-pr-tile.tif"))
 
       val tile = geoTiff.tile
       cfor(0)(_ < tile.rows, _ + 1) { row =>
@@ -464,13 +464,13 @@ class GeoTiffReaderSpec extends FunSpec
 
     it("should read clipped GeoTiff with byte NODATA value") {
       // Conversions carried out for both of these; first for byte -> float, second for user defined no data to constant
-      val geoTiff = SinglebandGeoTiff.streamCompressed(geoTiffPath("nodata-tag-byte.tif")).convert(FloatConstantNoDataCellType)
-      val geoTiff2 = SinglebandGeoTiff.streamCompressed(geoTiffPath("nodata-tag-float.tif")).convert(FloatConstantNoDataCellType)
+      val geoTiff = SinglebandGeoTiff.compressed(geoTiffPath("nodata-tag-byte.tif")).convert(FloatConstantNoDataCellType)
+      val geoTiff2 = SinglebandGeoTiff.compressed(geoTiffPath("nodata-tag-float.tif")).convert(FloatConstantNoDataCellType)
       assertEqual(geoTiff.toArrayTile, geoTiff2)
     }
 
     it("should read NODATA string with length = 4") {
-      val geoTiff = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/sbn/SBN_inc_percap-nodata-clip.tif")
+      val geoTiff = SinglebandGeoTiff.compressed(s"$baseDataPath/sbn/SBN_inc_percap-nodata-clip.tif")
       geoTiff.tile.cellType should be (ByteConstantNoDataCellType)
     }
   }
@@ -480,7 +480,7 @@ class GeoTiffReaderSpec extends FunSpec
     val path = temp.getPath()
 
     it("must read a tif, change the pixel sample type, write it out, and then read the correct in") {
-      val gt = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/slope.tif")
+      val gt = SinglebandGeoTiff.compressed(s"$baseDataPath/slope.tif")
       var headTags = gt.tags.headTags
       assert(headTags(Tags.AREA_OR_POINT) == "AREA")
       headTags -= Tags.AREA_OR_POINT
@@ -489,20 +489,20 @@ class GeoTiffReaderSpec extends FunSpec
       val gt2 = gt.copy(tags = tags)
       writer.GeoTiffWriter.write(gt2, path)
       addToPurge(path)
-      val gt3 = SinglebandGeoTiff.streamCompressed(path)
+      val gt3 = SinglebandGeoTiff.compressed(path)
 
       gt3.tags.headTags.get(Tags.AREA_OR_POINT) should be (Some("POINT"))
     }
 
     it("must read a tif, set a datetime, write it out, and then read the correct in") {
-      val gt = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/reproject/nlcd_tile_wsg84.tif")
+      val gt = SinglebandGeoTiff.compressed(s"$baseDataPath/reproject/nlcd_tile_wsg84.tif")
       var headTags = gt.tags.headTags
       headTags += ((Tags.TIFFTAG_DATETIME, "1988:02:18 13:59:59"))
       val tags = Tags(headTags, gt.tags.bandTags)
       val gt2 = gt.copy(tags = tags)
       writer.GeoTiffWriter.write(gt2, path)
       addToPurge(path)
-      val gt3 = SinglebandGeoTiff.streamCompressed(path)
+      val gt3 = SinglebandGeoTiff.compressed(path)
       assert(gt3.crs == LatLng)
 
       gt3.tags.headTags.get(Tags.TIFFTAG_DATETIME) should be (Some("1988:02:18 13:59:59"))
@@ -511,7 +511,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("handling special CRS cases") {
     it("can handle an ESRI written GeoTiff in WebMercator") {
-      val tif = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/propval_bg_01_01.tif")
+      val tif = SinglebandGeoTiff.compressed(s"$baseDataPath/propval_bg_01_01.tif")
       tif.crs should be (WebMercator)
     }
   }
@@ -524,16 +524,16 @@ class PackBitsGeoTiffReaderSpec extends FunSpec
     with GeoTiffTestUtils {
 
   describe("Reading geotiffs with PACKBITS compression") {
-    it("must read econic_packbits.tif and match unstreamCompressed file") {
-      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("econic_packbits.tif")).tile
-      val expected = SinglebandGeoTiff.streamCompressed(s"$baseDataPath/econic.tif").tile
+    it("must read econic_packbits.tif and match uncompressed file") {
+      val actual = SinglebandGeoTiff.compressed(geoTiffPath("econic_packbits.tif")).tile
+      val expected = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif").tile
 
       assertEqual(actual, expected)
     }
 
-    it("must read previously erroring packbits compression .tif and match unstreamCompressed file") {
-      val expected = SinglebandGeoTiff.streamCompressed(geoTiffPath("packbits-error-uncompressed.tif")).tile
-      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("packbits-error.tif")).tile
+    it("must read previously erroring packbits compression .tif and match uncompressed file") {
+      val expected = SinglebandGeoTiff.compressed(geoTiffPath("packbits-error-uncompressed.tif")).tile
+      val actual = SinglebandGeoTiff.compressed(geoTiffPath("packbits-error.tif")).tile
 
       assertEqual(actual, expected)
     }

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -77,7 +77,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading modelTransformation.tiff") {
     val path = "modelTransformation.tiff"
-    val compressed: SinglebandGeoTiff = SinglebandGeoTiff.streamCompressed(geoTiffPath(path))
+    val compressed: SinglebandGeoTiff = SinglebandGeoTiff.compressed(geoTiffPath(path))
     val tile = compressed.tile
     val bounds = tile.gridBounds
     bounds.width should be (1121)

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/MultibandGeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/MultibandGeoTiffReaderSpec.scala
@@ -6,7 +6,7 @@ import geotrellis.raster.testkit._
 
 import org.scalatest._
 
-class MultibandGeoTiffReaderSpec extends FunSpec
+class MultibandGeoTiffStreamReaderSpec extends FunSpec
     with RasterMatchers
     with GeoTiffTestUtils {
 
@@ -14,7 +14,7 @@ class MultibandGeoTiffReaderSpec extends FunSpec
     it("Uncompressed, Stripped") {
 
       val tile =
-        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
 
       // println("         PIXEL UNCOMPRESSED STRIPPED")
       // println(tile.band(0).asciiDraw)
@@ -28,7 +28,7 @@ class MultibandGeoTiffReaderSpec extends FunSpec
 
     it("Uncompressed, Tiled") {
       val tile =
-        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile
+        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile
 
       // println("         PIXEL UNCOMPRESSED TILED")
       // println(tile.band(0).asciiDraw)
@@ -42,7 +42,7 @@ class MultibandGeoTiffReaderSpec extends FunSpec
 
     it("COMPRESSION=DEFLATE, Stripped") {
       val tile =
-        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/3bands-deflate.tif")).tile
+        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/3bands-deflate.tif")).tile
 
       // println("         PIXEL COMPRESSED STRIPPED")
       // println(tile.band(0).asciiDraw)
@@ -56,7 +56,7 @@ class MultibandGeoTiffReaderSpec extends FunSpec
 
     it("COMPRESSION=DEFLATE, Tiled") {
       val tile =
-        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/3bands-tiled-deflate.tif")).tile
+        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/3bands-tiled-deflate.tif")).tile
 
       // println("         PIXEL COMPRESSED TILED")
       // println(tile.band(0).asciiDraw)
@@ -72,7 +72,7 @@ class MultibandGeoTiffReaderSpec extends FunSpec
   describe("Reading geotiffs with INTERLEAVE=BANDS") {
     it("Uncompressed, Stripped") {
       val tile =
-        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile
+        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile
 
 
       // println("         PIXEL UNCOMPRESSED STRIPPED")
@@ -87,7 +87,7 @@ class MultibandGeoTiffReaderSpec extends FunSpec
 
     it("Uncompressed, Tiled") {
       val tile =
-        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile
+        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile
 
       // println("         BANDS UNCOMPRESSED TILED")
       // println(tile.band(0).asciiDraw)
@@ -101,7 +101,7 @@ class MultibandGeoTiffReaderSpec extends FunSpec
 
     it("COMPRESSION=DEFLATE, Stripped") {
       val tile =
-        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/3bands-interleave-bands-deflate.tif")).tile
+        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/3bands-interleave-bands-deflate.tif")).tile
 
       // println("         BANDS COMPRESSED STRIPPED")
       // println(tile.band(0).asciiDraw)
@@ -115,7 +115,7 @@ class MultibandGeoTiffReaderSpec extends FunSpec
 
     it("COMPRESSION=DEFLATE, Tiled") {
       val tile =
-        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/3bands-tiled-interleave-bands-deflate.tif")).tile
+        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/3bands-tiled-interleave-bands-deflate.tif")).tile
 
       // println("         BANDS COMPRESSED TILED")
       // println(tile.band(0).asciiDraw)

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/MultibandGeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/MultibandGeoTiffReaderSpec.scala
@@ -6,7 +6,7 @@ import geotrellis.raster.testkit._
 
 import org.scalatest._
 
-class MultibandGeoTiffStreamReaderSpec extends FunSpec
+class MultibandGeoTiffReaderSpec extends FunSpec
     with RasterMatchers
     with GeoTiffTestUtils {
 
@@ -14,7 +14,7 @@ class MultibandGeoTiffStreamReaderSpec extends FunSpec
     it("Uncompressed, Stripped") {
 
       val tile =
-        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
 
       // println("         PIXEL UNCOMPRESSED STRIPPED")
       // println(tile.band(0).asciiDraw)
@@ -28,7 +28,7 @@ class MultibandGeoTiffStreamReaderSpec extends FunSpec
 
     it("Uncompressed, Tiled") {
       val tile =
-        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile
+        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile
 
       // println("         PIXEL UNCOMPRESSED TILED")
       // println(tile.band(0).asciiDraw)
@@ -42,7 +42,7 @@ class MultibandGeoTiffStreamReaderSpec extends FunSpec
 
     it("COMPRESSION=DEFLATE, Stripped") {
       val tile =
-        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/3bands-deflate.tif")).tile
+        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/3bands-deflate.tif")).tile
 
       // println("         PIXEL COMPRESSED STRIPPED")
       // println(tile.band(0).asciiDraw)
@@ -56,7 +56,7 @@ class MultibandGeoTiffStreamReaderSpec extends FunSpec
 
     it("COMPRESSION=DEFLATE, Tiled") {
       val tile =
-        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/3bands-tiled-deflate.tif")).tile
+        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/3bands-tiled-deflate.tif")).tile
 
       // println("         PIXEL COMPRESSED TILED")
       // println(tile.band(0).asciiDraw)
@@ -72,7 +72,7 @@ class MultibandGeoTiffStreamReaderSpec extends FunSpec
   describe("Reading geotiffs with INTERLEAVE=BANDS") {
     it("Uncompressed, Stripped") {
       val tile =
-        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile
+        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile
 
 
       // println("         PIXEL UNCOMPRESSED STRIPPED")
@@ -87,7 +87,7 @@ class MultibandGeoTiffStreamReaderSpec extends FunSpec
 
     it("Uncompressed, Tiled") {
       val tile =
-        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile
+        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile
 
       // println("         BANDS UNCOMPRESSED TILED")
       // println(tile.band(0).asciiDraw)
@@ -101,7 +101,7 @@ class MultibandGeoTiffStreamReaderSpec extends FunSpec
 
     it("COMPRESSION=DEFLATE, Stripped") {
       val tile =
-        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/3bands-interleave-bands-deflate.tif")).tile
+        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/3bands-interleave-bands-deflate.tif")).tile
 
       // println("         BANDS COMPRESSED STRIPPED")
       // println(tile.band(0).asciiDraw)
@@ -115,7 +115,7 @@ class MultibandGeoTiffStreamReaderSpec extends FunSpec
 
     it("COMPRESSION=DEFLATE, Tiled") {
       val tile =
-        reader.GeoTiffStreamReader.readMultiband(geoTiffPath("3bands/3bands-tiled-interleave-bands-deflate.tif")).tile
+        reader.GeoTiffReader.readMultiband(geoTiffPath("3bands/3bands-tiled-interleave-bands-deflate.tif")).tile
 
       // println("         BANDS COMPRESSED TILED")
       // println(tile.band(0).asciiDraw)

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/SinglebandGeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/SinglebandGeoTiffReaderSpec.scala
@@ -12,10 +12,10 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
     with GeoTiffTestUtils {
 
   def geoTiff(storage: String, cellType: String): SinglebandGeoTiff =
-    SinglebandGeoTiff.compressed(geoTiffPath(s"uncompressed/$storage/${cellType}.tif"))
+    SinglebandGeoTiff.streamCompressed(geoTiffPath(s"uncompressed/$storage/${cellType}.tif"))
 
   def geoTiff(compression: String, storage: String, cellType: String): SinglebandGeoTiff =
-    SinglebandGeoTiff.compressed(geoTiffPath(s"$compression/$storage/${cellType}.tif"))
+    SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$compression/$storage/${cellType}.tif"))
 
   def expectedTile(t: CellType, f: (Int, Int) => Double): Tile = {
     val cols = 500
@@ -49,9 +49,9 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
 
   describe("Reading a single band geotiff") {
     it("must read Striped Bit aspect and match tiled byte converted to bitfile") {
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("1band/aspect_bit_uncompressed_striped.tif")).tile
+      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("1band/aspect_bit_uncompressed_striped.tif")).tile
       val expected =
-        SinglebandGeoTiff.compressed(geoTiffPath("1band/aspect_byte_uncompressed_tiled.tif"))
+        SinglebandGeoTiff.streamCompressed(geoTiffPath("1band/aspect_byte_uncompressed_tiled.tif"))
           .tile
           .toArrayTile
           .map { b => if(b == 0) 0 else 1 }
@@ -68,13 +68,13 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       assertEqual(actual, expected)
     }
 
-    it("should be able to collect points from a large sparse compressed geotiff that couldn't fit all into memory") {
+    it("should be able to collect points from a large sparse Compressed geotiff that couldn't fit all into memory") {
       import geotrellis.vector._
       import scala.collection.mutable
 
       val n = "large-sparse-compressed.tif"
       val path = geoTiffPath(s"$n")
-      val raster = SinglebandGeoTiff.compressed(path).raster
+      val raster = SinglebandGeoTiff.streamCompressed(path).raster
 
       val points = mutable.ListBuffer[Point]()
       val re = raster.rasterExtent
@@ -86,10 +86,10 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       }
     }
 
-    it("should find min and max of a large sparse raster, lzw compressed") {
+    it("should find min and max of a large sparse raster, lzw Compressed") {
       val n = "wm_depth.tif"
       val path = geoTiffPath(s"$n")
-      val tile = SinglebandGeoTiff.compressed(path).tile
+      val tile = SinglebandGeoTiff.streamCompressed(path).tile
 
       val (min, max) = tile.findMinMaxDouble
 
@@ -115,7 +115,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -145,7 +145,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile
+          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile
 
           if(s == "striped") assertEqual(tile, expectedRaw) else assertEqual(tile, expected)
         }
@@ -172,7 +172,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
           println(s"     Testing $c $s:")
           withClue(s"Failed for Compression $c, storage $s") {
-            val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+            val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
             assertEqual(tile, expected)
           }
@@ -198,7 +198,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -224,7 +224,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -250,7 +250,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -276,7 +276,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -300,7 +300,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/SinglebandGeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/SinglebandGeoTiffReaderSpec.scala
@@ -12,10 +12,10 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
     with GeoTiffTestUtils {
 
   def geoTiff(storage: String, cellType: String): SinglebandGeoTiff =
-    SinglebandGeoTiff.streamCompressed(geoTiffPath(s"uncompressed/$storage/${cellType}.tif"))
+    SinglebandGeoTiff.compressed(geoTiffPath(s"uncompressed/$storage/${cellType}.tif"))
 
   def geoTiff(compression: String, storage: String, cellType: String): SinglebandGeoTiff =
-    SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$compression/$storage/${cellType}.tif"))
+    SinglebandGeoTiff.compressed(geoTiffPath(s"$compression/$storage/${cellType}.tif"))
 
   def expectedTile(t: CellType, f: (Int, Int) => Double): Tile = {
     val cols = 500
@@ -49,9 +49,9 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
 
   describe("Reading a single band geotiff") {
     it("must read Striped Bit aspect and match tiled byte converted to bitfile") {
-      val actual = SinglebandGeoTiff.streamCompressed(geoTiffPath("1band/aspect_bit_uncompressed_striped.tif")).tile
+      val actual = SinglebandGeoTiff.compressed(geoTiffPath("1band/aspect_bit_uncompressed_striped.tif")).tile
       val expected =
-        SinglebandGeoTiff.streamCompressed(geoTiffPath("1band/aspect_byte_uncompressed_tiled.tif"))
+        SinglebandGeoTiff.compressed(geoTiffPath("1band/aspect_byte_uncompressed_tiled.tif"))
           .tile
           .toArrayTile
           .map { b => if(b == 0) 0 else 1 }
@@ -74,7 +74,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
 
       val n = "large-sparse-compressed.tif"
       val path = geoTiffPath(s"$n")
-      val raster = SinglebandGeoTiff.streamCompressed(path).raster
+      val raster = SinglebandGeoTiff.compressed(path).raster
 
       val points = mutable.ListBuffer[Point]()
       val re = raster.rasterExtent
@@ -89,7 +89,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
     it("should find min and max of a large sparse raster, lzw Compressed") {
       val n = "wm_depth.tif"
       val path = geoTiffPath(s"$n")
-      val tile = SinglebandGeoTiff.streamCompressed(path).tile
+      val tile = SinglebandGeoTiff.compressed(path).tile
 
       val (min, max) = tile.findMinMaxDouble
 
@@ -115,7 +115,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -145,7 +145,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile
+          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile
 
           if(s == "striped") assertEqual(tile, expectedRaw) else assertEqual(tile, expected)
         }
@@ -172,7 +172,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
           println(s"     Testing $c $s:")
           withClue(s"Failed for Compression $c, storage $s") {
-            val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+            val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
             assertEqual(tile, expected)
           }
@@ -198,7 +198,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -224,7 +224,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -250,7 +250,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -276,7 +276,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -300,7 +300,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.streamCompressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
@@ -2,8 +2,11 @@ package geotrellis.raster.io.geotiff
 
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
+import geotrellis.raster.io.geotiff.reader.GeoTiffStreamReader
 import geotrellis.vector.Extent
 import geotrellis.proj4.CRS
+
+import java.nio.ByteBuffer
 
 case class MultibandGeoTiff(
   val tile: MultibandTile,
@@ -31,23 +34,29 @@ object MultibandGeoTiff {
   def apply(bytes: Array[Byte]): MultibandGeoTiff =
     GeoTiffReader.readMultiband(bytes)
 
+  def apply(bytes: ByteBuffer): MultibandGeoTiff =
+    GeoTiffStreamReader.readMultiband(bytes)
+
   /** Read a multi-band GeoTIFF file from a byte array.
     * If decompress = true, the GeoTIFF will be fully uncompressed and held in memory.
     */
   def apply(bytes: Array[Byte], decompress: Boolean): MultibandGeoTiff =
     GeoTiffReader.readMultiband(bytes, decompress)
 
+  def apply(bytes: ByteBuffer, decompress: Boolean): MultibandGeoTiff =
+    GeoTiffStreamReader.readMultiband(bytes, decompress)
+
   /** Read a multi-band GeoTIFF file from the file at the given path.
     * GeoTIFF will be fully decompressed and held in memory.
     */
   def apply(path: String): MultibandGeoTiff =
-    GeoTiffReader.readMultiband(path)
+    GeoTiffStreamReader.readMultiband(path)
 
   /** Read a multi-band GeoTIFF file from the file at the given path.
     * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
     */
   def apply(path: String, decompress: Boolean): MultibandGeoTiff =
-    GeoTiffReader.readMultiband(path, decompress)
+    GeoTiffStreamReader.readMultiband(path, decompress)
 
   /** Read a multi-band GeoTIFF file from the file at a given path.
     * The tile data will remain tiled/striped and compressed in the TIFF format.
@@ -55,11 +64,17 @@ object MultibandGeoTiff {
   def compressed(path: String): MultibandGeoTiff =
     GeoTiffReader.readMultiband(path, false)
 
+  def streamCompressed(path: String): MultibandGeoTiff =
+    GeoTiffStreamReader.readMultiband(path, false)
+
   /** Read a multi-band GeoTIFF file from a byte array.
     * The tile data will remain tiled/striped and compressed in the TIFF format.
     */
   def compressed(bytes: Array[Byte]): MultibandGeoTiff =
     GeoTiffReader.readMultiband(bytes, false)
+  
+  def streamCompressed(bytes: ByteBuffer): MultibandGeoTiff =
+  GeoTiffStreamReader.readMultiband(bytes, false)
 
   def apply(
     tile: MultibandTile,

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
@@ -34,6 +34,9 @@ object MultibandGeoTiff {
   def apply(bytes: Array[Byte]): MultibandGeoTiff =
     GeoTiffReader.readMultiband(bytes)
 
+  /** Read a multi-band GeoTIFF file from a ByteBuffer.
+    * GeoTIFF will be fully uncompressed and held in memory.
+    */
   def apply(bytes: ByteBuffer): MultibandGeoTiff =
     GeoTiffStreamReader.readMultiband(bytes)
 
@@ -43,27 +46,34 @@ object MultibandGeoTiff {
   def apply(bytes: Array[Byte], decompress: Boolean): MultibandGeoTiff =
     GeoTiffReader.readMultiband(bytes, decompress)
 
+  /** Read a multi-band GeoTIFF file from a ByteBuffer.
+    * If decompress = true, the GeoTIFF will be fully uncompressed and held in memory.
+    */
   def apply(bytes: ByteBuffer, decompress: Boolean): MultibandGeoTiff =
     GeoTiffStreamReader.readMultiband(bytes, decompress)
 
-  /** Read a multi-band GeoTIFF file from the file at the given path.
-    * GeoTIFF will be fully decompressed and held in memory.
+  /** Read a multi-band GeoTIFF file from the file at the given path and returns
+    * a ByteBuffer. GeoTIFF will be fully decompressed and held in memory.
     */
   def apply(path: String): MultibandGeoTiff =
     GeoTiffStreamReader.readMultiband(path)
 
-  /** Read a multi-band GeoTIFF file from the file at the given path.
+  /** Read a multi-band GeoTIFF file from the file at the given path and returns
+   *  a ByteBuffer.
     * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
     */
   def apply(path: String, decompress: Boolean): MultibandGeoTiff =
     GeoTiffStreamReader.readMultiband(path, decompress)
 
-  /** Read a multi-band GeoTIFF file from the file at a given path.
+  /** Read a multi-band GeoTIFF file from the file at a given path as a byte array.
     * The tile data will remain tiled/striped and compressed in the TIFF format.
     */
   def compressed(path: String): MultibandGeoTiff =
     GeoTiffReader.readMultiband(path, false)
 
+  /** Read a multi-band GeoTIFF file from the file at a given path as a ByteBuffer.
+    * The tile data will remain tiled/striped and compressed in the TIFF format.
+    */
   def streamCompressed(path: String): MultibandGeoTiff =
     GeoTiffStreamReader.readMultiband(path, false)
 
@@ -73,6 +83,9 @@ object MultibandGeoTiff {
   def compressed(bytes: Array[Byte]): MultibandGeoTiff =
     GeoTiffReader.readMultiband(bytes, false)
   
+  /** Read a multi-band GeoTIFF file from a ByteBuffer.
+    * The tile data will remain tiled/striped and compressed in the TIFF format.
+    */
   def streamCompressed(bytes: ByteBuffer): MultibandGeoTiff =
   GeoTiffStreamReader.readMultiband(bytes, false)
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
@@ -41,6 +41,10 @@ object SinglebandGeoTiff {
     */
   def apply(bytes: Array[Byte]): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(bytes)
+
+  /**Read a single-band GeoTiff file from a ByteBuffer.
+   * The GeoTiff will be fully decompressed and held in memory.
+   */
   
   def apply(bytes: ByteBuffer): SinglebandGeoTiff =
     GeoTiffStreamReader.readSingleband(bytes)
@@ -51,26 +55,35 @@ object SinglebandGeoTiff {
   def apply(bytes: Array[Byte], decompress: Boolean): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(bytes, decompress)
 
+  /** Read a single-band GeoTIFF file from a ByteBuffer.
+    * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
+    */
+
   def apply(bytes: ByteBuffer, decompress: Boolean): SinglebandGeoTiff =
     GeoTiffStreamReader.readSingleband(bytes, decompress)
 
   /** Read a single-band GeoTIFF file from the file at the given path.
-    * The GeoTIFF will be fully decompressed and held in memory.
+    * The GeoTIFF will be read in as a ByteBuffer, fully decompressed,
+    * and held in memory.
     */
   def apply(path: String): SinglebandGeoTiff =
     GeoTiffStreamReader.readSingleband(path)
 
-  /** Read a single-band GeoTIFF file from the file at the given path.
+  /** Read a single-band GeoTIFF file as a ByteBuffer from the file at the given path.
     * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
     */
   def apply(path: String, decompress: Boolean): SinglebandGeoTiff =
     GeoTiffStreamReader.readSingleband(path, decompress)
 
-  /** Read a single-band GeoTIFF file from the file at a given path.
+  /** Read a single-band GeoTIFF file as a byte array from the file at a given path.
     * The tile data will remain tiled/striped and compressed in the TIFF format.
     */
   def compressed(path: String): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(path, false)
+
+  /** Read a single-band GeoTIFF file as a ByteBuffer from the file at a given path.
+    * The tile data will remain tiled/striped and compressed in the TIFF format.
+    */
 
   def streamCompressed(path: String): SinglebandGeoTiff =
     GeoTiffStreamReader.readSingleband(path, false)
@@ -81,6 +94,9 @@ object SinglebandGeoTiff {
   def compressed(bytes: Array[Byte]): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(bytes, false)
 
+  /** Read a single-band GeoTIFF file from a ByteBuffer.
+    * The tile data will remain tiled/striped and compressed in the TIFF format.
+    */
   def streamCompressed(bytes: ByteBuffer): SinglebandGeoTiff =
     GeoTiffStreamReader.readSingleband(bytes, false)
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
@@ -2,8 +2,11 @@ package geotrellis.raster.io.geotiff
 
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
+import geotrellis.raster.io.geotiff.reader.GeoTiffStreamReader
 import geotrellis.vector.Extent
 import geotrellis.proj4.CRS
+
+import java.nio.ByteBuffer
 
 case class SinglebandGeoTiff(
   val tile: Tile,
@@ -38,6 +41,9 @@ object SinglebandGeoTiff {
     */
   def apply(bytes: Array[Byte]): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(bytes)
+  
+  def apply(bytes: ByteBuffer): SinglebandGeoTiff =
+    GeoTiffStreamReader.readSingleband(bytes)
 
   /** Read a single-band GeoTIFF file from a byte array.
     * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
@@ -45,17 +51,20 @@ object SinglebandGeoTiff {
   def apply(bytes: Array[Byte], decompress: Boolean): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(bytes, decompress)
 
+  def apply(bytes: ByteBuffer, decompress: Boolean): SinglebandGeoTiff =
+    GeoTiffStreamReader.readSingleband(bytes, decompress)
+
   /** Read a single-band GeoTIFF file from the file at the given path.
     * The GeoTIFF will be fully decompressed and held in memory.
     */
   def apply(path: String): SinglebandGeoTiff =
-    GeoTiffReader.readSingleband(path)
+    GeoTiffStreamReader.readSingleband(path)
 
   /** Read a single-band GeoTIFF file from the file at the given path.
     * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
     */
   def apply(path: String, decompress: Boolean): SinglebandGeoTiff =
-    GeoTiffReader.readSingleband(path, decompress)
+    GeoTiffStreamReader.readSingleband(path, decompress)
 
   /** Read a single-band GeoTIFF file from the file at a given path.
     * The tile data will remain tiled/striped and compressed in the TIFF format.
@@ -63,11 +72,17 @@ object SinglebandGeoTiff {
   def compressed(path: String): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(path, false)
 
+  def streamCompressed(path: String): SinglebandGeoTiff =
+    GeoTiffStreamReader.readSingleband(path, false)
+
   /** Read a single-band GeoTIFF file from a byte array.
     * The tile data will remain tiled/striped and compressed in the TIFF format.
     */
   def compressed(bytes: Array[Byte]): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(bytes, false)
+
+  def streamCompressed(bytes: ByteBuffer): SinglebandGeoTiff =
+    GeoTiffStreamReader.readSingleband(bytes, false)
 
   implicit def singlebandGeoTiffToTile(sbg: SinglebandGeoTiff): Tile =
     sbg.tile

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffStreamReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffStreamReader.scala
@@ -41,7 +41,7 @@ class GeoTiffReaderLimitationException(msg: String)
 // TODO: Streaming read (e.g. so that we can read GeoTiffs that cannot fit into memory. Perhaps support BigTIFF?)
 
 
-object GeoTiffReader {
+object GeoTiffStreamReader {
 
   /* Read a single band GeoTIFF file.
    * If there is more than one band in the GeoTiff, read the first band only.
@@ -53,18 +53,18 @@ object GeoTiffReader {
    * If there is more than one band in the GeoTiff, read the first band only.
    */
   def readSingleband(path: String, decompress: Boolean): SinglebandGeoTiff =
-    readSingleband(Filesystem.slurp(path), decompress)
+    readSingleband(Filesystem.streamByteBuffer(path), decompress)
 
   /* Read a single band GeoTIFF file.
    * If there is more than one band in the GeoTiff, read the first band only.
    */
-  def readSingleband(bytes: Array[Byte]): SinglebandGeoTiff =
+  def readSingleband(bytes: ByteBuffer): SinglebandGeoTiff =
     readSingleband(bytes, true)
 
   /* Read a single band GeoTIFF file.
    * If there is more than one band in the GeoTiff, read the first band only.
    */
-  def readSingleband(bytes: Array[Byte], decompress: Boolean): SinglebandGeoTiff = {
+  def readSingleband(bytes: ByteBuffer, decompress: Boolean): SinglebandGeoTiff = {
     val info = readGeoTiffInfo(bytes, decompress)
 
     val geoTiffTile =
@@ -202,11 +202,7 @@ object GeoTiffReader {
   }
 
 
-  private def readGeoTiffInfo(bytes: Array[Byte], decompress: Boolean): GeoTiffInfo = {
-    val byteBuffer = ByteBuffer.wrap(bytes, 0, bytes.size)
-
-    // Set byteBuffer position
-    byteBuffer.position(0)
+  private def readGeoTiffInfo(bytes: ByteBuffer, decompress: Boolean): GeoTiffInfo = {
 
     // set byte ordering
     (byteBuffer.get.toChar, byteBuffer.get.toChar) match {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffStreamReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffStreamReader.scala
@@ -33,14 +33,6 @@ import java.nio.{ByteBuffer, ByteOrder}
 import spire.syntax.cfor._
 
 
-class MalformedGeoTiffException(msg: String) extends RuntimeException(msg)
-
-class GeoTiffReaderLimitationException(msg: String)
-    extends RuntimeException(msg)
-
-// TODO: Streaming read (e.g. so that we can read GeoTiffs that cannot fit into memory. Perhaps support BigTIFF?)
-
-
 object GeoTiffStreamReader {
 
   /* Read a single band GeoTIFF file.
@@ -101,14 +93,14 @@ object GeoTiffStreamReader {
   /* Read a multi band GeoTIFF file.
    */
   def readMultiband(path: String, decompress: Boolean): MultibandGeoTiff =
-    readMultiband(Filesystem.slurp(path), decompress)
+    readMultiband(Filesystem.streamByteBuffer(path), decompress)
 
   /* Read a multi band GeoTIFF file.
    */
-  def readMultiband(bytes: Array[Byte]): MultibandGeoTiff =
+  def readMultiband(bytes: ByteBuffer): MultibandGeoTiff =
     readMultiband(bytes, true)
 
-  def readMultiband(bytes: Array[Byte], decompress: Boolean): MultibandGeoTiff = {
+  def readMultiband(bytes: ByteBuffer, decompress: Boolean): MultibandGeoTiff = {
     val info = readGeoTiffInfo(bytes, decompress)
     val geoTiffTile =
       GeoTiffMultibandTile(
@@ -202,7 +194,7 @@ object GeoTiffStreamReader {
   }
 
 
-  private def readGeoTiffInfo(bytes: ByteBuffer, decompress: Boolean): GeoTiffInfo = {
+  private def readGeoTiffInfo(byteBuffer: ByteBuffer, decompress: Boolean): GeoTiffInfo = {
 
     // set byte ordering
     (byteBuffer.get.toChar, byteBuffer.get.toChar) match {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffStreamReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffStreamReader.scala
@@ -196,21 +196,7 @@ object GeoTiffStreamReader {
 
   private def readGeoTiffInfo(byteBuffer: ByteBuffer, decompress: Boolean): GeoTiffInfo = {
 
-    // set byte ordering
-    (byteBuffer.get.toChar, byteBuffer.get.toChar) match {
-      case ('I', 'I') => byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
-      case ('M', 'M') => byteBuffer.order(ByteOrder.BIG_ENDIAN)
-      case _ => throw new MalformedGeoTiffException("incorrect byte order")
-    }
-
-    // Validate Tiff identification number
-    val tiffIdNumber = byteBuffer.getChar
-    if (tiffIdNumber != 42)
-      throw new MalformedGeoTiffException(s"bad identification number (must be 42, was $tiffIdNumber)")
-
-    val tagsStartPosition = byteBuffer.getInt
-
-    val tiffTags = TiffTagsReader.read(byteBuffer, tagsStartPosition)
+    val tiffTags = TiffTagsReader.read(byteBuffer)
 
     val hasPixelInterleave = tiffTags.hasPixelInterleave
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -15,15 +15,9 @@ import java.nio.{ ByteBuffer, ByteOrder }
 
 object TiffTagsReader {
 
-  //def read(path: String): TiffTags = read(Filesystem.slurp(path))
-  
   def read(path: String): TiffTags = read(Filesystem.streamByteBuffer(path))
-
-  def read(bytes: ByteBuffer): TiffTags = {
-    //val byteBuffer = ByteBuffer.wrap(bytes, 0, bytes.size)
-
-    // Set byteBuffer position
-    //byteBuffer.position(0)
+  
+  def read(byteBuffer: ByteBuffer): TiffTags = {
 
     // set byte ordering
     (byteBuffer.reader.toChar, byteBuffer.reader.toChar) match {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -14,16 +14,19 @@ import java.nio.{ ByteBuffer, ByteOrder }
 
 
 object TiffTagsReader {
-  def read(path: String): TiffTags = read(Filesystem.slurp(path))
 
-  def read(bytes: Array[Byte]): TiffTags = {
-    val byteBuffer = ByteBuffer.wrap(bytes, 0, bytes.size)
+  //def read(path: String): TiffTags = read(Filesystem.slurp(path))
+  
+  def read(path: String): TiffTags = read(Filesystem.streamByteBuffer(path))
+
+  def read(bytes: ByteBuffer): TiffTags = {
+    //val byteBuffer = ByteBuffer.wrap(bytes, 0, bytes.size)
 
     // Set byteBuffer position
-    byteBuffer.position(0)
+    //byteBuffer.position(0)
 
     // set byte ordering
-    (byteBuffer.get.toChar, byteBuffer.get.toChar) match {
+    (byteBuffer.reader.toChar, byteBuffer.reader.toChar) match {
       case ('I', 'I') => byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
       case ('M', 'M') => byteBuffer.order(ByteOrder.BIG_ENDIAN)
       case _ => throw new MalformedGeoTiffException("incorrect byte order")

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteBufferExtensions.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteBufferExtensions.scala
@@ -274,14 +274,17 @@ trait ByteBufferExtensions {
       arr
     }
 
-    def readr: Int = {
+    def reader: Int = {
       if (!byteBuffer.hasRemaining) -1
       else math.min(byteBuffer.get, (1<<18))
     }
+
+    /*
 
     def reader(bytes: Array[Byte], offset: Int, length: Int): Int = {
       val len = math.min(length, byteBuffer.remaining)
       byteBuffer.get(bytes, offset, len)
     }
+    */
   }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteBufferExtensions.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteBufferExtensions.scala
@@ -273,5 +273,15 @@ trait ByteBufferExtensions {
 
       arr
     }
+
+    def readr: Int = {
+      if (!byteBuffer.hasRemaining) -1
+      else math.min(byteBuffer.get, (1<<18))
+    }
+
+    def reader(bytes: Array[Byte], offset: Int, length: Int): Int = {
+      val len = math.min(length, byteBuffer.remaining)
+      byteBuffer.get(bytes, offset, len)
+    }
   }
 }

--- a/util/src/main/scala/geotrellis/util/Filesystem.scala
+++ b/util/src/main/scala/geotrellis/util/Filesystem.scala
@@ -52,6 +52,18 @@ object Filesystem {
     data
   }
 
+  def streamByteBuffer(path: String): ByteBuffer = {
+    val f = new File(path)
+    val fis = new FileInputStream(f)
+    val size = f.length.toInt
+    val channel = fis.getChannel
+    val buffer = channel.map(READ_ONLY, 0, size)
+    channel.close()
+    fis.close()
+    buffer
+  }
+
+
   /**
     * Make a contiguous chunk of a file available in the given array.
     *

--- a/util/src/main/scala/geotrellis/util/Filesystem.scala
+++ b/util/src/main/scala/geotrellis/util/Filesystem.scala
@@ -52,6 +52,12 @@ object Filesystem {
     data
   }
 
+  /**
+    * Read the contents of a file into a ByteBuffer.
+    *
+    * @param   path The path to the file to be read
+    * @return       A ByteBuffer that contains the file
+    */
   def streamByteBuffer(path: String): ByteBuffer = {
     val f = new File(path)
     val fis = new FileInputStream(f)

--- a/util/src/main/scala/geotrellis/util/Filesystem.scala
+++ b/util/src/main/scala/geotrellis/util/Filesystem.scala
@@ -63,6 +63,16 @@ object Filesystem {
     buffer
   }
 
+  def streamByteBuffer(path: String, sections: List[(Int, Int)]) = {
+
+    sections.sortBy(_._1)
+
+    def sectionsChecker: Boolean = {
+      if (sections.isEmpty)
+        throw new Error("WindowedReader needs sections of file to read")
+      else if (sections.filter
+
+
 
   /**
     * Make a contiguous chunk of a file available in the given array.

--- a/util/src/main/scala/geotrellis/util/Filesystem.scala
+++ b/util/src/main/scala/geotrellis/util/Filesystem.scala
@@ -63,16 +63,6 @@ object Filesystem {
     buffer
   }
 
-  def streamByteBuffer(path: String, sections: List[(Int, Int)]) = {
-
-    sections.sortBy(_._1)
-
-    def sectionsChecker: Boolean = {
-      if (sections.isEmpty)
-        throw new Error("WindowedReader needs sections of file to read")
-      else if (sections.filter
-
-
 
   /**
     * Make a contiguous chunk of a file available in the given array.


### PR DESCRIPTION
Read in GeoTiff files as a ByteBuffer.

- Reading just the TiffTags no longer brings in the entire file, but just a stream of it that can be read from.

- A new object, GeoTiffStreamReader, was created to read in GeoTiffs as ByteBuffers