### PR TITLE
doc-examples subproject; example for tiling to GeoTiff

### DIFF
--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project doc-examples" compile  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project spark" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project accumulo" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project proj4" test || { exit 1; }

--- a/build.sbt
+++ b/build.sbt
@@ -149,3 +149,7 @@ lazy val shapefile = Project("shapefile", file("shapefile")).
 
 lazy val util = Project("util", file("util")).
   settings(commonSettings: _*)
+
+lazy val docExamples = Project("doc-examples", file("doc-examples")).
+  dependsOn(spark, s3, accumulo, cassandra).
+  settings(commonSettings: _*)

--- a/doc-examples/build.sbt
+++ b/doc-examples/build.sbt
@@ -1,0 +1,7 @@
+import Dependencies._
+
+name := "geotrellis-doc-examples"
+libraryDependencies ++= Seq(
+  sparkCore % "provided",
+  logging,
+  scalatest % "test")

--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/SparkExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/SparkExamples.scala
@@ -1,0 +1,83 @@
+package geotrellis.doc.examples.spark
+
+object SparkExamples {
+  def `Using a SpaceTimeKey -> SpatialKey transformation to get summary information about tiles overlapping an area`: Unit = {
+    import geotrellis.raster._
+    import geotrellis.spark._
+    import geotrellis.util._
+
+    import org.apache.spark.rdd.RDD
+
+    val temperaturePerMonth: TileLayerRDD[SpaceTimeKey] = ???
+
+    val maximumTemperature: RDD[(SpatialKey, Tile)] =
+      temperaturePerMonth
+        .map { case (key, tile) =>
+          // Get the spatial component of the SpaceTimeKey, which turns it into SpatialKey
+          (key.getComponent[SpatialKey], tile)
+      }
+    // Now we have all the tiles that cover the same area with the same key.
+    // Simply reduce by the key with a localMax
+        .reduceByKey(_.localMax(_))
+  }
+
+  def `Tiling an RDD of spatial tiles, stitching and saving off as a single GeoTiff`: Unit = {
+    import geotrellis.raster._
+    import geotrellis.raster.io.geotiff._
+    import geotrellis.raster.resample._
+    import geotrellis.spark._
+    import geotrellis.spark.io._
+    import geotrellis.spark.tiling._
+    import geotrellis.vector._
+    import org.apache.spark.HashPartitioner
+    import org.apache.spark.rdd.RDD
+
+    val rdd: RDD[(ProjectedExtent, Tile)] = ???
+
+    // Tile this RDD to a grid layout. This will transform our raster data into a
+    // common grid format, and merge any overlapping data.
+
+    // We'll be tiling to a 512 x 512 tile size, and using the RDD's bounds as the tile bounds.
+    val layoutScheme = FloatingLayoutScheme(512)
+
+    // We gather the metadata that we will be targeting with the tiling here.
+    // The return also gives us a zoom level, which we ignore.
+    val (_: Int, metadata: TileLayerMetadata[SpatialKey]) =
+      TileLayerMetadata.fromRdd(rdd, layoutScheme)
+
+    // Here we set some options for our tiling.
+    // For this example, we will set the target partitioner to one
+    // that has the same number of partitions as our original RDD.
+    val tilerOptions =
+      Tiler.Options(
+        resampleMethod = Bilinear,
+        partitioner = new HashPartitioner(rdd.partitions.length)
+      )
+
+    // Now we tile to an RDD with a SpaceTimeKey.
+
+    val tiledRdd =
+      rdd.tileToLayout[SpatialKey](metadata, tilerOptions)
+
+
+    // At this point, we want to combine our RDD and our Metadata to get a TileLayerRDD[SpatialKey]
+
+    val layerRdd: TileLayerRDD[SpatialKey] =
+      ContextRDD(tiledRdd, metadata)
+
+    // Now we can save this layer off to a GeoTrellis backend (Accumulo, HDFS, S3, etc)
+    // In this example, though, we're going to just filter it by some bounding box
+    // and then save the result as a GeoTiff.
+
+    val areaOfInterest: Extent = ???
+
+    val raster: Raster[Tile] =
+      layerRdd
+        .filter()                            // Use the filter/query API to
+        .where(Intersects(areaOfInterest))   // filter so that only tiles intersecting
+        .result                              // the Extent are contained in the result
+        .stitch                 // Stitch together this RDD into a Raster[Tile]
+
+    GeoTiff(raster, metadata.crs).write("/some/path/result.tif")
+  }
+}

