### PR TITLE
Create GeoWave Subproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ index.html
 index.js
 .ensime*
 tags
+
+nohup.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_script:
   - psql -c 'CREATE EXTENSION postgis_topology;' -U postgres -d slick_tests
   - docker run -d --restart=always --net=host -m 1G --memory-swap -1 --env="MAX_HEAP_SIZE=500M" --env="HEAP_NEWSIZE=100M" --env="CASSANDRA_LISTEN_ADDRESS=127.0.0.1" cassandra:latest
   - .travis/hbase-install.sh
-  - nohup scripts/geowaveTestDB.sh &
 
 jdk:
   - openjdk7
@@ -32,7 +31,7 @@ jdk:
   - oraclejdk8
 
 scala:
-- "2.11.8"
+  - "2.11.8"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - psql -c 'CREATE EXTENSION postgis_topology;' -U postgres -d slick_tests
   - docker run -d --restart=always --net=host -m 1G --memory-swap -1 --env="MAX_HEAP_SIZE=500M" --env="HEAP_NEWSIZE=100M" --env="CASSANDRA_LISTEN_ADDRESS=127.0.0.1" cassandra:latest
   - .travis/hbase-install.sh
-  - scripts/geowaveTestDB.sh
+  - nohup scripts/geowaveTestDB.sh &
 
 jdk:
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
   - psql -c 'CREATE EXTENSION postgis_topology;' -U postgres -d slick_tests
   - docker run -d --restart=always --net=host -m 1G --memory-swap -1 --env="MAX_HEAP_SIZE=500M" --env="HEAP_NEWSIZE=100M" --env="CASSANDRA_LISTEN_ADDRESS=127.0.0.1" cassandra:latest
   - .travis/hbase-install.sh
+  - scripts/geowaveTestDB.sh
 
 jdk:
   - openjdk7

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -6,5 +6,4 @@
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project hbase" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project proj4" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geotools" test || { exit 1; }
-./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geowave" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project shapefile" test || { exit 1; }

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -6,4 +6,5 @@
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project hbase" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project proj4" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geotools" test || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geowave" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project shapefile" test || { exit 1; }

--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geowave" compile || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project cassandra" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project vector-test" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project raster-test" test || { exit 1; }

--- a/build.sbt
+++ b/build.sbt
@@ -160,9 +160,9 @@ lazy val geotools = Project("geotools", file("geotools")).
   dependsOn(raster, vector, proj4, vectorTestkit % "test->test", rasterTest % "test->test").
   settings(commonSettings: _*)
 
-lazy val geowave = Project("geowave", file("geowave"))
-  .dependsOn(spark, geotools)
-  .settings(commonSettings: _*)
+lazy val geowave = Project("geowave", file("geowave")).
+  dependsOn(sparkTestkit % "test->test", spark % "provided;test->test", geotools, accumulo % "provided;test->test").
+  settings(commonSettings: _*)
 
 lazy val shapefile = Project("shapefile", file("shapefile")).
   dependsOn(raster, rasterTestkit % "test").

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ lazy val root = Project("geotrellis", file(".")).
     accumulo,
     cassandra,
     hbase,
+    geowave,
     geotools,
     slick,
     vectortile
@@ -158,6 +159,10 @@ lazy val sparkEtl = Project(id = "spark-etl", base = file("spark-etl")).
 lazy val geotools = Project("geotools", file("geotools")).
   dependsOn(raster, vector, proj4, vectorTestkit % "test->test", rasterTest % "test->test").
   settings(commonSettings: _*)
+
+lazy val geowave = Project("geowave", file("geowave"))
+  .dependsOn(spark, geotools)
+  .settings(commonSettings: _*)
 
 lazy val shapefile = Project("shapefile", file("shapefile")).
   dependsOn(raster, rasterTestkit % "test").

--- a/geotools/src/main/scala/geotrellis/geotools/GridCoverage2DConversionMethods.scala
+++ b/geotools/src/main/scala/geotrellis/geotools/GridCoverage2DConversionMethods.scala
@@ -3,6 +3,7 @@ package geotrellis.geotools
 import geotrellis.proj4.LatLng
 import geotrellis.raster._
 import geotrellis.util._
+import geotrellis.vector.Extent
 
 import org.geotools.coverage.grid._
 import org.geotools.resources.coverage.CoverageUtilities
