### PR TITLE
Modified travis test runs to cut down on run time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ cache:
   - "$HOME/.sbt"
 
 script:
-  - ./scripts/buildall.sh
+  - .travis/build-and-test.sh
 
 notifications:
   email:

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project spark" test  || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project accumulo" test  || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project proj4" test || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geotools" test || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project shapefile" compile || { exit 1; }

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -4,4 +4,4 @@
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project accumulo" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project proj4" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geotools" test || { exit 1; }
-./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project shapefile" compile || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project shapefile" test || { exit 1; }

--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -5,4 +5,4 @@
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project raster-test" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project s3" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project spark-etl" compile  || { exit 1; }
-./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project slick" test:compile || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project slick" test || { exit 1; }

--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project cassandra" test  || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project vector-test" test || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project raster-test" test || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project s3" test  || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project spark-etl" compile  || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project slick" test:compile || { exit 1; }

--- a/.travis/build-and-test.sh
+++ b/.travis/build-and-test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+COMMIT_HASH_NUMBER=`printf %i "'${TRAVIS_COMMIT: -1}"`
+SCALA_MINOR_VERSION_NUMBER=`echo $TRAVIS_SCALA_VERSION | cut -d . -f2`
+JAVA_VERSION_NUMBER=`echo ${TRAVIS_JDK_VERSION: -1}`
+JDK_VERSION_NUMBER=`printf %i "'${TRAVIS_JDK_VERSION:3:3}"` # The 3rd letter in "openjdk" or "oracle", translates to 110 or 99
+
+# Since the whole test suite runs too long for travis,
+# we run a subset of the tests based on the mod 2 of
+# a number derived from the hash, the scala version and the java jdk version.
+
+RUN_SET=$((($COMMIT_HASH_NUMBER + $SCALA_MINOR_VERSION_NUMBER + $JAVA_VERSION_NUMBER + $JDK_VERSION_NUMBER) % 2))
+
+echo "USING SCALA VERSION: $TRAVIS_SCALA_VERSION";
+echo "USING JDK VERSION: $TRAVIS_JDK_VERSION";
+echo "RUN SET CALC: ($COMMIT_HASH_NUMBER + $SCALA_MINOR_VERSION_NUMBER + $JAVA_VERSION_NUMBER + $JDK_VERSION_NUMBER) % 2 == $RUN_SET";
+
+if [ $RUN_SET = "1" ]; then
+    echo "RUNNING SET 1";
+    .travis/build-and-test-set-1.sh;
+else
+    echo "RUNNING SET 2";
+    .travis/build-and-test-set-2.sh;
+fi

--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val root = Project("geotrellis", file(".")).
     sparkEtl,
     s3,
     accumulo,
+    cassandra,
     slick
   ).
   settings(commonSettings: _*).


### PR DESCRIPTION
This modifies the travis build to run only a subset of the tests, based on the JDK version and the scala version. It takes the commit hash into account so that it randomizes which run set will be executed for which environment. For instance, the second travis run for this executed these sets:

```
Scala 2.10.6, openjdk7   - Run set 2
Scala 2.11.8, openjdk7   - Run set 1
Scala 2.10.6, oraclejdk7 - Run set 1
Scala 2.11.8, oraclejdk7 - Run set 2
Scala 2.10.6, oraclejdk8 - Run set 2
Scala 2.11.8, oraclejdk8 - Run set 1
```

For the previous travis run of this PR, the run sets were flipped.

This modifies the building that was being run in a couple of ways: we no longer compile projects that are going to be compiled transitively by other projects, and runs tests on `slick` and `shapefile` as those tests were not actually being run.

Also, added the cassandra project to the root aggregate project.