--- a/docs/spark/spark-examples.md
+++ b/docs/spark/spark-examples.md
@@ -28,3 +28,71 @@ val maximumTemperature: RDD[(SpatialKey, Tile)] =
     // Simply reduce by the key with a localMax
     .reduceByKey(_.localMax(_))
 ```
+
+### Tiling an RDD of spatial tiles, stitching and saving off as a single GeoTiff
+
+This example will show how to start with an `RDD[(ProjectedExtent, Tile)]` and end with a stitched together GeoTiff.
+
+
+__Note__: Stitching together an RDD can produce a tile that is far bigger than the driver program's memory can handle.
+You should only do this with small layers, or a filtered RDD.
+
+```scala
+import geotrellis.raster._
+import geotrellis.raster.io.geotiff._
+import geotrellis.raster.resample._
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.tiling._
+import geotrellis.vector._
+import org.apache.spark.HashPartitioner
+import org.apache.spark.rdd.RDD
+
+val rdd: RDD[(ProjectedExtent, Tile)] = ???
+
+// Tile this RDD to a grid layout. This will transform our raster data into a
+// common grid format, and merge any overlapping data.
+
+// We'll be tiling to a 512 x 512 tile size, and using the RDD's bounds as the tile bounds.
+val layoutScheme = FloatingLayoutScheme(512)
+
+// We gather the metadata that we will be targeting with the tiling here.
+// The return also gives us a zoom level, which we ignore.
+val (_: Int, metadata: TileLayerMetadata[SpatialKey]) =
+  TileLayerMetadata.fromRdd(rdd, layoutScheme)
+
+// Here we set some options for our tiling.
+// For this example, we will set the target partitioner to one
+// that has the same number of partitions as our original RDD.
+val tilerOptions =
+  Tiler.Options(
+    resampleMethod = Bilinear,
+    partitioner = new HashPartitioner(rdd.partitions.length)
+  )
+
+// Now we tile to an RDD with a SpaceTimeKey.
+
+val tiledRdd =
+  rdd.tileToLayout[SpatialKey](metadata, tilerOptions)
+
+
+// At this point, we want to combine our RDD and our Metadata to get a TileLayerRDD[SpatialKey]
+
+val layerRdd: TileLayerRDD[SpatialKey] =
+  ContextRDD(tiledRdd, metadata)
+
+// Now we can save this layer off to a GeoTrellis backend (Accumulo, HDFS, S3, etc)
+// In this example, though, we're going to just filter it by some bounding box
+// and then save the result as a GeoTiff.
+
+val areaOfInterest: Extent = ???
+
+val raster: Raster[Tile] =
+  layerRdd
+    .filter()                            // Use the filter/query API to
+    .where(Intersects(areaOfInterest))   // filter so that only tiles intersecting
+    .result                              // the Extent are contained in the result
+    .stitch                 // Stitch together this RDD into a Raster[Tile]
+
+GeoTiff(raster, metadata.crs).write("/some/path/result.tif")
+```

--- a/scripts/buildall-2.11.sh
+++ b/scripts/buildall-2.11.sh
@@ -12,6 +12,7 @@
 ./sbt -J-Xmx2G ++2.11.8 "project slick" test:compile || { exit 1; }
 ./sbt -J-Xmx2G ++2.11.8 "project shapefile" compile || { exit 1; }
 ./sbt -J-Xmx2G ++2.11.8 "project util" compile || { exit 1; }
+./sbt -J-Xmx2G ++2.11.8 "project doc-examples" compile || { exit 1; }
 ./sbt -J-Xmx2G ++2.11.8 "project raster-testkit" compile || { exit 1; }
 ./sbt -J-Xmx2G ++2.11.8 "project vector-testkit" compile || { exit 1; }
 ./sbt -J-Xmx2G ++2.11.8 "project spark-testkit" compile || { exit 1; }

--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -12,6 +12,7 @@
 ./sbt -J-Xmx2G "project slick" test:compile || { exit 1; }
 ./sbt -J-Xmx2G "project shapefile" compile || { exit 1; }
 ./sbt -J-Xmx2G "project util" compile || { exit 1; }
+./sbt -J-Xmx2G "project doc-examples" compile || { exit 1; }
 ./sbt -J-Xmx2G "project raster-testkit" compile || { exit 1; }
 ./sbt -J-Xmx2G "project vector-testkit" compile || { exit 1; }
 ./sbt -J-Xmx2G "project spark-testkit" compile || { exit 1; }


### PR DESCRIPTION
Added a subproject that we can use for compiling documentation examples.

Added an example for starting with an `RDD[(ProjectedExtent, Tile)]` and ending up with a GeoTiff.