### PR TITLE
Add ClassTag where needed for compatibility with Spark 1.6.1

### DIFF
--- a/project/Environment.scala
+++ b/project/Environment.scala
@@ -21,6 +21,6 @@ object Environment {
     Properties.envOrElse(environmentVariable, default)
 
   lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.2.0")
-  lazy val sparkVersion   = either("SPARK_VERSION", "1.5.2")
+  lazy val sparkVersion   = either("SPARK_VERSION", "1.6.1")
   lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-SNAPSHOT")
 }

--- a/spark/src/main/scala/geotrellis/spark/join/SpatialJoin.scala
+++ b/spark/src/main/scala/geotrellis/spark/join/SpatialJoin.scala
@@ -14,7 +14,7 @@ object SpatialJoin {
     K: Boundable: PartitionerIndex: ClassTag,
     V: ClassTag,
     M: GetComponent[?, Bounds[K]],
-    W,
+    W: ClassTag,
     M1: GetComponent[?, Bounds[K]]
   ](
     left: RDD[(K, V)] with Metadata[M],
@@ -40,7 +40,7 @@ object SpatialJoin {
     K: Boundable: PartitionerIndex: ClassTag,
     V: ClassTag,
     M: GetComponent[?, Bounds[K]],
-    W,
+    W: ClassTag,
     M1: GetComponent[?, Bounds[K]]
   ](
     left: RDD[(K, V)] with Metadata[M],

--- a/spark/src/main/scala/geotrellis/spark/join/SpatialJoinMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/join/SpatialJoinMethods.scala
@@ -13,9 +13,9 @@ abstract class SpatialJoinMethods[
   V: ClassTag,
   M: GetComponent[?, Bounds[K]]
 ] extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
-  def spatialLeftOuterJoin[W, M1: Component[?, Bounds[K]]](right: RDD[(K, W)] with Metadata[M1]): RDD[(K, (V, Option[W]))] with Metadata[Bounds[K]] =
+  def spatialLeftOuterJoin[W: ClassTag, M1: Component[?, Bounds[K]]](right: RDD[(K, W)] with Metadata[M1]): RDD[(K, (V, Option[W]))] with Metadata[Bounds[K]] =
     SpatialJoin.leftOuterJoin(self, right)
 
-  def spatialJoin[W, M1: Component[?, Bounds[K]]](right: RDD[(K, W)] with Metadata[M1]): RDD[(K, (V, W))] with Metadata[Bounds[K]] =
+  def spatialJoin[W: ClassTag, M1: Component[?, Bounds[K]]](right: RDD[(K, W)] with Metadata[M1]): RDD[(K, (V, W))] with Metadata[Bounds[K]] =
     SpatialJoin.join(self, right)
 }


### PR DESCRIPTION
When performing spatial joins using the current version of Spark (1.6.1) with Geotrellis 0.10.1 (itself compiled against Spark 1.5.2), spatial joins fail with a NoSuchMethodError.

For example, running SpatialSparkExample.scala with the code at [https://gist.github.com/aeffrig/f49cefdb5326e0917263a926cd71c14b] and two overlapping Landsat images as arguments results in

```
Exception in thread "main" java.lang.NoSuchMethodError: org.apache.spark.rdd.ShuffledRDD.<init>(Lorg/apache/spark/rdd/RDD;Lorg/apache/spark/Partitioner;)V
        at geotrellis.spark.partition.SpacePartitioner.apply(SpacePartitioner.scala:65)
        at geotrellis.spark.join.SpatialJoin$.join(SpatialJoin.scala:53)
        at geotrellis.spark.join.SpatialJoinMethods.spatialJoin(SpatialJoinMethods.scala:20)
        at name.aeffrig.SpatialSparkExample$.run(SpatialSparkExample.scala:66)
        at name.aeffrig.SpatialSparkExample$.main(SpatialSparkExample.scala:32)
        at name.aeffrig.SpatialSparkExample.main(SpatialSparkExample.scala) 
```

The failure is a result of adding ClassTags in [https://github.com/apache/spark/pull/7403/commits/ed1afac5e4b43b6e9bae43ee3c18d6144d8e1729] to the ShuffledRDD constructor.

See [https://github.com/apache/spark/blob/branch-1.5/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala#L40] vs 
[https://github.com/apache/spark/blob/branch-1.6/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala#L42]