@@ -13,6 +14,9 @@ import java.awt.image.{Raster => AwtRaster, _}
 trait GridCoverage2DConversionMethods extends MethodExtensions[GridCoverage2D] {
   def toTile(bandIndex: Int): Tile =
     GridCoverage2DConverters.convertToTile(self, bandIndex)
+
+  def toMultibandTile(): MultibandTile =
+    GridCoverage2DConverters.convertToMultibandTile(self)
 
   def toRaster(bandIndex: Int): Raster[Tile] = {
     val tile = GridCoverage2DConverters.convertToTile(self, bandIndex)
@@ -38,7 +42,7 @@ trait GridCoverage2DConversionMethods extends MethodExtensions[GridCoverage2D] {
     Raster(tile, extent)
   }
 
-  def toProjectedRaster(bandIndex: Int): ProjectedRaster[Tile] =
+  def toProjectedRaster(bandIndex: Int): ProjectedRaster[Tile] = {
     GridCoverage2DConverters.getCrs(self) match {
       case Some(crs) =>
         ProjectedRaster(toRaster(bandIndex), crs)
@@ -46,8 +50,9 @@ trait GridCoverage2DConversionMethods extends MethodExtensions[GridCoverage2D] {
         // Default LatLng
         ProjectedRaster(toRaster(bandIndex), LatLng)
     }
+  }
 
-  def toProjectedRaster(): ProjectedRaster[MultibandTile] =
+  def toProjectedRaster(): ProjectedRaster[MultibandTile] = {
     GridCoverage2DConverters.getCrs(self) match {
       case Some(crs) =>
         ProjectedRaster(toRaster(), crs)
@@ -55,5 +60,6 @@ trait GridCoverage2DConversionMethods extends MethodExtensions[GridCoverage2D] {
         // Default LatLng
         ProjectedRaster(toRaster(), LatLng)
     }
+  }
 
 }

--- a/geotools/src/main/scala/geotrellis/geotools/GridCoverage2DConversionMethods.scala
+++ b/geotools/src/main/scala/geotrellis/geotools/GridCoverage2DConversionMethods.scala
@@ -42,7 +42,7 @@ trait GridCoverage2DConversionMethods extends MethodExtensions[GridCoverage2D] {
     Raster(tile, extent)
   }
 
-  def toProjectedRaster(bandIndex: Int): ProjectedRaster[Tile] = {
+  def toProjectedRaster(bandIndex: Int): ProjectedRaster[Tile] =
     GridCoverage2DConverters.getCrs(self) match {
       case Some(crs) =>
         ProjectedRaster(toRaster(bandIndex), crs)
@@ -50,9 +50,9 @@ trait GridCoverage2DConversionMethods extends MethodExtensions[GridCoverage2D] {
         // Default LatLng
         ProjectedRaster(toRaster(bandIndex), LatLng)
     }
-  }
 
-  def toProjectedRaster(): ProjectedRaster[MultibandTile] = {
+
+  def toProjectedRaster(): ProjectedRaster[MultibandTile] =
     GridCoverage2DConverters.getCrs(self) match {
       case Some(crs) =>
         ProjectedRaster(toRaster(), crs)
@@ -60,6 +60,4 @@ trait GridCoverage2DConversionMethods extends MethodExtensions[GridCoverage2D] {
         // Default LatLng
         ProjectedRaster(toRaster(), LatLng)
     }
-  }
-
 }

--- a/geotools/src/main/scala/geotrellis/geotools/GridCoverage2DConverters.scala
+++ b/geotools/src/main/scala/geotrellis/geotools/GridCoverage2DConverters.scala
@@ -1,6 +1,6 @@
 package geotrellis.geotools
 
-import geotrellis.proj4.CRS
+import geotrellis.proj4.{CRS, LatLng}
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.util._
 import geotrellis.vector.Extent
@@ -26,6 +26,12 @@ import scala.collection.JavaConverters._
   * related GeoTools types, and GeoTrellis types.
   */
 object GridCoverage2DConverters {
+
+  /**
+    * Create an authority factory which generates CRSs with Longitude
+    * guranteed to the be first coordinate.
+    */
+  val authorityFactory = GeoToolsCRS.getAuthorityFactory(true)
 
   /**
     * Given a GridCoverage2D and an index, this function optionally
@@ -190,6 +196,15 @@ object GridCoverage2DConverters {
     new Envelope2D(null, xmin, ymin, (xmax - xmin), (ymax - ymin))
   }
 
+  def getGeotoolsCRS(crs: CRS): CoordinateReferenceSystem = {
+    crs.epsgCode match {
+      case Some(code) =>
+        authorityFactory.createCoordinateReferenceSystem(s"EPSG:${code}")
+      case _ =>
+        null
+    }
+  }
+
   /**
     * A function to produce a GeoTools Envelope2D from a Geotrellis
     * Extent and CRS. If the CRS cannot be converted, a null GeoTools
@@ -202,13 +217,7 @@ object GridCoverage2DConverters {
     */
   def getEnvelope2D(extent: Extent, crs: CRS): Envelope2D = {
     val Extent(xmin, ymin, xmax, ymax) = extent
-    val geoToolsCRS: CoordinateReferenceSystem =
-      crs.epsgCode match {
-        case Some(code) =>
-          GeoToolsCRS.decode(s"EPSG:${code}")
-        case _ =>
-          null
-      }
+    val geoToolsCRS = getGeotoolsCRS(crs)
 
     new Envelope2D(geoToolsCRS, xmin, ymin, (xmax - xmin), (ymax - ymin))
   }
@@ -224,6 +233,12 @@ object GridCoverage2DConverters {
       case _: FloatCells => (Float.MinValue.toDouble, Float.MaxValue.toDouble)
       case _: DoubleCells => (Double.MinValue, Double.MaxValue)
     }
+
+  def convertToMultibandTile(gridCoverage: GridCoverage2D): MultibandTile = {
+    val numBands = gridCoverage.getRenderedImage.getSampleModel.getNumBands
+    val tiles = (0 until numBands).map({ i => convertToTile(gridCoverage, i) })
+    ArrayMultibandTile(tiles)
+  }
 
   def convertToTile(gridCoverage: GridCoverage2D, bandIndex: Int): Tile = {
     val renderedImage = gridCoverage.getRenderedImage
@@ -882,7 +897,7 @@ object GridCoverage2DConverters {
     }
 
     factory.create(
-      null,
+      "",
       image,
       envelope,
       gridSampleDimensions,

--- a/geotools/src/test/scala/geotrellis/geotools/GridCoverage2DConvertersSpec.scala
+++ b/geotools/src/test/scala/geotrellis/geotools/GridCoverage2DConvertersSpec.scala
@@ -199,7 +199,7 @@ class GridCoverage2DConvertersSpec extends FunSpec with Matchers with GeoTiffTes
     describe(s"ProjectedRaster Conversions: $description") {
       it("should convert the GridCoverage2D to a ProjectedRaster[MultibandTile]") {
         val (gridCoverage2D, projectedRaster) = (testFile.gridCoverage2D, testFile.multibandRaster)
-        assertEqual(gridCoverage2D.toProjectedRaster(), projectedRaster)
+        assertEqual(gridCoverage2D.toProjectedRaster, projectedRaster)
       }
 
       it("should convert a ProjectedRaster to a GridCoverage2D") {
@@ -231,7 +231,7 @@ class GridCoverage2DConvertersSpec extends FunSpec with Matchers with GeoTiffTes
     describe(s"Raster Conversions: $description") {
       it("should convert the GridCoverage2D to a Raster[MultibandTile]") {
         val (gridCoverage2D, raster) = (testFile.gridCoverage2D, testFile.multibandRaster.raster)
-        assertEqual(gridCoverage2D.toRaster(), raster)
+        assertEqual(gridCoverage2D.toRaster, raster)
       }
 
       it("should convert a Raster to a GridCoverage2D") {

--- a/geowave/build.sbt
+++ b/geowave/build.sbt
@@ -1,0 +1,62 @@
+import Dependencies._
+import sbtassembly.PathList
+
+
+name := "geotrellis-geowave"
+
+libraryDependencies ++= Seq(
+  "org.apache.accumulo" % "accumulo-core" % Version.accumulo
+    exclude("org.jboss.netty", "netty")
+    exclude("org.apache.hadoop", "hadoop-client"),
+  "mil.nga.giat" % "geowave-adapter-raster" % "0.9.3-SNAPSHOT",
+  "mil.nga.giat" % "geowave-adapter-vector" % "0.9.3-SNAPSHOT",
+  "mil.nga.giat" % "geowave-core-store" % "0.9.3-SNAPSHOT",
+  "mil.nga.giat" % "geowave-datastore-accumulo" % "0.9.3-SNAPSHOT",
+  "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
+  "org.apache.spark" %% "spark-core" % Version.spark % "provided",
+  "org.geoserver" % "gs-wms" % "2.8.2",
+  "org.geotools" % "gt-coverage" % Version.geotools % "provided",
+  "org.geotools" % "gt-epsg-hsql" % Version.geotools % "provided",
+  "org.geotools" % "gt-geotiff" % Version.geotools % "provided",
+  "org.geotools" % "gt-main" % Version.geotools % "provided",
+  "org.geotools" % "gt-referencing" % Version.geotools % "provided",
+  spire,
+  scalatest % "test")
+
+resolvers ++= Seq(
+  "boundless" at "https://repo.boundlessgeo.com/release",
+  "geosolutions" at "http://maven.geo-solutions.it/",
+  "geowave" at "http://geowave-maven.s3-website-us-east-1.amazonaws.com/snapshot",
+  "osgeo" at "http://download.osgeo.org/webdav/geotools/"
+)
+
+assemblyMergeStrategy in assembly := {
+  case "reference.conf" => MergeStrategy.concat
+  case "application.conf" => MergeStrategy.concat
+  case PathList("META-INF", xs @ _*) =>
+    xs match {
+      case ("MANIFEST.MF" :: Nil) => MergeStrategy.discard
+      // Concatenate everything in the services directory to keep GeoTools happy.
+      case ("services" :: _ :: Nil) =>
+        MergeStrategy.concat
+      // Concatenate these to keep JAI happy.
+      case ("javax.media.jai.registryFile.jai" :: Nil) | ("registryFile.jai" :: Nil) | ("registryFile.jaiext" :: Nil) =>
+        MergeStrategy.concat
+      case (name :: Nil) => {
+        // Must exclude META-INF/*.([RD]SA|SF) to avoid "Invalid signature file digest for Manifest main attributes" exception.
+        if (name.endsWith(".RSA") || name.endsWith(".DSA") || name.endsWith(".SF"))
+          MergeStrategy.discard
+        else
+          MergeStrategy.first
+      }
+      case _ => MergeStrategy.first
+    }
+  case _ => MergeStrategy.first
+}
+
+fork in Test := false
+parallelExecution in Test := false
+
+initialCommands in console :=
+  """
+  """

--- a/geowave/build.sbt
+++ b/geowave/build.sbt
@@ -50,6 +50,7 @@ libraryDependencies ++= Seq(
   scalatest % "test")
 
 resolvers ++= Seq(
+  // Resolver.mavenLocal,
   "boundless" at "https://repo.boundlessgeo.com/release",
   "geosolutions" at "http://maven.geo-solutions.it/",
   "geowave-release" at "http://geowave-maven.s3-website-us-east-1.amazonaws.com/release",

--- a/geowave/build.sbt
+++ b/geowave/build.sbt
@@ -11,6 +11,7 @@ libraryDependencies ++= Seq(
   "mil.nga.giat" % "geowave-adapter-raster" % "0.9.3-SNAPSHOT",
   "mil.nga.giat" % "geowave-adapter-vector" % "0.9.3-SNAPSHOT",
   "mil.nga.giat" % "geowave-core-store" % "0.9.3-SNAPSHOT",
+  "mil.nga.giat" % "geowave-core-geotime" % "0.9.3-SNAPSHOT",
   "mil.nga.giat" % "geowave-datastore-accumulo" % "0.9.3-SNAPSHOT",
   "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
   "org.apache.spark" %% "spark-core" % Version.spark % "provided",
@@ -20,13 +21,15 @@ libraryDependencies ++= Seq(
   "org.geotools" % "gt-geotiff" % Version.geotools % "provided",
   "org.geotools" % "gt-main" % Version.geotools % "provided",
   "org.geotools" % "gt-referencing" % Version.geotools % "provided",
+  "com.jsuereth" %% "scala-arm" % "1.4",
   spire,
   scalatest % "test")
 
 resolvers ++= Seq(
   "boundless" at "https://repo.boundlessgeo.com/release",
   "geosolutions" at "http://maven.geo-solutions.it/",
-  "geowave" at "http://geowave-maven.s3-website-us-east-1.amazonaws.com/snapshot",
+  "geowave-release" at "http://geowave-maven.s3-website-us-east-1.amazonaws.com/release",
+  "geowave-snapshot" at "http://geowave-maven.s3-website-us-east-1.amazonaws.com/snapshot",
   "osgeo" at "http://download.osgeo.org/webdav/geotools/"
 )
 

--- a/geowave/build.sbt
+++ b/geowave/build.sbt
@@ -8,19 +8,43 @@ libraryDependencies ++= Seq(
   "org.apache.accumulo" % "accumulo-core" % Version.accumulo
     exclude("org.jboss.netty", "netty")
     exclude("org.apache.hadoop", "hadoop-client"),
-  "mil.nga.giat" % "geowave-adapter-raster" % "0.9.3-SNAPSHOT",
-  "mil.nga.giat" % "geowave-adapter-vector" % "0.9.3-SNAPSHOT",
-  "mil.nga.giat" % "geowave-core-store" % "0.9.3-SNAPSHOT",
-  "mil.nga.giat" % "geowave-core-geotime" % "0.9.3-SNAPSHOT",
-  "mil.nga.giat" % "geowave-datastore-accumulo" % "0.9.3-SNAPSHOT",
-  "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
+  "mil.nga.giat" % "geowave-adapter-raster" % "0.9.3-SNAPSHOT"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "mil.nga.giat" % "geowave-adapter-vector" % "0.9.3-SNAPSHOT"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "mil.nga.giat" % "geowave-core-store" % "0.9.3-SNAPSHOT"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "mil.nga.giat" % "geowave-core-geotime" % "0.9.3-SNAPSHOT"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "mil.nga.giat" % "geowave-datastore-accumulo" % "0.9.3-SNAPSHOT"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
   "org.apache.spark" %% "spark-core" % Version.spark % "provided",
-  "org.geoserver" % "gs-wms" % "2.8.2",
-  "org.geotools" % "gt-coverage" % Version.geotools % "provided",
-  "org.geotools" % "gt-epsg-hsql" % Version.geotools % "provided",
-  "org.geotools" % "gt-geotiff" % Version.geotools % "provided",
-  "org.geotools" % "gt-main" % Version.geotools % "provided",
-  "org.geotools" % "gt-referencing" % Version.geotools % "provided",
+  "org.geoserver" % "gs-wms" % "2.8.2"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "org.geotools" % "gt-coverage" % Version.geotools % "provided"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "org.geotools" % "gt-epsg-hsql" % Version.geotools % "provided"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "org.geotools" % "gt-geotiff" % Version.geotools % "provided"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "org.geotools" % "gt-main" % Version.geotools % "provided"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
+  "org.geotools" % "gt-referencing" % Version.geotools % "provided"
+    excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
+      ExclusionRule(organization = "javax.servlet")),
   "com.jsuereth" %% "scala-arm" % "1.4",
   spire,
   scalatest % "test")

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
@@ -38,7 +38,6 @@ import org.opengis.parameter.GeneralParameterValue
 import scala.collection.JavaConverters._
 import scala.util.Try
 
-import resource._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -76,10 +75,14 @@ object GeowaveAttributeStore {
       geowaveNamespace)
   }
 
-  def adapters(bao: BasicAccumuloOperations): Array[RasterDataAdapter] =
-    managed(new AccumuloAdapterStore(bao).getAdapters)
-      .acquireAndGet { _.asScala.collect { case x: RasterDataAdapter => x } }
+  def adapters(bao: BasicAccumuloOperations): Array[RasterDataAdapter] = {
+    val adapters = new AccumuloAdapterStore(bao).getAdapters
+    val retval = adapters.asScala
+      .map(_.asInstanceOf[RasterDataAdapter])
       .toArray
+
+    adapters.close ; retval
+  }
 
   def primaryIndex = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
 

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
@@ -1,0 +1,244 @@
+package geotrellis.spark.io.geowave
+
+import geotrellis.geotools._
+import geotrellis.proj4.LatLng
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.vector.Extent
+
+import com.vividsolutions.jts.geom._
+import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
+import mil.nga.giat.geowave.adapter.raster.query.IndexOnlySpatialQuery
+import mil.nga.giat.geowave.core.geotime.ingest._
+import mil.nga.giat.geowave.core.geotime.store.statistics.BoundingBoxDataStatistics
+import mil.nga.giat.geowave.core.index.ByteArrayId
+import mil.nga.giat.geowave.core.index.HierarchicalNumericIndexStrategy
+import mil.nga.giat.geowave.core.index.HierarchicalNumericIndexStrategy.SubStrategy
+import mil.nga.giat.geowave.core.store._
+import mil.nga.giat.geowave.core.store.index.{PrimaryIndex, CustomIdIndex}
+import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions
+import mil.nga.giat.geowave.core.store.query.QueryOptions
+import mil.nga.giat.geowave.datastore.accumulo._
+import mil.nga.giat.geowave.datastore.accumulo.index.secondary.AccumuloSecondaryIndexDataStore
+import mil.nga.giat.geowave.datastore.accumulo.metadata._
+import mil.nga.giat.geowave.datastore.accumulo.operations.config.AccumuloRequiredOptions
+import mil.nga.giat.geowave.mapreduce.input.{GeoWaveInputKey, GeoWaveInputFormat}
+import org.apache.hadoop.mapreduce.Job
+import org.apache.log4j.Logger
+import org.apache.spark.Logging
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
+import org.apache.spark.SparkContext._
+import org.geotools.coverage.grid._
+import org.geotools.gce.geotiff._
+import org.opengis.coverage.grid.GridCoverage
+import org.opengis.parameter.GeneralParameterValue
+
+import scala.collection.JavaConverters._
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+
+object GeowaveAttributeStore {
+
+  def accumuloRequiredOptions(
+    zookeeper: String,
+    accumuloInstance: String,
+    accumuloUser: String,
+    accumuloPass: String,
+    geowaveNamespace: String
+  ): AccumuloRequiredOptions = {
+    val aro = new AccumuloRequiredOptions
+    aro.setZookeeper(zookeeper)
+    aro.setInstance(accumuloInstance)
+    aro.setUser(accumuloUser)
+    aro.setPassword(accumuloPass)
+    aro.setGeowaveNamespace(geowaveNamespace)
+    aro
+  }
+
+  def basicOperations(
+    zookeeper: String,
+    accumuloInstance: String,
+    accumuloUser: String,
+    accumuloPass: String,
+    geowaveNamespace: String
+  ): BasicAccumuloOperations = {
+    return new BasicAccumuloOperations(
+      zookeeper,
+      accumuloInstance,
+      accumuloUser,
+      accumuloPass,
+      geowaveNamespace)
+  }
+
+  def adapters(bao: BasicAccumuloOperations): Array[RasterDataAdapter] = {
+    val as = new AccumuloAdapterStore(bao).getAdapters
+    val list = Iterator.iterate(as)({ _ => as })
+      .takeWhile({ _ => as.hasNext })
+      .map(_.next.asInstanceOf[RasterDataAdapter])
+      .toArray
+
+    as.close
+    list
+  }
+
+  def primaryIndex = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
+
+  def subStrategies(idx: PrimaryIndex) = idx
+    .getIndexStrategy
+    .asInstanceOf[HierarchicalNumericIndexStrategy]
+    .getSubStrategies
+
+  def unapply(gas: GeowaveAttributeStore) = Some((
+    gas.getBasicAccumuloOperations,
+    gas.getAccumuloRequiredOptions,
+    gas.getAdapters,
+    gas.getPrimaryIndex,
+    gas.getSubStrategies,
+    gas.getBoundingBoxes
+  ))
+}
+
+class GeowaveAttributeStore(
+  zookeeper: String,
+  accumuloInstance: String,
+  accumuloUser: String,
+  accumuloPass: String,
+  geowaveNamespace: String
+) extends DiscreteLayerAttributeStore with Logging {
+
+  def zookeeper(): String = zookeeper
+  def accumuloInstance(): String = accumuloInstance
+  def accumuloUser(): String = accumuloUser
+  def accumuloPass(): String = accumuloPass
+  def geowaveNamespace(): String = geowaveNamespace
+
+  val bao = GeowaveAttributeStore.basicOperations(
+    zookeeper: String,
+    accumuloInstance: String,
+    accumuloUser: String,
+    accumuloPass: String,
+    geowaveNamespace: String
+  )
+  val aro = GeowaveAttributeStore.accumuloRequiredOptions(
+    zookeeper: String,
+    accumuloInstance: String,
+    accumuloUser: String,
+    accumuloPass: String,
+    geowaveNamespace: String
+  )
+
+  val ds = new AccumuloDataStore(bao)
+  val dss = new AccumuloDataStatisticsStore(bao)
+
+  val placeHolder = "_________________________________"
+
+  // Prevent "org.apache.accumulo.core.client.TableNotFoundException:
+  // Table gwRaster_GEOWAVE_METADATA does not exist" when writing from
+  // multiple threads to an initially-empty GeoWave instance.
+  {
+    val extent = Extent(-180, -90, 180, 90)
+    val tile = IntArrayTile.empty(512, 512)
+    val image = ProjectedRaster(Raster(tile, extent), LatLng).toGridCoverage2D
+    val index = getPrimaryIndex
+    val gwMetadata = new java.util.HashMap[String, String](); gwMetadata.put(placeHolder, placeHolder)
+    val adapter = new RasterDataAdapter(placeHolder, gwMetadata, image, 256, true)
+    val indexWriter = getDataStore.createWriter(adapter, index).asInstanceOf[IndexWriter[GridCoverage]]
+
+    indexWriter.write(image); indexWriter.close
+  }
+
+  def getBoundingBoxes(): Map[ByteArrayId, BoundingBoxDataStatistics[Any]] = {
+    getAdapters.map({ adapter =>
+      val adapterId = adapter.getAdapterId
+      val bboxId = BoundingBoxDataStatistics.STATS_ID
+      val bbox = dss
+        .getDataStatistics(adapterId, bboxId)
+        .asInstanceOf[BoundingBoxDataStatistics[Any]]
+
+      (adapterId, bbox)
+    }).toMap
+  }
+
+  def getLeastZooms(): Map[ByteArrayId, Int] = {
+    getAdapters.map({ adapter =>
+      val adapterId = adapter.getAdapterId
+      val bbox = getBoundingBoxes.getOrElse(adapterId, throw new Exception(s"Unknown Adapter Id $adapterId"))
+      val zoom = bbox match {
+        case null => {
+          log.warn(s"$adapterId has a broken bounding box")
+          0
+        }
+        case _ => {
+          val substrats = getSubStrategies
+          val width = bbox.getMaxX - bbox.getMinX
+          val height = bbox.getMaxY - bbox.getMinY
+          val zoom = (0 to getSubStrategies.length).toIterator.filter({ i =>
+            val substrat = substrats(i)
+            val ranges = substrat.getIndexStrategy.getHighestPrecisionIdRangePerDimension
+            ((ranges(0) <= width) && (ranges(1) <= height))
+          }).next
+
+          zoom
+        }
+      }
+
+      (adapterId, zoom)
+    }).toMap
+  }
+
+  def getAccumuloRequiredOptions = aro
+  def getBasicAccumuloOperations = bao
+  def getPrimaryIndex = GeowaveAttributeStore.primaryIndex
+  def getAdapters = GeowaveAttributeStore.adapters(bao).filter(_.getCoverageName != placeHolder)
+  def getSubStrategies = GeowaveAttributeStore.subStrategies(getPrimaryIndex)
+  def getDataStore = ds
+  def getDataStatisticsStore = dss
+
+  def delete(layerId: LayerId, attributeName: String): Unit = ???
+  def delete(layerId: LayerId): Unit = ???
+  def readAll[T: JsonFormat](attributeName: String): Map[LayerId, T] = ???
+  def read[T: JsonFormat](layerId: LayerId, attributeName: String): T = ???
+  def write[T: JsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = ???
+
+  /**
+    * Return a list of available attributes associated with this
+    * attribute store.
+    */
+  def availableAttributes(id: LayerId) = List.empty[String]
+
+  /**
+    * Answer whether a layer exists or not.
+    */
+  def layerExists(layerId: LayerId): Boolean = {
+    val LayerId(name, zoom) = layerId
+    val candidateAdapters = getAdapters.filter(_.getCoverageName == name)
+
+    if (candidateAdapters.nonEmpty) {
+      val adapterId = candidateAdapters.head.getAdapterId
+      val leastZoom = getLeastZooms.getOrElse(adapterId, throw new Exception(s"Unknown Adapter Id $adapterId"))
+      ((leastZoom <= zoom) && (zoom < getSubStrategies.length))
+    }
+    else false
+  }
+
+  /**
+    * Return a list of valid LayerIds.
+    */
+  def layerIds: Seq[LayerId] = {
+    val list =
+      for (
+        adapter <- getAdapters;
+        zoom <- {
+          val adapterId = adapter.getAdapterId
+          val leastZoom = getLeastZooms.getOrElse(adapter.getAdapterId, throw new Exception(s"Unknown Adapter Id $adapterId"))
+          (leastZoom  until getSubStrategies.length)
+        }
+      ) yield LayerId(adapter.getCoverageName, zoom)
+
+    list.distinct
+  }
+}

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
@@ -8,6 +8,7 @@ import geotrellis.spark.io._
 import geotrellis.vector.Extent
 import geotrellis.spark.io.accumulo.AccumuloAttributeStore
 
+import com.typesafe.scalalogging.LazyLogging
 import com.vividsolutions.jts.geom._
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
 import mil.nga.giat.geowave.core.geotime.ingest._
@@ -24,11 +25,10 @@ import mil.nga.giat.geowave.datastore.accumulo.index.secondary.AccumuloSecondary
 import mil.nga.giat.geowave.datastore.accumulo.metadata._
 import mil.nga.giat.geowave.datastore.accumulo.operations.config.AccumuloRequiredOptions
 import mil.nga.giat.geowave.mapreduce.input.{GeoWaveInputKey, GeoWaveInputFormat}
-import org.apache.accumulo.core.client.{TableNotFoundException, ZooKeeperInstance}
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.client.{TableNotFoundException, ZooKeeperInstance}
 import org.apache.hadoop.mapreduce.Job
-import org.apache.log4j.Logger
-import org.apache.spark.{Logging, SparkConf, SparkContext}
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.SparkContext._
 import org.geotools.coverage.grid._
 import org.geotools.gce.geotiff._
@@ -99,7 +99,7 @@ class GeowaveAttributeStore(
   val accumuloUser: String,
   val accumuloPass: String,
   val geowaveNamespace: String
-) extends DiscreteLayerAttributeStore with Logging {
+) extends DiscreteLayerAttributeStore with LazyLogging {
 
   val zkInstance = (new ZooKeeperInstance(accumuloInstance, zookeepers))
   val token = new PasswordToken(accumuloPass)
@@ -144,7 +144,7 @@ class GeowaveAttributeStore(
       val bbox = boundingBoxes.getOrElse(adapterId, throw new Exception(s"Unknown Adapter Id $adapterId"))
       val zoom = bbox match {
         case null => {
-          log.warn(s"$adapterId has a broken bounding box")
+          logger.warn(s"$adapterId has a broken bounding box")
           0
         }
         case _ => {

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveKryoRegistrator.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveKryoRegistrator.scala
@@ -1,0 +1,41 @@
+package geotrellis.spark.io.geowave
+
+import geotrellis.spark.io.kryo.KryoRegistrator
+
+import mil.nga.giat.geowave.core.index.Persistable
+import mil.nga.giat.geowave.core.index.PersistenceUtils
+import org.apache.accumulo.core.data.Key
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.Serializer
+
+
+object GeowaveKryoRegistrator {
+
+  // GeoWave registrator
+  class GeoWaveKryoRegistrator extends KryoRegistrator {
+    override def registerClasses(kryo: Kryo) = {
+      kryo.addDefaultSerializer(classOf[Persistable], new PersistableSerializer())
+      kryo.register(classOf[Key])
+      super.registerClasses(kryo)
+    }
+  }
+
+  //Default serializer for any GeoWave Persistable object
+  class PersistableSerializer extends Serializer[Persistable] {
+    override def write(kryo: Kryo, output: Output, geowaveObj: Persistable): Unit = {
+      val bytes = PersistenceUtils.toBinary(geowaveObj)
+      output.writeInt(bytes.length)
+      output.writeBytes(bytes)
+    }
+
+    override def read(kryo: Kryo, input: Input, t: Class[Persistable]): Persistable = {
+      val length = input.readInt()
+      val bytes = new Array[Byte](length)
+      input.read(bytes)
+
+      PersistenceUtils.fromBinary(bytes, classOf[Persistable])
+    }
+  }
+}

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
@@ -36,7 +36,7 @@ import spray.json._
 import scala.reflect._
 
 
-object GeoWaveLayerReader {
+object GeowaveLayerReader {
   val geometryFactory = new GeometryFactory
   val p = geometryFactory.createPoint(new Coordinate(31.137720, 29.975307))
   val emptySet = p.difference(p)
@@ -185,7 +185,7 @@ class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkC
     V: AvroRecordCodec: ClassTag,
     M: JsonFormat: GetComponent[?, Bounds[K]]
   ](id: LayerId, rasterQuery: LayerQuery[K, M], numPartitions: Int, filterIndexOnly: Boolean) = {
-    import GeoWaveLayerReader._
+    import GeowaveLayerReader._
 
     /* Perform checks */
     if (!attributeStore.layerExists(id))

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
@@ -1,0 +1,257 @@
+package geotrellis.spark.io.geowave
+
+import geotrellis.geotools._
+import geotrellis.proj4.LatLng
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.avro._
+import geotrellis.spark.io.index.KeyIndex
+import geotrellis.spark.tiling.{LayoutDefinition, MapKeyTransform}
+import geotrellis.util._
+import geotrellis.vector.Extent
+
+import com.vividsolutions.jts.geom._
+import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
+import mil.nga.giat.geowave.core.geotime.store.query.IndexOnlySpatialQuery
+import mil.nga.giat.geowave.core.geotime.ingest._
+import mil.nga.giat.geowave.core.geotime.store.statistics.BoundingBoxDataStatistics
+import mil.nga.giat.geowave.core.index.ByteArrayId
+import mil.nga.giat.geowave.core.store._
+import mil.nga.giat.geowave.core.store.index.CustomIdIndex
+import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions
+import mil.nga.giat.geowave.core.store.query.QueryOptions
+import mil.nga.giat.geowave.datastore.accumulo._
+import mil.nga.giat.geowave.datastore.accumulo.metadata._
+import mil.nga.giat.geowave.mapreduce.input.{GeoWaveInputKey, GeoWaveInputFormat}
+import org.apache.avro.Schema
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+import org.geotools.coverage.grid._
+
+import spray.json._
+
+import scala.reflect._
+
+
+object GeoWaveLayerReader {
+  val geometryFactory = new GeometryFactory
+  val p = geometryFactory.createPoint(new Coordinate(31.137720, 29.975307))
+  val emptySet = p.difference(p)
+
+  /**
+    * Given a map transform and a keybounds, produce a corresponding
+    * jts.Geometry.
+    *
+    * @param  mt  The map transform
+    * @param  kb  The KeyBounds
+    */
+  def keyBoundsToGeometry(mt: MapKeyTransform, kb: KeyBounds[SpatialKey]) = {
+    val KeyBounds(minKey, maxKey) = kb
+    val Extent(lng1, lat1, lng2, lat2) = mt(minKey)
+    val Extent(lng3, lat3, lng4, lat4) = mt(maxKey)
+    val lngs = List(lng1, lng2, lng3, lng4)
+    val lats = List(lat1, lat2, lat3, lat4)
+    val width = math.abs(lng1 - lng2)
+    val height = math.abs(lat1 - lat2)
+    val minLng = lngs.min
+    val maxLng = lngs.max
+    val minLat = lats.min
+    val maxLat = lats.max
+    val envelope = new Envelope(
+      minLng + width/3,
+      maxLng - width/3,
+      minLat + height/3,
+      maxLat - height/3)
+
+    geometryFactory.toGeometry(envelope)
+  }
+}
+
+class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkContext)
+    extends FilteringLayerReader[LayerId] {
+
+  val defaultNumPartitions = sc.defaultParallelism
+
+  val GeowaveAttributeStore(
+    basicOperations,
+    requiredOptions,
+    adapters,
+    index,
+    substrats,
+    bboxMap
+  ) = attributeStore
+
+  /**
+    * Compute the common part of the
+    * org.apache.hadoop.conf.Configuration associated with this layer.
+    * This result can be reused by changing the Query and QueryOptions
+    * as desired.
+    */
+  def computeConfiguration()(implicit sc: SparkContext) = {
+    val pluginOptions = new DataStorePluginOptions
+    pluginOptions.setFactoryOptions(requiredOptions)
+    val configOptions = pluginOptions.getFactoryOptionsAsMap
+    val job = Job.getInstance(sc.hadoopConfiguration)
+    val config = job.getConfiguration
+    GeoWaveInputFormat.setDataStoreName(config, "accumulo")
+    GeoWaveInputFormat.setStoreConfigOptions(config, configOptions)
+
+    config
+  }
+
+  /**
+    * Compute the metadata associated with this layer.
+    *
+    * @param  adapter  The RasterDataAdapter associated with the chosen layer
+    * @param  ranges   The ranges in degree of longitude and latitude associated with the chosen zoom level
+    */
+  def computeSpatialMetadata(
+    adapter: RasterDataAdapter,
+    ranges: Array[Double]
+  ): (TileLayerMetadata[SpatialKey], Int, Int) = {
+    val adapterId = adapter.getAdapterId
+
+    val metadata = adapter.getMetadata
+
+    val bbox = bboxMap.getOrElse(adapterId, throw new Exception(s"Unknown Adapter Id $adapterId"))
+
+    val minX = bbox.getMinX
+    val minY = bbox.getMinY
+    val maxX = bbox.getMaxX
+    val maxY = bbox.getMaxY
+    val minCol = (minX / ranges(0)).toInt
+    val minRow = (minY / ranges(1)).toInt
+    val maxCol = (maxX / ranges(0)).toInt
+    val maxRow = (maxY / ranges(1)).toInt
+
+    val extent = Extent(
+      minCol * ranges(0),
+      minRow * ranges(1),
+      (maxCol + 1) * ranges(0),
+      (maxRow + 1) * ranges(1)
+    )
+
+    val layout = {
+      val tileSize = adapter.getTileSize
+      val tileLayout = TileLayout(maxCol - minCol + 1, maxRow - minRow + 1, tileSize, tileSize)
+      LayoutDefinition(extent, tileLayout)
+    }
+
+    val cellType = metadata.get("cellType") match {
+      case null => {
+        val geom = (new GeometryFactory).createPoint(new Coordinate((minX + maxX) / 2.0, (minY + maxY) / 2.0))
+        val queryOptions = new QueryOptions(adapter, index)
+        val query = new IndexOnlySpatialQuery(geom)
+        val config = computeConfiguration
+        GeoWaveInputFormat.setQuery(config, query)
+        GeoWaveInputFormat.setQueryOptions(config, queryOptions)
+
+        val gc = sc.newAPIHadoopRDD(
+          config,
+          classOf[GeoWaveInputFormat[GridCoverage2D]],
+          classOf[GeoWaveInputKey],
+          classOf[GridCoverage2D])
+          .map({ case (_, gc) => gc })
+          .collect.head
+
+        GridCoverage2DConverters.getCellType(gc)
+      }
+      case s: String => CellType.fromString(s)
+    }
+
+    val bounds = KeyBounds(
+      SpatialKey(0, 0),
+      SpatialKey(maxCol - minCol, maxRow - minRow)
+    )
+
+    (TileLayerMetadata(cellType, layout, extent, LatLng, bounds), minCol, maxRow)
+  }
+
+  /**
+    * Read particular rasters out of the GeoWave database.  The
+    * particular rasters to read are given by the result running the
+    * provided LayerQuery.
+    *
+    * @param  id               The LayerId specifying the name and zoom level to query
+    * @param  rasterQuery      Produces a list of rasters to read
+    * @param  numPartitions    The number of Spark partitions to use
+    * @param  filterIndexOnly  ?
+    */
+  def read[
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    V: AvroRecordCodec: ClassTag,
+    M: JsonFormat: GetComponent[?, Bounds[K]]
+  ](id: LayerId, rasterQuery: LayerQuery[K, M], numPartitions: Int, filterIndexOnly: Boolean) = {
+    import GeoWaveLayerReader._
+
+    /* Perform checks */
+    if (!attributeStore.layerExists(id))
+      throw new LayerNotFoundError(id)
+    implicitly[ClassTag[K]].toString match {
+      case "geotrellis.spark.SpatialKey" =>
+      case t: String => throw new Exception("Unsupported Key Type: $t")
+    }
+
+    /* Boilerplate */
+    val LayerId(name, zoom) = id
+    val adapter = adapters.filter(_.getCoverageName == name).head
+    val strategy = substrats(zoom)
+    val ranges = strategy.getIndexStrategy.getHighestPrecisionIdRangePerDimension
+    val customIndex = new CustomIdIndex(strategy.getIndexStrategy, index.getIndexModel, index.getId)
+
+    /* GeoTrellis metadata */
+    val (_md, minCol, maxRow) = computeSpatialMetadata(adapter, ranges)
+    val md = _md.asInstanceOf[M]
+
+    /* GeoWave Query and Query Options */
+    val queryOptions = new QueryOptions(adapter, customIndex)
+    val query = {
+      val fn = keyBoundsToGeometry(_md.mapTransform, _: KeyBounds[SpatialKey])
+      val kbs = rasterQuery(md)
+
+      implicitly[ClassTag[K]].toString match {
+        case "geotrellis.spark.SpatialKey" => { // Spatial Query
+          val geom = kbs
+            .map({ kb => fn(kb.asInstanceOf[KeyBounds[SpatialKey]]) })
+            .foldLeft(emptySet)({ (l, r) => l.union(r) })
+          new IndexOnlySpatialQuery(geom)
+        }
+      }
+    }
+
+    /* Construct org.apache.hadoop.conf.Configuration */
+    val config = computeConfiguration
+    GeoWaveInputFormat.setQuery(config, query)
+    GeoWaveInputFormat.setQueryOptions(config, queryOptions)
+
+    /* Submit query */
+    val rdd =
+      implicitly[ClassTag[K]].toString match {
+        case "geotrellis.spark.SpatialKey" => { // Spatial Query
+          sc.newAPIHadoopRDD(
+            config,
+            classOf[GeoWaveInputFormat[GridCoverage2D]],
+            classOf[GeoWaveInputKey],
+            classOf[GridCoverage2D])
+            .map({ case (_, gc) =>
+              val Extent(lng, lat, _, _) = GridCoverage2DConverters.getExtent(gc)
+              val key = SpatialKey(
+                (lng / ranges(0)).toInt - minCol,
+                maxRow - (lat / ranges(1)).toInt
+              ).asInstanceOf[K]
+              val value = implicitly[ClassTag[V]].toString match {
+                case "geotrellis.raster.Tile" => gc.toTile(0).asInstanceOf[V]
+                case "geotrellis.raster.MultibandTile" => gc.toMultibandTile.asInstanceOf[V]
+                case t: String => throw new Exception("Unsupported Value Type: $t")
+              }
+              (key, value)
+            })
+        }
+      }
+
+    new ContextRDD(rdd, md)
+  }
+}

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
@@ -76,12 +76,12 @@ class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkC
 
   val gas = attributeStore.asInstanceOf[GeowaveAttributeStore]
 
-  private def adapters = gas.getAdapters
-  private def basicOperations = gas.getBasicAccumuloOperations
-  private def bboxMap = gas.getBoundingBoxes
-  private def index = gas.getPrimaryIndex
-  private def requiredOptions = gas.getAccumuloRequiredOptions
-  private def substrats = gas.getSubStrategies
+  private def adapters = gas.adapters
+  private def basicOperations = gas.basicAccumuloOperations
+  private def bboxMap = gas.boundingBoxes
+  private def index = gas.primaryIndex
+  private def requiredOptions = gas.accumuloRequiredOptions
+  private def substrats = gas.subStrategies
 
   /**
     * Compute the common part of the

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
@@ -15,7 +15,6 @@ import com.vividsolutions.jts.geom._
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
 import mil.nga.giat.geowave.core.geotime.store.query.IndexOnlySpatialQuery
 import mil.nga.giat.geowave.core.geotime.ingest._
-import mil.nga.giat.geowave.core.geotime.store.statistics.BoundingBoxDataStatistics
 import mil.nga.giat.geowave.core.index.ByteArrayId
 import mil.nga.giat.geowave.core.store._
 import mil.nga.giat.geowave.core.store.index.CustomIdIndex
@@ -23,7 +22,7 @@ import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePlugin
 import mil.nga.giat.geowave.core.store.query.QueryOptions
 import mil.nga.giat.geowave.datastore.accumulo._
 import mil.nga.giat.geowave.datastore.accumulo.metadata._
-import mil.nga.giat.geowave.mapreduce.input.{GeoWaveInputKey, GeoWaveInputFormat}
+import mil.nga.giat.geowave.mapreduce.input.{ GeoWaveInputKey, GeoWaveInputFormat }
 import org.apache.avro.Schema
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapreduce.Job
@@ -75,14 +74,14 @@ class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkC
 
   val defaultNumPartitions = sc.defaultParallelism
 
-  val GeowaveAttributeStore(
-    basicOperations,
-    requiredOptions,
-    adapters,
-    index,
-    substrats,
-    bboxMap
-  ) = attributeStore
+  val gas = attributeStore.asInstanceOf[GeowaveAttributeStore]
+
+  private def adapters = gas.getAdapters
+  private def basicOperations = gas.getBasicAccumuloOperations
+  private def bboxMap = gas.getBoundingBoxes
+  private def index = gas.getPrimaryIndex
+  private def requiredOptions = gas.getAccumuloRequiredOptions
+  private def substrats = gas.getSubStrategies
 
   /**
     * Compute the common part of the

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
@@ -104,7 +104,7 @@ class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkC
     * Compute the metadata associated with this layer.
     *
     * @param  adapter  The RasterDataAdapter associated with the chosen layer
-    * @param  ranges   The ranges in degree of longitude and latitude associated with the chosen zoom level
+    * @param  ranges   The ranges in degrees of longitude and latitude associated with the chosen tier
     */
   def computeSpatialMetadata(
     adapter: RasterDataAdapter,
@@ -173,7 +173,7 @@ class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkC
     * particular rasters to read are given by the result of running
     * the provided LayerQuery.
     *
-    * @param  id               The LayerId specifying the name and zoom level to query
+    * @param  id               The LayerId specifying the name and tier to query
     * @param  rasterQuery      Produces a list of rasters to read
     * @param  numPartitions    The number of Spark partitions to use
     * @param  filterIndexOnly  ?
@@ -190,9 +190,9 @@ class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkC
       throw new LayerNotFoundError(id)
 
     /* Boilerplate */
-    val LayerId(name, zoom) = id
+    val LayerId(name, tier) = id
     val adapter = adapters.filter(_.getCoverageName == name).head
-    val strategy = substrats(zoom)
+    val strategy = substrats(tier)
     val ranges = strategy.getIndexStrategy.getHighestPrecisionIdRangePerDimension
     val customIndex = new CustomIdIndex(strategy.getIndexStrategy, index.getIndexModel, index.getId)
 

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -99,7 +99,7 @@ object GeowaveLayerWriter extends LazyLogging {
         )
         val dataStore = new AccumuloDataStore(basicOperations)
         val index = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
-        val adapter = new RasterDataAdapter(coverageName, gwMetadata, image, 256, true) // image only used for sample and color metadata, not data
+        val adapter = new RasterDataAdapter(new RasterDataAdapter(coverageName, gwMetadata, image, 256, true), coverageName, null) // image only used for sample and color metadata, not data, overriding default merge strategy because geotrellis data is already tiled (non-overlapping)
         val indexWriter = dataStore.createWriter(adapter, index).asInstanceOf[IndexWriter[GridCoverage]]
 
         /* Write the mosaic into GeoWave */

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -50,8 +50,8 @@ import spray.json._
 object GeowaveLayerWriter extends LazyLogging {
 
   def write[
-    K: ClassTag,
-    V: ClassTag,
+    K <: SpatialKey: ClassTag,
+    V: TileOrMultibandTile: ClassTag,
     M: JsonFormat: GetComponent[?, Bounds[K]]
   ](
     coverageName: String,
@@ -59,10 +59,7 @@ object GeowaveLayerWriter extends LazyLogging {
     as: GeowaveAttributeStore,
     accumuloWriter: AccumuloWriteStrategy
   ): Unit = {
-    val metadata = implicitly[ClassTag[K]].toString match {
-      case "geotrellis.spark.SpatialKey" => rdd.metadata.asInstanceOf[TileLayerMetadata[SpatialKey]]
-      case t: String => throw new Exception(s"Unsupported Key Type: $t")
-    }
+    val metadata = rdd.metadata.asInstanceOf[TileLayerMetadata[SpatialKey]]
 
     val crs = metadata.crs
     val mt = metadata.mapTransform
@@ -71,20 +68,12 @@ object GeowaveLayerWriter extends LazyLogging {
 
     /* Construct (Multiband|)Tile to GridCoverage2D conversion function */
     val geotrellisKvToGeotools: ((K, V)) => GridCoverage2D = {
-      specimen match {
-        case (_: SpatialKey, _: Tile) => {
-          case (k: K, v: V) =>
-            val extent = mt(k.asInstanceOf[SpatialKey]).reproject(crs, LatLng)
-            val tile = v.asInstanceOf[Tile]
-            ProjectedRaster(Raster(tile, extent), LatLng).toGridCoverage2D
-        }
-        case (_: SpatialKey, _: MultibandTile) => {
-          case (k: K, v: V) =>
-            val extent = mt(k.asInstanceOf[SpatialKey]).reproject(crs, LatLng)
-            val tile = v.asInstanceOf[MultibandTile]
-            ProjectedRaster(Raster(tile, extent), LatLng).toGridCoverage2D
-        }
-      }
+      case (k: SpatialKey, tile: Tile) =>
+        val extent = mt(k.asInstanceOf[SpatialKey]).reproject(crs, LatLng)
+        ProjectedRaster(Raster(tile, extent), LatLng).toGridCoverage2D
+      case (k: SpatialKey, tile: MultibandTile) =>
+        val extent = mt(k.asInstanceOf[SpatialKey]).reproject(crs, LatLng)
+        ProjectedRaster(Raster(tile, extent), LatLng).toGridCoverage2D
     }
     val image = geotrellisKvToGeotools(specimen)
 
@@ -93,7 +82,7 @@ object GeowaveLayerWriter extends LazyLogging {
 
     val configOptions = pluginOptions.getFactoryOptionsAsMap
 
-    val geotrellisKvToGeoWaveKv: Iterable[(K, V)] => Iterable[(Key, Value)] = { pair =>
+    val geotrellisKvToGeoWaveKv: Iterable[(K, V)] => Iterable[(Key, Value)] = { pairs =>
       {
         val gwMetadata = new java.util.HashMap[String, String](); gwMetadata.put("cellType", cellType)
         configOptions.put(
@@ -101,7 +90,7 @@ object GeowaveLayerWriter extends LazyLogging {
           "accumulo")
 
         /* Produce mosaic from all of the tiles in this partition */
-        val sources = new java.util.ArrayList(pair.map(geotrellisKvToGeotools))
+        val sources = new java.util.ArrayList(pairs.map(geotrellisKvToGeotools))
         val accumuloKvs = ListBuffer[Iterable[(Key, Value)]]()
 
         /* Objects for writing into GeoWave */
@@ -122,9 +111,9 @@ object GeowaveLayerWriter extends LazyLogging {
           val adapter = new RasterDataAdapter(
             coverageName,
             gwMetadata,
-            image,
+            image,  // image only used for sample and color metadata, not data
             256, false, false,
-            Array.fill[Array[Double]](image.getNumSampleDimensions)(Array(0.0))) // image only used for sample and color metadata, not data, overriding default merge strategy because geotrellis data is already tiled (non-overlapping)
+            Array.fill[Array[Double]](image.getNumSampleDimensions)(Array(0.0))) // overriding default merge strategy because geotrellis data is already tiled (non-overlapping)
 
           for (
             statsAggregator <- managed(new StatsCompositionTool(new DataStoreStatisticsProvider(
@@ -139,7 +128,11 @@ object GeowaveLayerWriter extends LazyLogging {
               statsAggregator,
               DataStoreUtils.UNCONSTRAINED_VISIBILITY.asInstanceOf[VisibilityWriter[GridCoverage]])
 
-            adapter.convertToIndex(index, image).foreach { x => (accumuloKvs += (kvGen.constructKeyValuePairs(adapter.getAdapterId.getBytes, x).toList.map { kv => (kv.getKey, kv.getValue) })) }
+            adapter.convertToIndex(index, image).foreach({ i =>
+              val keyValues = kvGen.constructKeyValuePairs(adapter.getAdapterId.getBytes, i).toList
+              val keyValuePairs = keyValues.map({ kv => (kv.getKey, kv.getValue) })
+              accumuloKvs += keyValuePairs
+            })
           }
         }
         accumuloKvs.foldLeft(Iterable[(Key, Value)]())(_ ++ _)
@@ -165,7 +158,7 @@ object GeowaveLayerWriter extends LazyLogging {
       Array.fill[Array[Double]](image.getNumSampleDimensions)(Array(0.0))
     )
 
-    // make sure adapter get written
+    // make sure adapter gets written
     val adapterStore = new AccumuloAdapterStore(basicOperations)
     adapterStore.addAdapter(adapter)
 
@@ -224,26 +217,33 @@ class GeowaveLayerWriter(
   val attributeStore: GeowaveAttributeStore,
   val accumuloWriter: AccumuloWriteStrategy
 )(implicit sc: SparkContext)
-    extends LayerWriter[LayerId] with LazyLogging {
+    extends LazyLogging {
 
-  protected def _write[K: AvroRecordCodec: JsonFormat: ClassTag, V: AvroRecordCodec: ClassTag, M: JsonFormat: GetComponent[?, Bounds[K]]](
+  def write[
+    K <: SpatialKey: ClassTag,
+    V: TileOrMultibandTile: ClassTag,
+    M: JsonFormat: GetComponent[?, Bounds[K]]
+  ](id: LayerId, layer: RDD[(K, V)] with Metadata[M]): Unit =
+    layer.metadata.getComponent[Bounds[K]] match {
+      case keyBounds: KeyBounds[K] =>
+        _write[K, V, M](id, layer)
+      case EmptyBounds =>
+        throw new EmptyBoundsError("Cannot write layer with empty bounds.")
+    }
+
+  protected def _write[
+    K <: SpatialKey: ClassTag,
+    V: TileOrMultibandTile: ClassTag,
+    M: JsonFormat: GetComponent[?, Bounds[K]]
+  ](
     layerId: LayerId,
-    rdd: RDD[(K, V)] with Metadata[M],
-    keyIndex: KeyIndex[K]): Unit = {
-
+    rdd: RDD[(K, V)] with Metadata[M]
+  ): Unit = {
     val LayerId(coverageName, zoom) = layerId
     val specimen = rdd.first
 
-    // Perform checks
-    if (zoom > 0) logger.warn("The zoom level is mostly ignored because GeoWave does its own pyramiding")
-    specimen._1 match {
-      case _: SpatialKey =>
-      case _ => throw new Exception(s"Unsupported Key Type: ${implicitly[ClassTag[K]].toString}")
-    }
-    specimen._2 match {
-      case _: Tile =>
-      case _: MultibandTile =>
-      case _ => throw new Exception(s"Unsupported Value Type: ${implicitly[ClassTag[V]].toString}")
+    if (zoom > 0) {
+      logger.warn("The zoom level is mostly ignored because GeoWave has its own notion of zoom level.")
     }
 
     GeowaveLayerWriter.write(coverageName, rdd, attributeStore, accumuloWriter)

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -89,7 +89,7 @@ object GeowaveLayerWriter extends LazyLogging {
     val image = geotrellisKvToGeotools(specimen)
 
     val pluginOptions = new DataStorePluginOptions
-    pluginOptions.setFactoryOptions(as.aro)
+    pluginOptions.setFactoryOptions(as.accumuloRequiredOptions)
 
     val configOptions = pluginOptions.getFactoryOptionsAsMap
 

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -1,0 +1,156 @@
+package geotrellis.spark.io.geowave
+
+import geotrellis.geotools._
+import geotrellis.proj4.LatLng
+import geotrellis.raster._
+import geotrellis.raster.resample.NearestNeighbor
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.avro._
+import geotrellis.spark.io.index.KeyIndex
+import geotrellis.util._
+import geotrellis.vector.Extent
+
+import com.typesafe.scalalogging.slf4j._
+import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
+import mil.nga.giat.geowave.core.geotime.ingest._
+import mil.nga.giat.geowave.core.store._
+import mil.nga.giat.geowave.datastore.accumulo._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+import org.geotools.coverage.grid.GridCoverage2D
+import org.geotools.coverage.processing.CoverageProcessor
+import org.geotools.coverage.processing.operation.Mosaic
+import org.geotools.coverage.processing.operation.Mosaic.GridGeometryPolicy
+import org.geotools.factory.{GeoTools, Hints}
+import org.opengis.coverage.grid.GridCoverage
+import org.opengis.parameter.ParameterValueGroup
+
+import spray.json._
+
+import scala.reflect._
+import javax.media.jai.{ImageLayout, JAI}
+
+object GeowaveLayerWriter extends LazyLogging {
+
+  def write[
+    K: ClassTag,
+    V: ClassTag,
+    M: JsonFormat: GetComponent[?, Bounds[K]]
+  ](
+    coverageName: String,
+    rdd: RDD[(K, V)] with Metadata[M],
+    zookeeper: String,
+    accumuloInstance: String,
+    accumuloUser: String,
+    accumuloPass: String,
+    geowaveNamespace: String
+  ): Unit = {
+    val metadata = implicitly[ClassTag[K]].toString match {
+      case "geotrellis.spark.SpatialKey" => rdd.metadata.asInstanceOf[TileLayerMetadata[SpatialKey]]
+      case t: String => throw new Exception(s"Unsupported Key Type: $t")
+    }
+    val crs = metadata.crs
+    val mt = metadata.mapTransform
+    val cellType = metadata.cellType.toString
+    val specimen = rdd.first
+
+    rdd.mapPartitions({ partition =>
+      val gwMetadata = new java.util.HashMap[String, String](); gwMetadata.put("cellType", cellType)
+
+      /* Construct (Multiband|)Tile to GridCoverage2D conversion function */
+      val fn: (((K, V)) => GridCoverage2D) = {
+        specimen match {
+          case (_ : SpatialKey, _: Tile) => { case (k: K, v: V) =>
+            val extent = mt(k.asInstanceOf[SpatialKey]).reproject(crs, LatLng)
+            val tile = v.asInstanceOf[Tile]
+            ProjectedRaster(Raster(tile, extent), LatLng).toGridCoverage2D
+          }
+          case (_ : SpatialKey, _: MultibandTile) => { case (k: K, v: V) =>
+            val extent = mt(k.asInstanceOf[SpatialKey]).reproject(crs, LatLng)
+            val tile = v.asInstanceOf[MultibandTile]
+            ProjectedRaster(Raster(tile, extent), LatLng).toGridCoverage2D
+          }
+        }
+      }
+
+      /* Produce mosaic from all of the tiles in this partition */
+      val sources = new java.util.ArrayList[GridCoverage2D]
+      val retval = partition.map({ case kv => sources.add(fn(kv)); Unit }); retval.toList
+      val processor = CoverageProcessor.getInstance(GeoTools.getDefaultHints())
+      val param = processor.getOperation("Mosaic").getParameters()
+      val hints = new Hints
+      val imageLayout = new ImageLayout
+      logger.info(s"partition size = ${sources.size}")
+      param.parameter("Sources").setValue(sources)
+      hints.put(JAI.KEY_IMAGE_LAYOUT, imageLayout)
+      imageLayout.setTileHeight(256)
+      imageLayout.setTileWidth(256)
+      val image = processor.doOperation(param, hints).asInstanceOf[GridCoverage2D]
+
+      /* Objects for writing into GeoWave */
+      if (sources.size > 0) {
+        val basicOperations = new BasicAccumuloOperations(
+          zookeeper,
+          accumuloInstance,
+          accumuloUser,
+          accumuloPass,
+          geowaveNamespace
+        )
+        val dataStore = new AccumuloDataStore(basicOperations)
+        val index = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
+        val adapter = new RasterDataAdapter(coverageName, gwMetadata, image, 256, true) // image only used for sample and color metadata, not data
+        val indexWriter = dataStore.createWriter(adapter, index).asInstanceOf[IndexWriter[GridCoverage]]
+
+        /* Write the mosaic into GeoWave */
+        indexWriter.write(image)
+        indexWriter.close
+
+        import org.geotools.gce.geotiff._
+        import org.opengis.parameter.GeneralParameterValue
+        val writer = new GeoTiffWriter(new java.io.File(s"/tmp/tif/writer-${System.currentTimeMillis}.tif"))
+        writer.write(image, Array.empty[GeneralParameterValue])
+      }
+      retval
+    }, preservesPartitioning = true).collect
+  }
+}
+
+class GeowaveLayerWriter(val attributeStore: GeowaveAttributeStore)(implicit sc: SparkContext)
+    extends LayerWriter[LayerId] with LazyLogging {
+
+  protected def _write[
+    K: AvroRecordCodec: JsonFormat: ClassTag,
+    V: AvroRecordCodec: ClassTag,
+    M: JsonFormat: GetComponent[?, Bounds[K]]
+  ](
+    layerId: LayerId,
+    rdd: RDD[(K, V)] with Metadata[M],
+    keyIndex: KeyIndex[K]
+  ): Unit = {
+    val LayerId(coverageName, zoom) = layerId
+    val specimen = rdd.first
+
+    // Perform checks
+    if (zoom > 0) logger.warn("The zoom level is ignored because GeoWave does its own pyramiding")
+    specimen._1 match {
+      case _: SpatialKey =>
+      case _ => throw new Exception(s"Unsupported Key Type: ${implicitly[ClassTag[K]].toString}")
+    }
+    specimen._2 match {
+      case _: Tile =>
+      case _: MultibandTile =>
+      case _ => throw new Exception(s"Unsupported Value Type: ${implicitly[ClassTag[V]].toString}")
+    }
+
+    GeowaveLayerWriter.write(
+      coverageName, rdd,
+      attributeStore.zookeeper,
+      attributeStore.accumuloInstance,
+      attributeStore.accumuloUser,
+      attributeStore.accumuloPass,
+      attributeStore.geowaveNamespace
+    )
+  }
+
+}

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -6,17 +6,52 @@ import geotrellis.raster._
 import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.spark._
 import geotrellis.spark.io._
+import geotrellis.spark.io.accumulo._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index.KeyIndex
+import geotrellis.spark.io.kryo.KryoRegistrator
 import geotrellis.util._
 import geotrellis.vector.Extent
 
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.{Kryo, Serializer}
 import com.typesafe.scalalogging.slf4j._
+import mil.nga.giat.geowave.adapter.raster.adapter.merge.RasterTileRowTransform
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
 import mil.nga.giat.geowave.core.geotime.ingest._
+import mil.nga.giat.geowave.core.index.Persistable
+import mil.nga.giat.geowave.core.index.PersistenceUtils
 import mil.nga.giat.geowave.core.store._
+import mil.nga.giat.geowave.core.store.adapter.statistics.DataStatistics
+import mil.nga.giat.geowave.core.store.adapter.statistics.RowRangeDataStatistics
+import mil.nga.giat.geowave.core.store.adapter.statistics.RowRangeHistogramStatistics
+import mil.nga.giat.geowave.core.store.adapter.statistics.StatsCompositionTool
+import mil.nga.giat.geowave.core.store.data.VisibilityWriter
+import mil.nga.giat.geowave.core.store.memory.DataStoreUtils
+import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions
+import mil.nga.giat.geowave.core.store.query.QueryOptions
 import mil.nga.giat.geowave.datastore.accumulo._
+import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterIndexMappingStore
+import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore
+import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloDataStatisticsStore
+import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloIndexStore
+import mil.nga.giat.geowave.datastore.accumulo.operations.config.AccumuloOptions
+import mil.nga.giat.geowave.datastore.accumulo.util.AccumuloKeyValuePair
+import mil.nga.giat.geowave.datastore.accumulo.util.AccumuloKeyValuePairGenerator
+import mil.nga.giat.geowave.datastore.accumulo.util.AccumuloUtils
+import mil.nga.giat.geowave.datastore.accumulo.util.ConnectorPool
+import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputFormat
+import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputKey
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.data.Key
+import org.apache.accumulo.core.data.Value
+import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.Writable
+import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.mapreduce.task.JobContextImpl
 import org.apache.spark.rdd.RDD
+import org.apache.spark.SerializableWritable
 import org.apache.spark.SparkContext
 import org.geotools.coverage.grid.GridCoverage2D
 import org.geotools.coverage.processing.CoverageProcessor
@@ -26,10 +61,17 @@ import org.geotools.factory.{GeoTools, Hints}
 import org.opengis.coverage.grid.GridCoverage
 import org.opengis.parameter.ParameterValueGroup
 
+import java.io.{DataInputStream, DataOutputStream, File}
+import java.util.UUID
+import javax.imageio.ImageIO
+import javax.media.jai.{ImageLayout, JAI}
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ListBuffer
+import scala.reflect._
+
+import resource._
 import spray.json._
 
-import scala.reflect._
-import javax.media.jai.{ImageLayout, JAI}
 
 object GeowaveLayerWriter extends LazyLogging {
 
@@ -40,97 +82,137 @@ object GeowaveLayerWriter extends LazyLogging {
   ](
     coverageName: String,
     rdd: RDD[(K, V)] with Metadata[M],
-    zookeeper: String,
-    accumuloInstance: String,
-    accumuloUser: String,
-    accumuloPass: String,
-    geowaveNamespace: String
+    as: GeowaveAttributeStore,
+    accumuloWriter: AccumuloWriteStrategy
   ): Unit = {
     val metadata = implicitly[ClassTag[K]].toString match {
       case "geotrellis.spark.SpatialKey" => rdd.metadata.asInstanceOf[TileLayerMetadata[SpatialKey]]
       case t: String => throw new Exception(s"Unsupported Key Type: $t")
     }
+
     val crs = metadata.crs
     val mt = metadata.mapTransform
     val cellType = metadata.cellType.toString
     val specimen = rdd.first
 
-    rdd
-      .sortBy({ case (k, v) => SpatialKey.keyToTup(k.asInstanceOf[SpatialKey]) })
-      .groupBy({ case (k, _) => k.asInstanceOf[SpatialKey]._1 })
-      .map(_._2)
-      .foreach({ partition =>
-      val gwMetadata = new java.util.HashMap[String, String](); gwMetadata.put("cellType", cellType)
-
-      /* Construct (Multiband|)Tile to GridCoverage2D conversion function */
-      val fn: (((K, V)) => GridCoverage2D) = {
-        specimen match {
-          case (_ : SpatialKey, _: Tile) => { case (k: K, v: V) =>
+    /* Construct (Multiband|)Tile to GridCoverage2D conversion function */
+    val geotrellisKvToGeotools: (((K, V)) => GridCoverage2D) = {
+      specimen match {
+        case (_: SpatialKey, _: Tile) => {
+          case (k: K, v: V) =>
             val extent = mt(k.asInstanceOf[SpatialKey]).reproject(crs, LatLng)
             val tile = v.asInstanceOf[Tile]
             ProjectedRaster(Raster(tile, extent), LatLng).toGridCoverage2D
-          }
-          case (_ : SpatialKey, _: MultibandTile) => { case (k: K, v: V) =>
+        }
+        case (_: SpatialKey, _: MultibandTile) => {
+          case (k: K, v: V) =>
             val extent = mt(k.asInstanceOf[SpatialKey]).reproject(crs, LatLng)
             val tile = v.asInstanceOf[MultibandTile]
             ProjectedRaster(Raster(tile, extent), LatLng).toGridCoverage2D
-          }
         }
       }
+    }
+    val image = geotrellisKvToGeotools(specimen)
 
+    val pluginOptions = new DataStorePluginOptions
+    pluginOptions.setFactoryOptions(as.aro)
+    val configOptions = pluginOptions.getFactoryOptionsAsMap
+    val geotrellisKvToGeoWaveKv: Iterable[(K, V)] => Iterable[(Key, Value)] = p => {
+      val gwMetadata = new java.util.HashMap[String, String](); gwMetadata.put("cellType", cellType)
+      configOptions.put(
+        GeoWaveStoreFinder.STORE_HINT_OPTION.getName(),
+        "accumulo")
       /* Produce mosaic from all of the tiles in this partition */
       val sources = new java.util.ArrayList[GridCoverage2D]
-      partition.map({ case kv => sources.add(fn(kv)); Unit }).toList
-      val processor = CoverageProcessor.getInstance(GeoTools.getDefaultHints())
-      val param = processor.getOperation("Mosaic").getParameters()
-      val hints = new Hints
-      val imageLayout = new ImageLayout
-      logger.info(s"partition size = ${sources.size}")
-      param.parameter("Sources").setValue(sources)
-      hints.put(JAI.KEY_IMAGE_LAYOUT, imageLayout)
-      imageLayout.setTileHeight(256)
-      imageLayout.setTileWidth(256)
-      val image = processor.doOperation(param, hints).asInstanceOf[GridCoverage2D]
-
+      p.map({ case kv => sources.add(geotrellisKvToGeotools(kv)); Unit }).toList
+      val accumuloKvs = ListBuffer[Iterable[(Key, Value)]]()
       /* Objects for writing into GeoWave */
       if (sources.size > 0) {
-        val basicOperations = new BasicAccumuloOperations(
-          zookeeper,
-          accumuloInstance,
-          accumuloUser,
-          accumuloPass,
-          geowaveNamespace
-        )
-        val dataStore = new AccumuloDataStore(basicOperations)
+        val processor = CoverageProcessor.getInstance(GeoTools.getDefaultHints())
+        val param = processor.getOperation("Mosaic").getParameters()
+        val hints = new Hints
+        val imageLayout = new ImageLayout
+        logger.info(s"partition size = ${sources.size}")
+        param.parameter("Sources").setValue(sources)
+        hints.put(JAI.KEY_IMAGE_LAYOUT, imageLayout)
+        imageLayout.setTileHeight(256)
+        imageLayout.setTileWidth(256)
         val index = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
-        val adapter = new RasterDataAdapter(coverageName, gwMetadata, image, 256, true) // image only used for sample and color metadata, not data, overriding default merge strategy because geotrellis data is already tiled (non-overlapping)
-        val indexWriter = dataStore.createWriter(adapter, index).asInstanceOf[IndexWriter[GridCoverage]]
+        val image = processor.doOperation(param, hints).asInstanceOf[GridCoverage2D]
+        val adapter = new RasterDataAdapter(coverageName, gwMetadata, image, 256, false, false, Array.fill[Array[Double]](image.getNumSampleDimensions)(Array(0.0))) // image only used for sample and color metadata, not data, overriding default merge strategy because geotrellis data is already tiled (non-overlapping)
+        for (
+          statsAggregator <- managed(new StatsCompositionTool(new DataStoreStatisticsProvider(
+            adapter,
+            index,
+            true),
+            GeoWaveStoreFinder.createDataStatisticsStore(configOptions)))
+        ) {
+          val kvGen = new AccumuloKeyValuePairGenerator[GridCoverage](
+            adapter,
+            index,
+            statsAggregator,
+            DataStoreUtils.UNCONSTRAINED_VISIBILITY.asInstanceOf[VisibilityWriter[GridCoverage]])
 
-        /* Write the mosaic into GeoWave */
-        indexWriter.write(image)
-        indexWriter.close
-
-        import org.geotools.gce.geotiff._
-        import org.opengis.parameter.GeneralParameterValue
-        val writer = new GeoTiffWriter(new java.io.File(s"/tmp/tif/writer-${System.currentTimeMillis}.tif"))
-        writer.write(image, Array.empty[GeneralParameterValue])
+          adapter.convertToIndex(index, image).foreach { x => (accumuloKvs += (kvGen.constructKeyValuePairs(adapter.getAdapterId.getBytes, x).toList.map { kv => (kv.getKey, kv.getValue) })) }
+        }
       }
-    })
+      accumuloKvs.foldLeft(Iterable[(Key, Value)]())(_ ++ _)
+    }
+    val index = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
+    val indexName = index.getId.getString
+    val tableName = AccumuloUtils.getQualifiedTableName(as.geowaveNamespace, indexName)
+
+    val gwMetadata = new java.util.HashMap[String, String](); gwMetadata.put("cellType", cellType)
+    val basicOperations = new BasicAccumuloOperations(
+      as.zookeeper,
+      as.accumuloInstance,
+      as.accumuloUser,
+      as.accumuloPass,
+      as.geowaveNamespace)
+    val adapter = new RasterDataAdapter(coverageName, gwMetadata, image, 256, true, false, Array.fill[Array[Double]](image.getNumSampleDimensions)(Array(0.0)))
+    //make sure adapter and index get written
+    val adapterStore = new AccumuloAdapterStore(basicOperations)
+    adapterStore.addAdapter(adapter)
+    val indexStore = new AccumuloIndexStore(basicOperations)
+    indexStore.addIndex(index)
+    //make sure adapter and index are associated together in the mapping store
+    val mappingStore = new AccumuloAdapterIndexMappingStore(basicOperations)
+    mappingStore.addAdapterIndexMapping(new AdapterToIndexMapping(adapter.getAdapterId, Array(index.getId)))
+    AccumuloUtils.attachRowMergingIterators(
+      adapter,
+      basicOperations,
+      new AccumuloOptions,
+      index.getIndexStrategy().getNaturalSplits(),
+      indexName)
+    accumuloWriter.write(
+      rdd
+        .sortBy({ case (k, v) => SpatialKey.keyToTup(k.asInstanceOf[SpatialKey]) })
+        .groupBy({ case (k, _) => k.asInstanceOf[SpatialKey]._1 })
+        .map(_._2)
+        .mapPartitions(partitions => partitions.map(geotrellisKvToGeoWaveKv)).flatMap(i => i), AccumuloInstance(as.accumuloInstance, as.zookeeper, as.accumuloUser, new PasswordToken(as.accumuloPass)), tableName)
+
+    //compact and detach iterator
+    val conn = ConnectorPool.getInstance.getConnector(as.zookeeper,
+      as.accumuloInstance,
+      as.accumuloUser,
+      as.accumuloPass)
+    val ops = conn.tableOperations()
+    ops.compact(tableName, null, null, true, true)
+    val iterators = ops.listIterators(tableName)
+    iterators.foreach(kv => if (kv._1.startsWith(RasterTileRowTransform.TRANSFORM_NAME)) { ops.removeIterator(tableName, kv._1, kv._2) })
   }
 }
 
-class GeowaveLayerWriter(val attributeStore: GeowaveAttributeStore)(implicit sc: SparkContext)
+class GeowaveLayerWriter(
+  val attributeStore: GeowaveAttributeStore,
+  val accumuloWriter: AccumuloWriteStrategy
+)(implicit sc: SparkContext)
     extends LayerWriter[LayerId] with LazyLogging {
 
-  protected def _write[
-    K: AvroRecordCodec: JsonFormat: ClassTag,
-    V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
-  ](
+  protected def _write[K: AvroRecordCodec: JsonFormat: ClassTag, V: AvroRecordCodec: ClassTag, M: JsonFormat: GetComponent[?, Bounds[K]]](
     layerId: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
-    keyIndex: KeyIndex[K]
-  ): Unit = {
+    keyIndex: KeyIndex[K]): Unit = {
     val LayerId(coverageName, zoom) = layerId
     val specimen = rdd.first
 
@@ -146,14 +228,7 @@ class GeowaveLayerWriter(val attributeStore: GeowaveAttributeStore)(implicit sc:
       case _ => throw new Exception(s"Unsupported Value Type: ${implicitly[ClassTag[V]].toString}")
     }
 
-    GeowaveLayerWriter.write(
-      coverageName, rdd,
-      attributeStore.zookeeper,
-      attributeStore.accumuloInstance,
-      attributeStore.accumuloUser,
-      attributeStore.accumuloPass,
-      attributeStore.geowaveNamespace
-    )
+    GeowaveLayerWriter.write(coverageName, rdd, attributeStore, accumuloWriter)
   }
 
 }

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -3,68 +3,42 @@ package geotrellis.spark.io.geowave
 import geotrellis.geotools._
 import geotrellis.proj4.LatLng
 import geotrellis.raster._
-import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.accumulo._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index.KeyIndex
-import geotrellis.spark.io.kryo.KryoRegistrator
 import geotrellis.util._
 import geotrellis.vector.Extent
 
-import com.esotericsoftware.kryo.io.{Input, Output}
-import com.esotericsoftware.kryo.{Kryo, Serializer}
 import com.typesafe.scalalogging.slf4j._
 import mil.nga.giat.geowave.adapter.raster.adapter.merge.RasterTileRowTransform
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
 import mil.nga.giat.geowave.core.geotime.ingest._
-import mil.nga.giat.geowave.core.index.Persistable
-import mil.nga.giat.geowave.core.index.PersistenceUtils
 import mil.nga.giat.geowave.core.store._
-import mil.nga.giat.geowave.core.store.adapter.statistics.DataStatistics
-import mil.nga.giat.geowave.core.store.adapter.statistics.RowRangeDataStatistics
-import mil.nga.giat.geowave.core.store.adapter.statistics.RowRangeHistogramStatistics
 import mil.nga.giat.geowave.core.store.adapter.statistics.StatsCompositionTool
 import mil.nga.giat.geowave.core.store.data.VisibilityWriter
-import mil.nga.giat.geowave.core.store.memory.DataStoreUtils
 import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions
-import mil.nga.giat.geowave.core.store.query.QueryOptions
+import mil.nga.giat.geowave.core.store.util.DataStoreUtils
 import mil.nga.giat.geowave.datastore.accumulo._
-import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterIndexMappingStore
-import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore
-import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloDataStatisticsStore
-import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloIndexStore
+import mil.nga.giat.geowave.datastore.accumulo.metadata._
 import mil.nga.giat.geowave.datastore.accumulo.operations.config.AccumuloOptions
-import mil.nga.giat.geowave.datastore.accumulo.util.AccumuloKeyValuePair
-import mil.nga.giat.geowave.datastore.accumulo.util.AccumuloKeyValuePairGenerator
+import mil.nga.giat.geowave.datastore.accumulo.util._
 import mil.nga.giat.geowave.datastore.accumulo.util.AccumuloUtils
-import mil.nga.giat.geowave.datastore.accumulo.util.ConnectorPool
-import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputFormat
-import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputKey
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
-import org.apache.accumulo.core.data.Key
-import org.apache.accumulo.core.data.Value
-import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope
-import org.apache.hadoop.fs.Path
-import org.apache.hadoop.io.Writable
-import org.apache.hadoop.mapreduce.Job
-import org.apache.hadoop.mapreduce.task.JobContextImpl
+import org.apache.accumulo.core.data.{ Key, Value }
 import org.apache.spark.rdd.RDD
-import org.apache.spark.SerializableWritable
 import org.apache.spark.SparkContext
 import org.geotools.coverage.grid.GridCoverage2D
 import org.geotools.coverage.processing.CoverageProcessor
-import org.geotools.coverage.processing.operation.Mosaic
-import org.geotools.coverage.processing.operation.Mosaic.GridGeometryPolicy
-import org.geotools.factory.{GeoTools, Hints}
+import org.geotools.factory.{ GeoTools, Hints }
 import org.opengis.coverage.grid.GridCoverage
 import org.opengis.parameter.ParameterValueGroup
 
-import java.io.{DataInputStream, DataOutputStream, File}
+import java.io.{ DataInputStream, DataOutputStream, File }
 import java.util.UUID
 import javax.imageio.ImageIO
-import javax.media.jai.{ImageLayout, JAI}
+import javax.media.jai.{ ImageLayout, JAI }
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
 import scala.reflect._
@@ -116,68 +90,94 @@ object GeowaveLayerWriter extends LazyLogging {
 
     val pluginOptions = new DataStorePluginOptions
     pluginOptions.setFactoryOptions(as.aro)
-    val configOptions = pluginOptions.getFactoryOptionsAsMap
-    val geotrellisKvToGeoWaveKv: Iterable[(K, V)] => Iterable[(Key, Value)] = p => {
-      val gwMetadata = new java.util.HashMap[String, String](); gwMetadata.put("cellType", cellType)
-      configOptions.put(
-        GeoWaveStoreFinder.STORE_HINT_OPTION.getName(),
-        "accumulo")
-      /* Produce mosaic from all of the tiles in this partition */
-      val sources = new java.util.ArrayList[GridCoverage2D]
-      p.map({ case kv => sources.add(geotrellisKvToGeotools(kv)); Unit }).toList
-      val accumuloKvs = ListBuffer[Iterable[(Key, Value)]]()
-      /* Objects for writing into GeoWave */
-      if (sources.size > 0) {
-        val processor = CoverageProcessor.getInstance(GeoTools.getDefaultHints())
-        val param = processor.getOperation("Mosaic").getParameters()
-        val hints = new Hints
-        val imageLayout = new ImageLayout
-        logger.info(s"partition size = ${sources.size}")
-        param.parameter("Sources").setValue(sources)
-        hints.put(JAI.KEY_IMAGE_LAYOUT, imageLayout)
-        imageLayout.setTileHeight(256)
-        imageLayout.setTileWidth(256)
-        val index = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
-        val image = processor.doOperation(param, hints).asInstanceOf[GridCoverage2D]
-        val adapter = new RasterDataAdapter(coverageName, gwMetadata, image, 256, false, false, Array.fill[Array[Double]](image.getNumSampleDimensions)(Array(0.0))) // image only used for sample and color metadata, not data, overriding default merge strategy because geotrellis data is already tiled (non-overlapping)
-        for (
-          statsAggregator <- managed(new StatsCompositionTool(new DataStoreStatisticsProvider(
-            adapter,
-            index,
-            true),
-            GeoWaveStoreFinder.createDataStatisticsStore(configOptions)))
-        ) {
-          val kvGen = new AccumuloKeyValuePairGenerator[GridCoverage](
-            adapter,
-            index,
-            statsAggregator,
-            DataStoreUtils.UNCONSTRAINED_VISIBILITY.asInstanceOf[VisibilityWriter[GridCoverage]])
 
-          adapter.convertToIndex(index, image).foreach { x => (accumuloKvs += (kvGen.constructKeyValuePairs(adapter.getAdapterId.getBytes, x).toList.map { kv => (kv.getKey, kv.getValue) })) }
+    val configOptions = pluginOptions.getFactoryOptionsAsMap
+
+    val geotrellisKvToGeoWaveKv: Iterable[(K, V)] => Iterable[(Key, Value)] = { pair =>
+      {
+        val gwMetadata = new java.util.HashMap[String, String](); gwMetadata.put("cellType", cellType)
+        configOptions.put(
+          GeoWaveStoreFinder.STORE_HINT_OPTION.getName(),
+          "accumulo")
+
+        /* Produce mosaic from all of the tiles in this partition */
+        val sources = new java.util.ArrayList[GridCoverage2D]
+        pair.map({ case kv => sources.add(geotrellisKvToGeotools(kv)); Unit }).toList
+        val accumuloKvs = ListBuffer[Iterable[(Key, Value)]]()
+
+        /* Objects for writing into GeoWave */
+        if (sources.size > 0) {
+          val processor = CoverageProcessor.getInstance(GeoTools.getDefaultHints())
+          val param = processor.getOperation("Mosaic").getParameters()
+          val hints = new Hints
+          val imageLayout = new ImageLayout
+          imageLayout.setTileHeight(256)
+          imageLayout.setTileWidth(256)
+
+          logger.info(s"partition size = ${sources.size}")
+          param.parameter("Sources").setValue(sources)
+          hints.put(JAI.KEY_IMAGE_LAYOUT, imageLayout)
+
+          val index = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
+          val image = processor.doOperation(param, hints).asInstanceOf[GridCoverage2D]
+          val adapter = new RasterDataAdapter(
+            coverageName,
+            gwMetadata,
+            image,
+            256, false, false,
+            Array.fill[Array[Double]](image.getNumSampleDimensions)(Array(0.0))) // image only used for sample and color metadata, not data, overriding default merge strategy because geotrellis data is already tiled (non-overlapping)
+
+          for (
+            statsAggregator <- managed(new StatsCompositionTool(new DataStoreStatisticsProvider(
+              adapter,
+              index,
+              true),
+              GeoWaveStoreFinder.createDataStatisticsStore(configOptions)))
+          ) {
+            val kvGen = new AccumuloKeyValuePairGenerator[GridCoverage](
+              adapter,
+              index,
+              statsAggregator,
+              DataStoreUtils.UNCONSTRAINED_VISIBILITY.asInstanceOf[VisibilityWriter[GridCoverage]])
+
+            adapter.convertToIndex(index, image).foreach { x => (accumuloKvs += (kvGen.constructKeyValuePairs(adapter.getAdapterId.getBytes, x).toList.map { kv => (kv.getKey, kv.getValue) })) }
+          }
         }
+        accumuloKvs.foldLeft(Iterable[(Key, Value)]())(_ ++ _)
       }
-      accumuloKvs.foldLeft(Iterable[(Key, Value)]())(_ ++ _)
     }
+
     val index = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
     val indexName = index.getId.getString
     val tableName = AccumuloUtils.getQualifiedTableName(as.geowaveNamespace, indexName)
 
     val gwMetadata = new java.util.HashMap[String, String](); gwMetadata.put("cellType", cellType)
     val basicOperations = new BasicAccumuloOperations(
-      as.zookeeper,
+      as.zookeepers,
       as.accumuloInstance,
       as.accumuloUser,
       as.accumuloPass,
       as.geowaveNamespace)
-    val adapter = new RasterDataAdapter(coverageName, gwMetadata, image, 256, true, false, Array.fill[Array[Double]](image.getNumSampleDimensions)(Array(0.0)))
-    //make sure adapter and index get written
+    val adapter = new RasterDataAdapter(
+      coverageName,
+      gwMetadata,
+      image,
+      256, true, false,
+      Array.fill[Array[Double]](image.getNumSampleDimensions)(Array(0.0))
+    )
+
+    // make sure adapter get written
     val adapterStore = new AccumuloAdapterStore(basicOperations)
     adapterStore.addAdapter(adapter)
+
+    // make sure index gets written
     val indexStore = new AccumuloIndexStore(basicOperations)
     indexStore.addIndex(index)
-    //make sure adapter and index are associated together in the mapping store
+
+    // make sure adapter and index are associated together in the mapping store
     val mappingStore = new AccumuloAdapterIndexMappingStore(basicOperations)
     mappingStore.addAdapterIndexMapping(new AdapterToIndexMapping(adapter.getAdapterId, Array(index.getId)))
+
     AccumuloUtils.attachRowMergingIterators(
       adapter,
       basicOperations,
@@ -189,17 +189,35 @@ object GeowaveLayerWriter extends LazyLogging {
         .sortBy({ case (k, v) => SpatialKey.keyToTup(k.asInstanceOf[SpatialKey]) })
         .groupBy({ case (k, _) => k.asInstanceOf[SpatialKey]._1 })
         .map(_._2)
-        .mapPartitions(partitions => partitions.map(geotrellisKvToGeoWaveKv)).flatMap(i => i), AccumuloInstance(as.accumuloInstance, as.zookeeper, as.accumuloUser, new PasswordToken(as.accumuloPass)), tableName)
+        .mapPartitions({ partitions => partitions.map(geotrellisKvToGeoWaveKv) })
+        .flatMap(i => i), // first argument to accumuloWriter.write
+      AccumuloInstance(
+        as.accumuloInstance,
+        as.zookeepers,
+        as.accumuloUser,
+        new PasswordToken(as.accumuloPass)
+      ), // second argument
+      tableName // third argument
+    )
 
-    //compact and detach iterator
-    val conn = ConnectorPool.getInstance.getConnector(as.zookeeper,
+    val conn = ConnectorPool.getInstance.getConnector(
+      as.zookeepers,
       as.accumuloInstance,
       as.accumuloUser,
-      as.accumuloPass)
+      as.accumuloPass
+    )
+
+    // compact
     val ops = conn.tableOperations()
     ops.compact(tableName, null, null, true, true)
+
+    // detach iterator
     val iterators = ops.listIterators(tableName)
-    iterators.foreach(kv => if (kv._1.startsWith(RasterTileRowTransform.TRANSFORM_NAME)) { ops.removeIterator(tableName, kv._1, kv._2) })
+    iterators.foreach({ kv =>
+      if (kv._1.startsWith(RasterTileRowTransform.TRANSFORM_NAME)) {
+        ops.removeIterator(tableName, kv._1, kv._2)
+      }
+    })
   }
 }
 
@@ -213,11 +231,12 @@ class GeowaveLayerWriter(
     layerId: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
     keyIndex: KeyIndex[K]): Unit = {
+
     val LayerId(coverageName, zoom) = layerId
     val specimen = rdd.first
 
     // Perform checks
-    if (zoom > 0) logger.warn("The zoom level is ignored because GeoWave does its own pyramiding")
+    if (zoom > 0) logger.warn("The zoom level is mostly ignored because GeoWave does its own pyramiding")
     specimen._1 match {
       case _: SpatialKey =>
       case _ => throw new Exception(s"Unsupported Key Type: ${implicitly[ClassTag[K]].toString}")

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -132,19 +132,8 @@ object GeowaveLayerWriter extends LazyLogging {
           param.parameter("Sources").setValue(sources)
           hints.put(JAI.KEY_IMAGE_LAYOUT, imageLayout)
 
-          val index = {
-            val SPATIAL_DIMENSIONS = Array[SFCDimensionDefinition](
-              new SFCDimensionDefinition(new LongitudeDefinition, bits),
-              new SFCDimensionDefinition(new LatitudeDefinition(true), bits)
-            )
-            val model = (new SpatialDimensionalityTypeProvider).createPrimaryIndex.getIndexModel
-            val strategy = TieredSFCIndexFactory.createSingleTierStrategy(
-              SPATIAL_DIMENSIONS,
-              SFCType.HILBERT
-            )
+          val index = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
 
-            new PrimaryIndex(strategy, model)
-          }
           val image = processor.doOperation(param, hints).asInstanceOf[GridCoverage2D]
           val adapter = new RasterDataAdapter(
             coverageName,

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -11,7 +11,7 @@ import geotrellis.spark.io.index.KeyIndex
 import geotrellis.util._
 import geotrellis.vector.Extent
 
-import com.typesafe.scalalogging.slf4j._
+import com.typesafe.scalalogging.LazyLogging
 import mil.nga.giat.geowave.adapter.raster.adapter.merge.RasterTileRowTransform
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
 import mil.nga.giat.geowave.core.geotime.index.dimension._

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -70,7 +70,7 @@ object GeowaveLayerWriter extends LazyLogging {
     val specimen = rdd.first
 
     /* Construct (Multiband|)Tile to GridCoverage2D conversion function */
-    val geotrellisKvToGeotools: (((K, V)) => GridCoverage2D) = {
+    val geotrellisKvToGeotools: ((K, V)) => GridCoverage2D = {
       specimen match {
         case (_: SpatialKey, _: Tile) => {
           case (k: K, v: V) =>
@@ -101,8 +101,7 @@ object GeowaveLayerWriter extends LazyLogging {
           "accumulo")
 
         /* Produce mosaic from all of the tiles in this partition */
-        val sources = new java.util.ArrayList[GridCoverage2D]
-        pair.map({ case kv => sources.add(geotrellisKvToGeotools(kv)); Unit }).toList
+        val sources = new java.util.ArrayList(pair.map(geotrellisKvToGeotools))
         val accumuloKvs = ListBuffer[Iterable[(Key, Value)]]()
 
         /* Objects for writing into GeoWave */

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveUtil.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveUtil.scala
@@ -1,0 +1,19 @@
+package geotrellis.spark.io.geowave
+
+import scala.math.{ abs, pow, round }
+
+
+object GeowaveUtil {
+  /**
+    * If an edge or corner of an extent is very close to a split in
+    * the GeoWave index (for some given number of bits), then it
+    * should be snapped to the split to avoid pathological behavior).
+    */
+  def rectify(bits: Int)(_x: Double) = {
+    val division = if (bits > 0) pow(2, -bits) ; else 1
+    val x = (_x / 360.0) / division
+    val xPrime = round(x)
+
+    360 * division * (if (abs(x - xPrime) < 0.000001) xPrime ; else x)
+  }
+}

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/SerializablePersistable.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/SerializablePersistable.scala
@@ -1,0 +1,30 @@
+package geotrellis.spark.io.geowave
+
+import mil.nga.giat.geowave.core.index.Persistable
+import mil.nga.giat.geowave.core.index.PersistenceUtils
+import org.apache.hadoop.io.ObjectWritable
+import org.apache.spark.util.Utils
+
+import java.io.{ObjectInputStream, ObjectOutputStream}
+
+
+class SerializablePersistable[T <: Persistable](@transient var t: T)
+    extends Serializable {
+
+  def value: T = t
+
+  override def toString: String = t.toString
+
+  private def writeObject(out: ObjectOutputStream): Unit = {
+    val bytes = PersistenceUtils.toBinary(t)
+    out.writeInt(bytes.length)
+    out.write(bytes)
+  }
+
+  private def readObject(in: ObjectInputStream): Unit = {
+    val length = in.readInt()
+    val bytes = new Array[Byte](length)
+    in.readFully(bytes)
+    t=PersistenceUtils.fromBinary(bytes, classOf[Persistable]).asInstanceOf[T]
+  }
+}

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/package.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/package.scala
@@ -1,0 +1,14 @@
+package geotrellis.spark.io
+
+import geotrellis.raster._
+
+
+package object geowave {
+
+  /* http://stackoverflow.com/questions/3508077/how-to-define-type-disjunction-union-types */
+  sealed class TileOrMultibandTile[T]
+  object TileOrMultibandTile {
+    implicit object TileWitness extends TileOrMultibandTile[Tile]
+    implicit object MultibandTileWitness extends TileOrMultibandTile[MultibandTile]
+  }
+}

--- a/geowave/src/main/scala/geotrellis/spark/io/kryo/GeowaveKryoRegistrator.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/kryo/GeowaveKryoRegistrator.scala
@@ -1,18 +1,20 @@
 package geotrellis.spark.io.kryo
 
-import com.esotericsoftware.kryo.io.Input
-import com.esotericsoftware.kryo.io.Output
+import com.esotericsoftware.kryo.io.{ Input, Output }
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Serializer
-import mil.nga.giat.geowave.core.index.Persistable
-import mil.nga.giat.geowave.core.index.PersistenceUtils
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
+import java.io.{ ObjectInputStream, ObjectOutputStream }
+import mil.nga.giat.geowave.core.index.{ Persistable, PersistenceUtils }
 import org.apache.accumulo.core.data.Key
+import org.geotools.coverage.grid.GridCoverage2D
 
 
 // GeoWave registrator
 class GeowaveKryoRegistrator extends KryoRegistrator {
   override def registerClasses(kryo: Kryo) = {
     kryo.addDefaultSerializer(classOf[Persistable], new PersistableSerializer())
+    kryo.addDefaultSerializer(classOf[GridCoverage2D], new GridCoverage2DSerializer())
     kryo.register(classOf[Key])
     super.registerClasses(kryo)
   }
@@ -33,4 +35,35 @@ class GeowaveKryoRegistrator extends KryoRegistrator {
       PersistenceUtils.fromBinary(bytes, classOf[Persistable])
     }
   }
+
+  // Serializer for GridCoverage2D.  Delegate to Java Serialization.
+  private class GridCoverage2DSerializer extends Serializer[GridCoverage2D] {
+    override def write(kryo: Kryo, output: Output, gc: GridCoverage2D): Unit = {
+      val bs = new ByteArrayOutputStream
+      val oos = new ObjectOutputStream(bs)
+
+      oos.writeObject(gc)
+
+      val bytes = bs.toByteArray
+
+      output.writeInt(bytes.length)
+      output.writeBytes(bytes)
+      bs.close ; oos.close
+    }
+
+    override def read(kryo: Kryo, input: Input, t: Class[GridCoverage2D]): GridCoverage2D = {
+      val length = input.readInt
+      val bytes = new Array[Byte](length)
+
+      input.read(bytes)
+
+      val bs = new ByteArrayInputStream(bytes)
+      val ois = new ObjectInputStream(bs)
+      val gc = ois.readObject.asInstanceOf[GridCoverage2D]
+
+      bs.close ; ois.close
+      gc
+    }
+  }
+
 }

--- a/geowave/src/main/scala/geotrellis/spark/io/kryo/GeowaveKryoRegistrator.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/kryo/GeowaveKryoRegistrator.scala
@@ -1,29 +1,24 @@
-package geotrellis.spark.io.geowave
+package geotrellis.spark.io.kryo
 
-import geotrellis.spark.io.kryo.KryoRegistrator
-
-import mil.nga.giat.geowave.core.index.Persistable
-import mil.nga.giat.geowave.core.index.PersistenceUtils
-import org.apache.accumulo.core.data.Key
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Serializer
+import mil.nga.giat.geowave.core.index.Persistable
+import mil.nga.giat.geowave.core.index.PersistenceUtils
+import org.apache.accumulo.core.data.Key
 
 
-object GeowaveKryoRegistrator {
-
-  // GeoWave registrator
-  class GeoWaveKryoRegistrator extends KryoRegistrator {
-    override def registerClasses(kryo: Kryo) = {
-      kryo.addDefaultSerializer(classOf[Persistable], new PersistableSerializer())
-      kryo.register(classOf[Key])
-      super.registerClasses(kryo)
-    }
+// GeoWave registrator
+class GeowaveKryoRegistrator extends KryoRegistrator {
+  override def registerClasses(kryo: Kryo) = {
+    kryo.addDefaultSerializer(classOf[Persistable], new PersistableSerializer())
+    kryo.register(classOf[Key])
+    super.registerClasses(kryo)
   }
 
   //Default serializer for any GeoWave Persistable object
-  class PersistableSerializer extends Serializer[Persistable] {
+  private class PersistableSerializer extends Serializer[Persistable] {
     override def write(kryo: Kryo, output: Output, geowaveObj: Persistable): Unit = {
       val bytes = PersistenceUtils.toBinary(geowaveObj)
       output.writeInt(bytes.length)

--- a/geowave/src/test/scala/geotrellis/spark/GeowaveTestEnvironment.scala
+++ b/geowave/src/test/scala/geotrellis/spark/GeowaveTestEnvironment.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2014 DigitalGlobe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark
+
+import geotrellis.spark.io.kryo.GeowaveKryoRegistrator
+
+import org.apache.spark.SparkConf
+import org.scalatest._
+
+
+trait GeowaveTestEnvironment extends TestEnvironment { self: Suite =>
+  override def setKryoRegistrator(conf: SparkConf) = {
+    conf
+      .set("spark.kryo.registrator", "geotrellis.spark.io.kryo.GeowaveKryoRegistrator")
+      .set("spark.kryo.registrationRequired", "false")
+  }
+}

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveAttributeStoreSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveAttributeStoreSpec.scala
@@ -12,7 +12,7 @@ class GeowaveAttributeStoreSpec
       .foreach(attributeStore.delete(_))
 
   lazy val attributeStore = new GeowaveAttributeStore(
-    "leader",
+    "leader:21810",
     "instance",
     "root",
     "password",

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveAttributeStoreSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveAttributeStoreSpec.scala
@@ -1,0 +1,25 @@
+package geotrellis.spark.io.geowave
+
+import geotrellis.spark.io.AttributeStoreSpec
+import org.scalatest.BeforeAndAfter
+
+class GeowaveAttributeStoreSpec
+    extends AttributeStoreSpec {
+
+  private def clear: Unit =
+    attributeStore
+      .layerIds
+      .foreach(attributeStore.delete(_))
+
+  lazy val attributeStore = new GeowaveAttributeStore(
+    "leader",
+    "instance",
+    "root",
+    "password",
+    "TEST"
+  )
+
+  it("should clean up after itself") {
+    clear
+  }
+}

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
@@ -90,7 +90,7 @@ class GeowaveSpatialSpec
   it("should write a layer") {
     val layer = reader.read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id1)
 
-    writer.write(id2, layer, ZCurveKeyIndexMethod)
+    writer.write(id2, layer)
   }
 
   it("should read a layer back") {

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
@@ -75,7 +75,7 @@ class GeowaveSpatialSpec
 
   it("should read an existing layer") {
     val img = getGridCoverage2D("spark/src/test/resources/elevation.tif")
-    val bo = attributeStore.getBasicAccumuloOperations
+    val bo = attributeStore.basicAccumuloOperations
 
     poke(bo, img)
 

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
@@ -31,7 +31,7 @@ class GeowaveSpatialSpec
   val gwNamespace = "TEST"
 
   val attributeStore = new GeowaveAttributeStore(
-    "leader",
+    "leader:21810",
     "instance",
     "root",
     "password",

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
@@ -1,0 +1,110 @@
+package geotrellis.spark.io.geowave
+
+import geotrellis.raster.Tile
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.accumulo.SocketWriteStrategy
+import geotrellis.spark.io.index.ZCurveKeyIndexMethod
+import geotrellis.spark.testfiles.TestFiles
+
+import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
+import mil.nga.giat.geowave.core.geotime.ingest._
+import mil.nga.giat.geowave.core.store._
+import mil.nga.giat.geowave.core.store.index.writer.IndexWriter
+import mil.nga.giat.geowave.datastore.accumulo._
+import org.geotools.coverage.grid._
+import org.geotools.gce.geotiff._
+import org.opengis.coverage.grid.GridCoverage
+import org.opengis.parameter.GeneralParameterValue
+
+import org.scalatest._
+
+
+class GeowaveSpatialSpec
+    extends FunSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with GeowaveTestEnvironment
+    with TestFiles
+{
+
+  val gwNamespace = "TEST"
+
+  val attributeStore = new GeowaveAttributeStore(
+    "leader",
+    "instance",
+    "root",
+    "password",
+    gwNamespace
+  )
+
+  val reader = new GeowaveLayerReader(attributeStore)
+  val writer = new GeowaveLayerWriter(attributeStore, SocketWriteStrategy())
+  val coverageName = "Sample Elevation 1"
+  val id1 = LayerId(coverageName, 11)
+  val id2 = LayerId("Sample Elevation 2", 11)
+
+  def getGridCoverage2D(filename: String): GridCoverage2D = {
+    val file = new java.io.File(filename)
+    val params = Array[GeneralParameterValue]()
+
+    new GeoTiffReader(file).read(params)
+  }
+
+  def poke(bo: BasicAccumuloOperations, img: GridCoverage2D): Unit = {
+    val metadata = new java.util.HashMap[String, String]()
+    val dataStore = new AccumuloDataStore(bo)
+    val index = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
+    val adapter = new RasterDataAdapter(coverageName, metadata, img, 256, true) // img only used for metadata, not data
+    val indexWriter = dataStore.createWriter(adapter, index).asInstanceOf[IndexWriter[GridCoverage]]
+
+    indexWriter.write(img)
+    indexWriter.close
+  }
+
+  def clear(): Unit = {
+    attributeStore.delete(s"${gwNamespace}_GEOWAVE_METADATA")
+    attributeStore.delete(s"${gwNamespace}_SPATIAL_IDX")
+  }
+
+  it("should not find layer before write") {
+    intercept[LayerNotFoundError] {
+      reader.read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id1)
+    }
+  }
+
+  it("should read an existing layer") {
+    val img = getGridCoverage2D("spark/src/test/resources/elevation.tif")
+    val bo = attributeStore.getBasicAccumuloOperations
+
+    poke(bo, img)
+
+    val layer = reader
+      .read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id1)
+      .map({ kv => 1 })
+      .collect()
+
+    layer.length should be (6)
+  }
+
+  it("should write a layer") {
+    val layer = reader.read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id1)
+
+    writer.write(id2, layer, ZCurveKeyIndexMethod)
+  }
+
+  it("should read a layer back") {
+    val original = reader
+      .read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id1)
+      .keys.count
+    val geowave = reader
+      .read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id2)
+      .keys.count
+
+    original should be (geowave)
+  }
+
+  it("should clean up after itself") {
+    clear
+  }
+}

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+miniAccumuloCluster-assembly-0.1.0.jar.1

--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -4,7 +4,7 @@
 ./sbt -J-Xmx2G "project cassandra" test  || { exit 1; }
 ./sbt -J-Xmx2G "project doc-examples" compile || { exit 1; }
 ./sbt -J-Xmx2G "project geotools" test || { exit 1; }
-./sbt -J-Xmx2G "project geowave" test || { exit 1; }
+HOSTALIASES=/tmp/hostaliases ./sbt -J-Xmx2G "project geowave" test || { exit 1; }
 ./sbt -J-Xmx2G "project hbase" test  || { exit 1; }
 ./sbt -J-Xmx2G "project proj4" test || { exit 1; }
 ./sbt -J-Xmx2G "project raster-test" test || { exit 1; }

--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -4,6 +4,7 @@
 ./sbt -J-Xmx2G "project cassandra" test  || { exit 1; }
 ./sbt -J-Xmx2G "project doc-examples" compile || { exit 1; }
 ./sbt -J-Xmx2G "project geotools" test || { exit 1; }
+./sbt -J-Xmx2G "project geowave" test || { exit 1; }
 ./sbt -J-Xmx2G "project hbase" test  || { exit 1; }
 ./sbt -J-Xmx2G "project proj4" test || { exit 1; }
 ./sbt -J-Xmx2G "project raster-test" test || { exit 1; }

--- a/scripts/cleanall.sh
+++ b/scripts/cleanall.sh
@@ -3,10 +3,10 @@
 ./sbt -J-Xmx2G "project accumulo" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project cassandra" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project geotools" clean || { exit 1; }
+./sbt -J-Xmx2G "project geowave" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project hbase" clean || { exit 1; }
 ./sbt -J-Xmx2G "project proj4" clean || { exit 1; }
 ./sbt -J-Xmx2G "project raster-test" clean || { exit 1; }
-./sbt -J-Xmx2G "project s3" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project shapefile" clean || { exit 1; }
 ./sbt -J-Xmx2G "project slick" clean || { exit 1; }
 ./sbt -J-Xmx2G "project spark" clean  || { exit 1; }

--- a/scripts/geowaveTestDB.sh
+++ b/scripts/geowaveTestDB.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-wget -k 'https://s3.amazonaws.com/geotrellis-test/geowave-minicluster/miniAccumuloCluster-assembly-0.1.0.jar'
+wget -c 'https://s3.amazonaws.com/geotrellis-test/geowave-minicluster/miniAccumuloCluster-assembly-0.1.0.jar'
 
-java -jar miniAccumuloCluster-assembly-0.1.0.jar
+java -cp miniAccumuloCluster-assembly-0.1.0.jar geotrellis.minicluster.Main

--- a/scripts/geowaveTestDB.sh
+++ b/scripts/geowaveTestDB.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+wget -k 'https://s3.amazonaws.com/geotrellis-test/geowave-minicluster/miniAccumuloCluster-assembly-0.1.0.jar'
+
+java -jar miniAccumuloCluster-assembly-0.1.0.jar

--- a/scripts/geowaveTestDB.sh
+++ b/scripts/geowaveTestDB.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-wget -c 'https://s3.amazonaws.com/geotrellis-test/geowave-minicluster/miniAccumuloCluster-assembly-0.1.0.jar'
-
-java -cp miniAccumuloCluster-assembly-0.1.0.jar geotrellis.minicluster.Main
+echo leader localhost > /tmp/hostaliases
+docker pull jamesmcclain/geowave:8760ce2
+docker network create --driver bridge geowave
+docker run -td --restart=always --net=geowave \
+       -p 50095:5009 -p 21810:2181 -p 9997:9997 -p 9999:9999 \
+       --hostname leader --name leader \
+       jamesmcclain/geowave:8760ce2

--- a/scripts/publish-local-crossversion.sh
+++ b/scripts/publish-local-crossversion.sh
@@ -3,6 +3,7 @@
 ./sbt "project accumulo" +publish-local && \
 ./sbt "project cassandra" +publish-local && \
 ./sbt "project geotools" +publish-local && \
+./sbt "project geowave" +publish-local && \
 ./sbt "project hbase" +publish-local && \
 ./sbt "project macros" +publish-local && \
 ./sbt "project proj4" +publish-local && \

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -4,6 +4,7 @@
 ./sbt "project accumulo" publish-local && \
 ./sbt "project cassandra" publish-local && \
 ./sbt "project geotools" publish-local && \
+./sbt "project geowave" publish-local && \
 ./sbt "project hbase" publish-local && \
 ./sbt "project macros" publish-local && \
 ./sbt "project proj4" publish-local && \

--- a/scripts/publish-m2.sh
+++ b/scripts/publish-m2.sh
@@ -10,6 +10,8 @@
       "project raster-testkit" +publish-m2 \
       "project s3" +publish-m2 \
       "project shapefile" +publish-m2 \
+      "project geotools" +publish-m2 \
+      "project geowave" +publish-m2 \
       "project slick" +publish-m2 \
       "project spark" +publish-m2 \
       "project spark-testkit" +publish-m2 \

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -3,6 +3,7 @@
 ./sbt "project accumulo" publish \
       "project cassandra" publish \
       "project geotools" publish \
+      "project geowave" publish \
       "project hbase" publish \
       "project macros" publish \
       "project proj4" publish \

--- a/scripts/runTestDBs.sh
+++ b/scripts/runTestDBs.sh
@@ -3,3 +3,4 @@
 ./slickTestDB.sh
 ./cassandraTestDB.sh
 ./hbaseTestDB.sh
+./geowaveTestDB.sh

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
@@ -26,7 +26,7 @@ object FileRDDReader {
     threads: Int = ConfigFactory.load().getThreads("geotrellis.file.threads.rdd.read")
   )(implicit sc: SparkContext): RDD[(K, V)] = {
     if(queryKeyBounds.isEmpty) return sc.emptyRDD[(K, V)]
-    
+
     val ranges = if (queryKeyBounds.length > 1)
       MergeQueue(queryKeyBounds.flatMap(decomposeBounds))
     else

--- a/spark/src/test/scala/geotrellis/spark/TestEnvironment.scala
+++ b/spark/src/test/scala/geotrellis/spark/TestEnvironment.scala
@@ -76,7 +76,7 @@ trait TestEnvironment extends BeforeAndAfterAll
       conf
         .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
         .set("spark.kryoserializer.buffer.max", "500m")
-        .set("spark.kryo.registrationRequired","false")
+        .set("spark.kryo.registrationRequired", "false")
       setKryoRegistrator(conf)
     }
 

--- a/spark/src/test/scala/geotrellis/spark/testfiles/SpatialTestFileValues.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/SpatialTestFileValues.scala
@@ -33,7 +33,7 @@ class IncreasingSpatialTiles(tileLayout: TileLayout, gridBounds: GridBounds) ext
     val tc = tileCol - gridBounds.colMin
     val tr = tileRow - gridBounds.rowMin
 
-    val r = (tr * tileLayout.tileRows + row) * (tileLayout.tileCols * gridBounds.width) 
+    val r = (tr * tileLayout.tileRows + row) * (tileLayout.tileCols * gridBounds.width)
     val c = (tc * tileLayout.tileCols) + col
 
     r + c


### PR DESCRIPTION
These changes add a GeoWave subproject, which includes a `GeowaveAttributeStore`, `GeowaveLayerReader`, and `GeowaveLayerWriter`.

   - [x] Missing metadata exception
   - [x] Reduction or elimination of use of `asInstanceOf`
   - [x] Fix `geotools` Tests
   - [x] Find work-arounds for bugs
   - [x] Unit Tests
   - [x] `GridCoverage2D` Kryo Serializer
   - [x] Address Feedback
   - [x] Hillshade Demo

Tests can be run locally and they pass, but there appears to be [insufficient memory to bring up GeoWave on Travis](https://travis-ci.org/geotrellis/geotrellis/builds/155751339):
```
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x0000000768680000, 51904512, 0) failed; error='Cannot allocate memory' (errno=12)
#
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (malloc) failed to allocate 51904512 bytes for committing reserved memory.
# An error report file with more information is saved as:
# /home/travis/build/geotrellis/geotrellis/hs_err_pid4764.log
+exit 1
The command ".travis/build-and-test.sh" exited with 1.
cache.2
store build cache
0.00s
2.98snothing changed, not updating cache
Done. Your build exited with 1.
```
