### PR TITLE
Better HDFS Support

### DIFF
--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloUtils.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloUtils.scala
@@ -16,42 +16,8 @@ object AccumuloUtils {
    * Mapping KeyBounds of Extent to SFC ranges will often result in a set of non-contigrious ranges.
    * The indices exluded by these ranges should not be included in split calculation as they will never be seen.
    */
-  def getSplits[K](kb: KeyBounds[K], ki: KeyIndex[K], count: Int): Seq[Long] = {
-    var stack = ki.indexRanges(kb).toList
-    def len(r: (Long, Long)) = r._2 - r._1 + 1l
-    val total = stack.foldLeft(0l){ (s,r) => s + len(r) }
-    val binWidth = total / count
-
-    def splitRange(range: (Long, Long), take: Long): ((Long, Long), (Long, Long)) = {
-      assert(len(range) > take)
-      assert(take > 0)
-      (range._1, range._1 + take - 1) -> (range._1 + take, range._2)
-    }
-
-    val arr = Array.fill[Long](count - 1)(0)
-    var sum = 0l
-    var i = 0
-
-    while (i < count - 1) {
-      val nextStep = sum + len(stack.head)
-      if (nextStep < binWidth){
-        sum += len(stack.head)
-        stack = stack.tail
-      } else if (nextStep == binWidth) {
-        arr(i) = stack.head._2
-        stack = stack.tail
-        i += 1
-        sum = 0l
-      } else {
-        val (take, left) = splitRange(stack.head, binWidth - sum)
-        stack = left :: stack.tail
-        arr(i) = take._2
-        i += 1
-        sum = 0l
-      }
-    }
-    arr
-  }
+  def getSplits[K](kb: KeyBounds[K], ki: KeyIndex[K], count: Int): Seq[Long] =
+    KeyIndex.breaks(kb, ki, count)
 
   /**
     * Split the given Accumulo table into the given number of tablets.

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerWriter.scala
@@ -19,7 +19,8 @@ import scala.reflect._
 
 class HadoopLayerWriter(
   rootPath: Path,
-  val attributeStore: AttributeStore
+  val attributeStore: AttributeStore,
+  indexInterval: Int = 4
 ) extends LayerWriter[LayerId] {
 
   protected def _write[
@@ -45,7 +46,7 @@ class HadoopLayerWriter(
 
     try {
       attributeStore.writeLayerAttributes(id, header, metadata, keyIndex, KeyValueRecordCodec[K, V].schema)
-      HadoopRDDWriter.write[K, V](rdd, layerPath, keyIndex)
+      HadoopRDDWriter.write[K, V](rdd, layerPath, keyIndex, indexInterval)
     } catch {
       case e: Exception => throw new LayerWriteError(id).initCause(e)
     }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
@@ -43,7 +43,7 @@ object HadoopRDDWriter extends LazyLogging {
           MapFile.Writer.keyClass(classOf[LongWritable]),
           MapFile.Writer.valueClass(classOf[BytesWritable]),
           MapFile.Writer.compression(SequenceFile.CompressionType.NONE))
-      writer.setIndexInterval(1)
+      writer.setIndexInterval(32)
       writer
     }
 

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
@@ -64,7 +64,7 @@ object HadoopRDDWriter extends LazyLogging {
     rdd: RDD[(K, V)],
     path: Path,
     keyIndex: KeyIndex[K],
-    indexInterval: Int = 16
+    indexInterval: Int = 4
   ): Unit = {
     implicit val sc = rdd.sparkContext
     val fs = path.getFileSystem(sc.hadoopConfiguration)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
@@ -61,7 +61,8 @@ object HadoopRDDWriter extends LazyLogging {
       bytesRemaining -= recordSize
     }
 
-    def close(): Unit = writer.close()
+    def close(): Unit =
+      if (null != writer) writer.close()
   }
 
   def write[K: AvroRecordCodec: ClassTag, V: AvroRecordCodec: ClassTag](

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
@@ -43,7 +43,7 @@ object HadoopRDDWriter extends LazyLogging {
           MapFile.Writer.keyClass(classOf[LongWritable]),
           MapFile.Writer.valueClass(classOf[BytesWritable]),
           MapFile.Writer.compression(SequenceFile.CompressionType.NONE))
-      writer.setIndexInterval(32)
+      writer.setIndexInterval(16)
       writer
     }
 

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
@@ -1,6 +1,8 @@
 package geotrellis.spark.io.hadoop
 
 import geotrellis.spark._
+import geotrellis.spark.util._
+import geotrellis.spark.partition._
 import geotrellis.spark.io.hadoop.formats._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.avro._
@@ -9,68 +11,84 @@ import geotrellis.spark.io.avro.codecs._
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io._
-import org.apache.hadoop.mapreduce.lib.output.{MapFileOutputFormat, SequenceFileOutputFormat}
-import org.apache.hadoop.mapreduce.Job
-import org.apache.spark.rdd.RDD
+import org.apache.hadoop.mapreduce.lib.output._
+import org.apache.hadoop.mapreduce.{Job, RecordWriter}
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.rdd.{RDD, ShuffledRDD}
 import org.apache.spark.SparkContext
 
 import scala.reflect._
 
 object HadoopRDDWriter extends LazyLogging {
 
+  /**
+    * When record being written would exceed the block size of the current MapFile
+    * opens a new file to continue writing. This allows to split partition into block-sized
+    * chunks without foreknowledge of how bit it is.
+    */
+  class MultiMapWriter(layerPath: String, partition: Int, blockSize: Long) {
+    private var writer: MapFile.Writer = newWriter()
+    private var block = 0
+    private var blockBytesWritten = 0l
+
+    private def newWriter() = {
+      val path = new Path(layerPath, f"part-r-${partition}%05d-${block}%05d")
+      blockBytesWritten = 0l
+      val writer =
+        new MapFile.Writer(
+          new Configuration,
+          path.toString,
+          MapFile.Writer.keyClass(classOf[LongWritable]),
+          MapFile.Writer.valueClass(classOf[BytesWritable]),
+          MapFile.Writer.compression(SequenceFile.CompressionType.NONE))
+      writer.setIndexInterval(1)
+      writer
+    }
+
+    def write(key: LongWritable, value: BytesWritable): Unit = {
+      val recordSize = 8 + value.getLength
+      if ((blockBytesWritten + recordSize) > blockSize && blockBytesWritten > 0l) {
+        writer.close()
+        block += 1
+        writer = newWriter()
+      }
+      writer.append(key, value)
+      blockBytesWritten += recordSize
+    }
+
+    def close(): Unit = writer.close()
+  }
+
   def write[K: AvroRecordCodec, V: AvroRecordCodec](
     rdd: RDD[(K, V)],
     path: Path,
-    keyIndex: KeyIndex[K],
-    tileSize: Int = 256*256*8,
-    compressionFactor: Double = 1.3
+    keyIndex: KeyIndex[K]
   ): Unit = {
     implicit val sc = rdd.sparkContext
-    val conf = sc.hadoopConfiguration
-
     val fs = path.getFileSystem(sc.hadoopConfiguration)
+    if(fs.exists(path)) throw new Exception(s"Directory already exists: $path")
 
-    if(fs.exists(path)) { throw new Exception(s"Directory already exists: $path") }
-
-    val job = Job.getInstance(conf)
-    job.getConfiguration.set("io.map.index.interval", "1")
-    SequenceFileOutputFormat.setOutputCompressionType(job, SequenceFile.CompressionType.RECORD)
-
-    // Figure out how many partitions there should be based on block size.
-    val partitions = {
-      val blockSize = fs.getDefaultBlockSize(path)
-      val tileCount = rdd.count()
-      val tilesPerBlock = {
-        val tpb = (blockSize / tileSize) * compressionFactor
-        if(tpb == 0) {
-          logger.warn(s"Tile size is too large for this filesystem (tile size: $tileSize, block size: $blockSize)")
-          1
-        } else tpb
-      }
-      math.ceil(tileCount / tilesPerBlock.toDouble).toInt
-    }
-
-    // Sort the writables, and cache as we'll be computing this RDD twice.
-    val closureKeyIndex = keyIndex
     val codec = KeyValueRecordCodec[K, V]
+    val blockSize = fs.getDefaultBlockSize(path)
+    val layerPath = path.toString
 
-    // Call groupBy with numPartitions; if called without that argument or a partitioner,
-    // groupBy will reuse the partitioner on the parent RDD if it is set, which could be typed
-    // on a key type that may no longer by valid for the key type of the resulting RDD.
-    rdd
-      .groupBy({ case (key, _) => closureKeyIndex.toIndex(key) }, numPartitions = rdd.partitions.length)
-      .sortByKey(numPartitions = partitions)
-      .map { case (index, pairs) =>
-        (new LongWritable(index), new BytesWritable(AvroEncoder.toBinary(pairs.toVector)(codec)))
-      }
-      .saveAsNewAPIHadoopFile(
-        path.toUri.toString,
-        classOf[LongWritable],
-        classOf[BytesWritable],
-        classOf[MapFileOutputFormat],
-        job.getConfiguration
-      )
+    new ShuffledRDD(rdd, IndexPartitioner(keyIndex, rdd.partitions.length))
+      .setKeyOrdering(Ordering.by(keyIndex.toIndex))
+      .asInstanceOf[RDD[(K, V)]]
+      .mapPartitionsWithIndex { (pid, iter) =>
+        var writer = new MultiMapWriter(layerPath, pid, blockSize)
 
+        for ( (index, pairs) <- GroupConsecutiveIterator(iter)(r => keyIndex.toIndex(r._1))) {
+          writer.write(
+            new LongWritable(index),
+            new BytesWritable(AvroEncoder.toBinary(pairs.toVector)(codec)))
+        }
+        writer.close()
+        // TODO: collect statistics on written records and return those
+        Iterator.empty
+      }.count
+
+    fs.createNewFile(new Path(layerPath, "_SUCCESS"))
     logger.info(s"Finished saving tiles to ${path}")
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
@@ -24,7 +24,7 @@ object HadoopRDDWriter extends LazyLogging {
   /**
     * When record being written would exceed the block size of the current MapFile
     * opens a new file to continue writing. This allows to split partition into block-sized
-    * chunks without foreknowledge of how bit it is.
+    * chunks without foreknowledge of how big it is.
     */
   class MultiMapWriter(layerPath: String, partition: Int, blockSize: Long, indexInterval: Int) {
     private var writer: MapFile.Writer = null // avoids creating a MapFile for empty partitions

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopRDDWriter.scala
@@ -31,7 +31,7 @@ object HadoopRDDWriter extends LazyLogging {
     private var bytesRemaining = 0l
 
     private def getWriter(firstIndex: Long) = {
-      val path = new Path(layerPath, f"part-r-${partition}%05d-${firstIndex}%05d")
+      val path = new Path(layerPath, f"part-r-${partition}%05d-${firstIndex}")
       bytesRemaining = blockSize - 16*1024 // buffer by 16BK for SEQ file overhead
       val writer =
         new MapFile.Writer(

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopValueReader.scala
@@ -24,7 +24,9 @@ class HadoopValueReader(val attributeStore: HadoopAttributeStore, maxOpenFiles: 
     (implicit sc: SparkContext) extends ValueReader[LayerId] {
 
   val conf = attributeStore.hadoopConfiguration
-  val readers = new LRUCache[(LayerId, Path), MapFile.Reader](maxOpenFiles.toLong, {x => 1l})
+  val readers = new LRUCache[(LayerId, Path), MapFile.Reader](maxOpenFiles.toLong, {x => 1l}) {
+    override def evicted(reader: MapFile.Reader) = reader.close()
+  }
 
   def reader[K: AvroRecordCodec: JsonFormat: ClassTag, V: AvroRecordCodec](layerId: LayerId): Reader[K, V] = new Reader[K, V] {
     val header = attributeStore.readHeader[HadoopLayerHeader](layerId)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopValueReader.scala
@@ -35,22 +35,22 @@ class HadoopValueReader(
     val keyIndex = attributeStore.readKeyIndex[K](layerId)
     val writerSchema = attributeStore.readSchema(layerId)
     val codec = KeyValueRecordCodec[K, V]
-    // Map from last key in each reader to that reader
 
+    // Map from last key in each reader to that reader
     val ranges: Vector[(Path, Long, Long)] =
       FilterMapFileInputFormat.layerRanges(header.path, conf)
 
     def read(key: K): V = {
       val index: Long = keyIndex.toIndex(key)
       val valueWritable: BytesWritable =
-        ranges
+      ranges
           .find{ row =>
             index >= row._2 && index <= row._3
           }
-          .map { case (path, _, _) =>
+        .map { case (path, _, _) =>
             readers.getOrInsert((layerId, path), new MapFile.Reader(path, conf))
-          }
-          .getOrElse(throw new TileNotFoundError(key, layerId))
+        }
+        .getOrElse(throw new TileNotFoundError(key, layerId))
           .get(new LongWritable(index), new BytesWritable())
           .asInstanceOf[BytesWritable]
 

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopValueReader.scala
@@ -36,7 +36,6 @@ class HadoopValueReader(
     val writerSchema = attributeStore.readSchema(layerId)
     val codec = KeyValueRecordCodec[K, V]
 
-    // Map from last key in each reader to that reader
     val ranges: Vector[(Path, Long, Long)] =
       FilterMapFileInputFormat.layerRanges(header.path, conf)
 
@@ -45,7 +44,7 @@ class HadoopValueReader(
       val valueWritable: BytesWritable =
       ranges
           .find{ row =>
-            index >= row._2 && index <= row._3
+            index >= row._2 && index < row._3
           }
         .map { case (path, _, _) =>
             readers.getOrInsert((layerId, path), new MapFile.Reader(path, conf))

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopValueReader.scala
@@ -81,12 +81,4 @@ object HadoopValueReader {
 
   def apply(rootPath: Path, conf: Configuration): HadoopValueReader =
     apply(HadoopAttributeStore(rootPath, conf))
-
-  /** Return index from last key index to map file reader for each partition in a layer */
-  def partitionReaders(layerPath: Path, conf: Configuration): Array[MapFile.Reader] =
-    layerPath
-      .getFileSystem(conf)
-      .globStatus(layerPath)
-      .filter(_.isDirectory)
-      .map( status => new MapFile.Reader(status.getPath, conf))
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/FilterMapFileInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/FilterMapFileInputFormat.scala
@@ -37,15 +37,20 @@ object FilterMapFileInputFormat {
     // this is not the type of thing we can afford to do on the driver.
     // instead we assume that each map file runs from its min index to min index of next file
 
-    // TODO: Check if starting index is encoded in the file name
+    val fileNameRx = ".*part-r-([0-9]+)-([0-9]+)$".r
     def readStartingIndex(path: Path): Long = {
-      val indexPath = new Path(path, "index")
-      val in = new SequenceFile.Reader(conf, SequenceFile.Reader.file(indexPath))
-      val minKey = new LongWritable
-      try {
-        in.next(minKey)
-      } finally { in.close() }
-      minKey.get
+      path.toString match {
+        case fileNameRx(part, firstIndex) =>
+          firstIndex.toLong
+        case _ =>
+          val indexPath = new Path(path, "index")
+          val in = new SequenceFile.Reader(conf, SequenceFile.Reader.file(indexPath))
+          val minKey = new LongWritable
+          try {
+            in.next(minKey)
+          } finally { in.close() }
+          minKey.get
+      }
     }
 
     mapFiles

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/FilterMapFileInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/FilterMapFileInputFormat.scala
@@ -14,7 +14,6 @@ import scala.reflect._
 
 object FilterMapFileInputFormat {
   // Define some key names for Hadoop configuration
-  val SPLITS_FILE_PATH = "splits_file_path"
   val FILTER_INFO_KEY = "geotrellis.spark.io.hadoop.filterinfo"
 
   type FilterDefinition = Array[(Long, Long)]

--- a/spark/src/main/scala/geotrellis/spark/io/index/KeyIndex.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/KeyIndex.scala
@@ -8,3 +8,51 @@ trait KeyIndex[K] extends Serializable {
   def toIndex(key: K): Long
   def indexRanges(keyRange: (K, K)): Seq[(Long, Long)]
 }
+
+object KeyIndex {
+  /**
+   * Mapping KeyBounds of Extent to SFC ranges will often result in a set of non-contigrious ranges.
+   * The indices excluded by these ranges should not be included in breaks calculation as they will never be seen.
+   */
+  def breaks[K](kb: KeyBounds[K], ki: KeyIndex[K], count: Int): Vector[Long] = {
+    breaks(ki.indexRanges(kb), count)
+  }
+
+  /**
+    * Divide the space covered by ranges as evenly as possible by providing break points from the ranges.
+    * All break points will be from the ranges given and never from spaces between the ranges.
+    *
+    * @param ranges  sorted list of tuples which represent non-negative, non-intersecting ranges.
+    * @param count   desired number of break points
+    */
+  def breaks(ranges: Seq[(Long, Long)], count: Int): Vector[Long] = {
+    require(count > 0, "breaks count must be at least one")
+    def len(r: (Long, Long)) = r._2 - r._1 + 1l
+    val total: Double = ranges.foldLeft(0l)(_ + len(_))
+    val maxBinSize =  math.max(math.ceil(total / (count+1)), 1).toLong
+
+    def take(range: (Long, Long), count: Long): Long = {
+      if (len(range) >= count) count
+      else len(range)
+    }
+    ranges.foldLeft((Vector.empty[Long], maxBinSize)) { case ((_breaks, _roomLeft), range) =>
+      var breaks = _breaks
+      var roomLeft = _roomLeft
+      var remainder = range
+      var taken: Long = 0l
+      do {
+        taken = take(remainder, roomLeft)
+        if (taken == roomLeft) {
+          breaks = breaks :+ (remainder._1 + taken - 1)
+          roomLeft = maxBinSize
+          remainder = (remainder._1 + taken, remainder._2)
+        } else {
+          roomLeft -= taken
+          remainder = (0,-1)
+        }
+      } while (len(remainder) > 0)
+        (breaks, roomLeft)
+    }._1.take(count) // we need to drop the break that falls on the end of the last range
+
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/partition/IndexPartitioner.scala
+++ b/spark/src/main/scala/geotrellis/spark/partition/IndexPartitioner.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.reflect._
 
 /**
-  * Uses [[KeyIndex]] to partition an RDD in memory, giving its records some spatial locality.
+  * Uses KeyIndex to partition an RDD in memory, giving its records some spatial locality.
   * When persisting an RDD partitioned by this partitioner we can safely assume that all records
   * contributing to the same SFC index will reside in one partition.
   */

--- a/spark/src/main/scala/geotrellis/spark/partition/IndexPartitioner.scala
+++ b/spark/src/main/scala/geotrellis/spark/partition/IndexPartitioner.scala
@@ -1,0 +1,46 @@
+package geotrellis.spark.partition
+
+import geotrellis.spark._
+import geotrellis.spark.io.index._
+import geotrellis.spark.io.index.zcurve.{Z3, Z2, ZSpatialKeyIndex}
+import geotrellis.util._
+
+import org.apache.spark._
+import org.apache.spark.rdd.{ShuffledRDD, RDD}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect._
+
+/**
+  * Uses [[KeyIndex]] to partition an RDD in memory, giving its records some spatial locality.
+  * When persisting an RDD partitioned by this partitioner we can safely assume that all records
+  * contributing to the same SFC index will reside in one partition.
+  */
+class IndexPartitioner[K](index: KeyIndex[K], count: Int) extends Partitioner {
+  val breaks: Array[Long] =
+    if (count > 1)
+      KeyIndex.breaks(index.keyBounds, index, count - 1).sorted.toArray
+    else
+      Array(Long.MaxValue)
+
+  def numPartitions = breaks.length + 1
+
+  /**
+    * Because breaks define divisions rather than breaks all indexable keys will have a bucket.
+    * Keys that are far out of bounds will be assigned to either first or last partition.
+    */
+  def getPartition(key: Any): Int = {
+    val i = index.toIndex(key.asInstanceOf[K])
+    val res = java.util.Arrays.binarySearch(breaks, i)
+    if (res >= 0) res // matched break exactly, partitions are inclusive on right
+    else -(res+1)     // got an insertion point, convert it to corresponding partition
+  }
+}
+
+object IndexPartitioner {
+  def apply[K](index: KeyIndex[K], count: Int): IndexPartitioner[K] =
+    new IndexPartitioner(index, count)
+
+  def apply[K](bounds: Bounds[K], indexMethod: KeyIndexMethod[K], count: Int): IndexPartitioner[K] =
+    new IndexPartitioner(indexMethod.createIndex(bounds.get), count)
+}

--- a/spark/src/main/scala/geotrellis/spark/util/GroupIterator.scala
+++ b/spark/src/main/scala/geotrellis/spark/util/GroupIterator.scala
@@ -1,0 +1,25 @@
+package geotrellis.spark.util
+
+/**
+  * Groups consecutive records that share a projection from an iterator to form an iterator of iterators.
+  *
+  * You can think of this as Iterator equivalent of.groupBy that only works on consecutive records.
+  */
+class GroupConsecutiveIterator[T, R](iter: Iterator[T])(f: T => R)
+    extends Iterator[(R, Iterator[T])] {
+  private var remaining = iter.buffered
+
+  def hasNext = remaining.hasNext
+
+  def next = {
+    val cur = f(remaining.head)
+    val (left, right) = remaining.span(x => f(x) == cur)
+    remaining = right.buffered
+    (cur, left)
+  }
+}
+
+object GroupConsecutiveIterator {
+  def apply[T, R](iter: Iterator[T])(f: T => R) =
+    new GroupConsecutiveIterator(iter)(f)
+}

--- a/spark/src/main/scala/geotrellis/spark/util/cache/cache.scala
+++ b/spark/src/main/scala/geotrellis/spark/util/cache/cache.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -151,6 +151,8 @@ trait BoundedCache[K,V] extends Cache[K,V] {
       false
     }
   }
+
+  def evicted(v: V): Unit = {}
 }
 
 trait OrderedBoundedCache[K,V] extends BoundedCache[K,V] {
@@ -178,6 +180,7 @@ trait OrderedBoundedCache[K,V] extends BoundedCache[K,V] {
       val removedSize: Long = remove(item) match {
         case Some(v) => {
 //          println(s"[Cache]\tEvicted $item (${sizeOf(v)} units) from cache")
+          evicted(v)
           sizeOf(v)
         }
         case None => 0L

--- a/spark/src/main/scala/geotrellis/spark/util/cache/cache.scala
+++ b/spark/src/main/scala/geotrellis/spark/util/cache/cache.scala
@@ -16,8 +16,8 @@
 
 package geotrellis.spark.util.cache
 
-import java.util.concurrent.locks.Lock
-import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.locks._
+import java.util.concurrent._
 import scala.collection.mutable.HashMap
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable
@@ -70,24 +70,11 @@ class NoCache[K,V] extends Cache[K,V] {
  * Operations on this cache execute in O(1) time
  */
 trait HashBackedCache[K,V] extends Cache[K,V] {
-  val cache = new mutable.HashMap[K,V].empty
+  val cache = new ConcurrentHashMap[K, V]()
 
-  def lookup(k: K):Option[V] = cache.get(k)
-  def remove(k: K):Option[V] = cache.remove(k)
+  def lookup(k: K):Option[V] = Option(cache.get(k))
+  def remove(k: K):Option[V] = Option(cache.remove(k))
   def insert(k: K, v: V):Boolean = { cache.put(k,v); true }
-}
-
-trait LoggingCache[K,V] extends Cache[K,V] {
-  abstract override def lookup(k: K):Option[V] = super.lookup(k) match {
-    case None => {
-      //println(s"Cache miss on $k")
-      None
-    }
-    case z => {
-      //println(s"Cache hit on $k")
-      z
-    }
-  }
 }
 
 /** A hash backed cache with a size boundary
@@ -110,7 +97,7 @@ trait BoundedCache[K,V] extends Cache[K,V] {
    * this method is called once after an insert would have failed due to
    * space constraints. After this method returns the insert will be retried
    */
-  def cacheFree(l: Long):Unit
+  def cacheFree(l: Long): Unit
 
   var currentSize: Long = 0
 
@@ -155,31 +142,33 @@ trait BoundedCache[K,V] extends Cache[K,V] {
   def evicted(v: V): Unit = {}
 }
 
-trait OrderedBoundedCache[K,V] extends BoundedCache[K,V] {
+class LRUCache[K,V](val maxSize: Long, val sizeOf: V => Long = (v:V) => 1) extends HashBackedCache[K,V]  with BoundedCache[K,V] {
 
-  /** Called when attempt to make space in the cache. This function should
-   * return the index of the item to remove next
-   *
-   * @param k: Seq[K]  first element was accessed most recently
-   */
-  val removeIdx: Seq[K] => Int
+  /** Contains order of cache requests, with the key at the tail read most recently */
+  private[this] val cacheOrder = new ConcurrentLinkedQueue[K]()
+
+  /** Signal that the value for k was recently looked up */
+  private[this] def touch(k: K): Unit = {
+    cacheOrder.remove(k)
+    cacheOrder.add(k)
+  }
 
   /** Attempt to free space in the cache starting with the last accessed element
    * @param ltgt: The additional space in the cache requested
    */
   def cacheFree(ltgt: Long):Unit = {
-    //println(s"[Cache] Attempting to free $ltgt units of data (cache max: $maxSize, cache cur: $currentSize)")
+    // logger.trace(s"Attempting to free $ltgt units of data (cache max: $maxSize, cache cur: $currentSize)")
 
     // if (ltgt > maxSize) {
-    //    println("[Cache] File to big to fit in cache at all")
+    //    logger.warn(s"Item to big to fit in cache at all")
     // }
 
     var l = ltgt
-    while(l > 0 && cacheOrder.length > 0) {
-      val item:K = cacheOrder.remove(removeIdx(cacheOrder))
+    while(l > 0 && cacheOrder.size > 0) {
+      val item: K = cacheOrder.poll() // remove the oldest element
       val removedSize: Long = remove(item) match {
         case Some(v) => {
-//          println(s"[Cache]\tEvicted $item (${sizeOf(v)} units) from cache")
+          // logger.trace(s"Evicted $item (${sizeOf(v)} units) from cache")
           evicted(v)
           sizeOf(v)
         }
@@ -189,146 +178,18 @@ trait OrderedBoundedCache[K,V] extends BoundedCache[K,V] {
     }
   }
 
-  /* Contains order of cache requests
-   * the item at index 0 was read most recently and item at (length - 1) was read the longest ago
-   */
-  private[this] var cacheOrder:ListBuffer[K] = new ListBuffer[K]()
-  private[this] var lock = new Object();
-
-  // Signal that the value for k was recently looked up
-  private[this] def prepend(k: K) = {
-    lock.synchronized {
-      cacheOrder -= k
-      cacheOrder.prepend(k)
-    }
-    k
+  override def lookup(k: K) = super.lookup(k) match {
+    case v: Some[_] =>
+      touch(k)
+      v
+    case None =>
+      None
   }
 
-  abstract override def lookup(k: K) = super.lookup(k) match {
-    case v@Some(_) => { prepend(k); v }
-    case None => None
-  }
-
-  abstract override def insert(k: K, v: V) = if (super.insert(k,v)) {
-    prepend(k); true
+  override def insert(k: K, v: V) = if (super.insert(k,v)) {
+    touch(k)
+    true
   } else {
     false
-  }
-}
-
-class LRUCache[K,V](val maxSize: Long, val sizeOf: V => Long = (v:V) => 1) extends HashBackedCache[K,V] with OrderedBoundedCache[K,V] with AtomicCache[K,V] with LoggingCache[K,V] {
-  val removeIdx: Seq[K] => Int = (s: Seq[K]) => s.length - 1
-}
-
-class MRUCache[K,V](val maxSize: Long, val sizeOf: V => Long = (v:V) => 1) extends HashBackedCache[K,V] with OrderedBoundedCache[K,V] with AtomicCache[K,V] with LoggingCache[K,V] {
-  val removeIdx: Seq[K] => Int = (s: Seq[K]) => 0
-}
-
-
-/** Atomic cache provides an atomic getOrInsert(k,v) method
- * This cache assumes that (k,v) pair is immutable
- */
-trait AtomicCache[K,V] extends Cache[K,V] {
-  val bigLock:Lock = new ReentrantLock()
-
-  val currentlyLoading:HashMap[K,Lock] = new HashMap[K,Lock].empty
-
-  abstract override def lookup(k: K):Option[V] = {
-    bigLock.lock()
-    val smallLockOpt = currentlyLoading.get(k)
-    bigLock.unlock()
-
-    smallLockOpt.map(smallLock => {
-      smallLock.lock()
-      smallLock.unlock()
-    })
-
-    super.lookup(k)
-  }
-
-  abstract override def getOrInsert(k: K, v: => V):V = {
-    val t0 = System.currentTimeMillis
-    bigLock.lock()
-    try {
-      if (currentlyLoading.contains(k)) {
-        // Another thread is currently loading up the cache entry for k so we
-        // block until it is done.
-        val smallLock = currentlyLoading.get(k).get
-        bigLock.unlock()
-
-        // the small lock blocks until the thread that is doing the loading is
-        // complete.
-        smallLock.lock()
-        smallLock.unlock()
-
-        // v will already have been evaluated by some other thread
-        // if there was an error we'll evaluate v
-        //super.lookup(k).getOrElse(v)
-        val resultOpt = super.lookup(k)
-        resultOpt match {
-          case None => {
-            val vv = v
-            val t = System.currentTimeMillis - t0
-            //println(s"waited on other thread, but failed: $t ms")
-            vv
-          }
-          case Some(vv) => {
-            val t = System.currentTimeMillis - t0
-            //println(s"waited on other thread: $t ms")
-            vv
-          }
-        }
-      } else {
-        super.lookup(k) match {
-          case Some(vv) => {
-            bigLock.unlock()
-            val t = System.currentTimeMillis - t0
-            //println(s"found in cache: $t ms")
-            vv
-          }
-          case None => {
-            val smallLock = new ReentrantLock()
-            currentlyLoading.put(k, smallLock)
-            smallLock.lock()
-            val vv = try {
-              bigLock.unlock()
-
-              val vv = v    // Evaluate v
-
-              bigLock.lock()
-              super.insert(k,v)
-
-              currentlyLoading.remove(k)
-              bigLock.unlock()
-              vv
-
-            } catch {
-              case t:Throwable => { println("error"); t.printStackTrace(); println("rethrow..."); throw t }
-            } finally {
-              smallLock.unlock()
-            }
-
-            val t = System.currentTimeMillis - t0
-            //println(s"added to cache: $t ms")
-            vv
-          }
-        }
-      }
-    } catch {
-      case t:Throwable => {
-        bigLock.unlock()
-        throw t
-      }
-    }
-  }
-
-
-  abstract override def insert(k: K, v: V):Boolean = {
-    bigLock.lock()
-    try {
-      super.insert(k,v)
-    } finally {
-      bigLock.unlock()
-    }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/util/cache/CacheSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/util/cache/CacheSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -115,53 +115,6 @@ class CacheSpec extends FunSpec with MustMatchers {
       cache.lookup(1) must equal(None)
       cache.lookup(2) must equal(None)
       cache.lookup(3) must equal(Some(f(3)))
-      cache.lookup(4) must equal(Some(f(4)))
-
-    }
-  }
-
-  describe("MRU cache") {
-
-    def getCache(max: Int) =
-      new MRUCache[Int,Int](max, (v: Int) => 1)
-
-    hashCacheTest(getCache _)
-    boundedCacheTest(getCache _)
-
-    it("should be contain at most maxSize number of items") {
-      val cache = getCache(5)
-
-      for(j <- 1 to 100)
-        cache.getOrInsert(j,f(j))
-
-      cache.cache.size must equal(5)
-
-      for(j <- 5 to 99)
-        cache.lookup(j) must equal(None)
-      for(j <- 1 to 4)
-        cache.lookup(j) must equal(Some(f(j)))
-      cache.lookup(100) must equal(Some(f(100)))
-    }
-
-    it("should evict the item accessed most recently") {
-      val cache = getCache(2)
-
-      cache.insert(1, f(1))
-      cache.insert(2, f(2))
-      cache.lookup(1) must equal(Some(f(1)))
-      cache.lookup(2) must equal(Some(f(2)))
-
-      cache.lookup(1) // Make 1 newer than 2
-
-      cache.insert(3, f(3))
-      cache.lookup(1) must equal(None)
-      cache.lookup(2) must equal(Some(f(2)))
-      cache.lookup(3) must equal(Some(f(3)))
-
-      cache.insert(4, f(4))
-      cache.lookup(1) must equal(None)
-      cache.lookup(2) must equal(Some(f(2)))
-      cache.lookup(3) must equal(None)
       cache.lookup(4) must equal(Some(f(4)))
 
     }


### PR DESCRIPTION
This PR improves HDFS layer writing and random value reading support.

`HadoopValuesReader` now opens up `MapFile.Readers` for each map file in the layer. These readers cache the index of available keys so they are able to provide quick lookups. This replaces and improves previous method of using `FileInputFormat` to query for a single record.

`HadoopRDDWriter` has multiple improvements:
- Accomplishes it's task with a single shuffle step
 - This is possible because instead of estimating the blocks required by counting we simply roll over to a new file when the record being written is about to surpass the block boundary.
 - Instead of using a groupBy we sort our records on shuffle which uses IO index to partition the records
- Writes happen through mapping the partition iterator, this is possible because the partition comes pre-sorted and greatly reduces memory pressure as records can be garbage collected after they are written.

Current testing shows:
- HDFS ingest speeds exceed those seen in Accumulo
- tile fetching latency is visually acceptable
- that jobs using the `GroupedCumulativeIterator` approach are able to complete in settings where .groupBy/sort/write jobs are killed for memory violations. 

Future improvements that on the mind:
- Save bloom filter index for layer MapFiles to reduce memory requirements for `HadoopValueReader` and to produce quicker lookup in most cases.
- In `HadoopValueReader` when fetching a record, cache all the tiles that share that index before filtering down to a single tile. These records are very likely to be asked for next and should be stored in LRU cache.
- Devise a method to compare KeyIndex instances such that if the RDD to be saved is already partitioned by compatible index (where all key boundaries are shared) to avoid the extra shuffle.