### PR TITLE
Refactor proj wrapper to allow other referencing impls

### DIFF
--- a/proj4/build.sbt
+++ b/proj4/build.sbt
@@ -3,6 +3,8 @@ import Dependencies._
 name := "geotrellis-proj4"
 
 libraryDependencies ++= Seq(
+  apacheSIS,
+  apacheSISEPSG,
   openCSV,
   scalatest   % "test",
   scalacheck  % "test")

--- a/proj4/src/main/scala/geotrellis/proj4/ConusAlbers.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/ConusAlbers.scala
@@ -1,7 +1,0 @@
-package geotrellis.proj4
-
-object ConusAlbers extends CRS {
-  lazy val proj4jCrs = factory.createFromName("EPSG:5070")
-
-  def epsgCode: Option[Int] = Some(5070)
-}

--- a/proj4/src/main/scala/geotrellis/proj4/LatLng.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/LatLng.scala
@@ -1,7 +1,0 @@
-package geotrellis.proj4
-
-object LatLng extends CRS {
-  lazy val proj4jCrs = factory.createFromName("EPSG:4326")
-
-  def epsgCode: Option[Int] = Some(4326)
-}

--- a/proj4/src/main/scala/geotrellis/proj4/Transform.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/Transform.scala
@@ -4,21 +4,5 @@ import org.osgeo.proj4j._
 
 object Transform {
   def apply(src: CRS, dest: CRS): (Double, Double) => (Double, Double) =
-    src.alternateTransform(dest) match {
-      case Some(f) => f
-      case None => Proj4Transform(src, dest)
-    }
-}
-
-object Proj4Transform {
-  def apply(src: CRS, dest: CRS): Transform = {
-    val t = new BasicCoordinateTransform(src.proj4jCrs, dest.proj4jCrs)
-
-    { (x: Double, y: Double) =>
-      val srcP = new ProjCoordinate(x, y)
-      val destP = new ProjCoordinate
-      t.transform(srcP, destP)
-      (destP.x, destP.y)
-    }
-  }
+    Backend.getTransform(src, dest)
 }

--- a/proj4/src/main/scala/geotrellis/proj4/WebMercator.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/WebMercator.scala
@@ -1,7 +1,0 @@
-package geotrellis.proj4
-
-object WebMercator extends CRS {
-  lazy val proj4jCrs = factory.createFromName("EPSG:3857")
-
-  def epsgCode: Option[Int] = Some(3857)
-}

--- a/proj4/src/main/scala/geotrellis/proj4/package.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/package.scala
@@ -2,4 +2,10 @@ package geotrellis
 
 package object proj4 {
   type Transform = (Double, Double) => (Double, Double)
+
+  val WebMercator = CRS.fromEpsgCode(3857)
+  val LatLng = CRS.fromEpsgCode(4326)
+  val ConusAlbers = CRS.fromEpsgCode(5070)
+
+  lazy val Backend = Proj4Backend
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,5 +61,8 @@ object Dependencies {
 
   val avro          = "org.apache.avro" % "avro" % "1.8.0"
 
-  val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.14.0"
+  val slickPG       = "com.github.tminglei" %% "slick-pg" % "0.14.0"
+
+  val apacheSIS     = "org.apache.sis.core" % "sis-referencing" % "0.7"
+  val apacheSISEPSG = "org.apache.sis.non-free" % "sis-epsg" % "0.7"
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/CoordinateSystemParser.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/CoordinateSystemParser.scala
@@ -33,6 +33,7 @@ import CommonPublicValues._
 import GeoKeys._
 import ModelTypes._
 import CoordinateTransformTypes._
+
 import ProjectedLinearUnits._
 
 case class GeoDirectoryTags(shortTags: Array[(Int, Int, Int, Int)], doubles: Array[Double])
@@ -59,7 +60,7 @@ class CoordinateSystemParser(val crs: CRS, val pixelSampleType: Option[PixelSamp
 
   import CoordinateSystemParser._
 
-  private val proj4String: String = crs.toProj4String
+  private val proj4String: String = crs.toNativeString
 
   private val proj4Map: Map[String, String] =
     proj4String.split('+').

--- a/spark/src/main/scala/geotrellis/spark/io/json/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/json/Implicits.scala
@@ -22,7 +22,7 @@ trait Implicits extends KeyFormats with KeyIndexFormats {
 
   implicit object CRSFormat extends RootJsonFormat[CRS] {
     def write(crs: CRS) =
-      JsString(crs.toProj4String)
+      JsString(crs.toNativeString)
 
     def read(value: JsValue): CRS =
       value match {


### PR DESCRIPTION
This updates the proj wrapper to factor all the calls that actually use proj4j into one `Backend` object, making it simple to replace that with other implementations (an alternative based on [Apache SIS](http://sis.apache.org/) is provided.)  However there are a few places in the geotrellis codebase where we appear to rely on proj.4 parameter strings (notably the GeoTiff parser, although there also seems to be some spark code which is putting parameter strings into JSON to serialize CRS's.)  I updated these to compile but I fully expect them to fail if the SIS backend is engaged.