### PR TITLE
Moved RDDLayoutMergeMethods functionality to object.

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/merge/RDDLayoutMerge.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/RDDLayoutMerge.scala
@@ -1,0 +1,41 @@
+package geotrellis.spark.merge
+
+import geotrellis.raster._
+import geotrellis.raster.merge._
+import geotrellis.raster.prototype._
+import geotrellis.spark._
+import geotrellis.spark.tiling.LayoutDefinition
+import geotrellis.util._
+
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+object RDDLayoutMerge {
+  /** Merges an RDD with metadata that contains a layout definition into another. */
+  def merge[
+    K: SpatialComponent: ClassTag,
+    V <: CellGrid: ClassTag: ? => TileMergeMethods[V]: ? => TilePrototypeMethods[V],
+    M: (? => LayoutDefinition)
+  ](left: RDD[(K, V)] with Metadata[M], right: RDD[(K, V)] with Metadata[M]) = {
+    val thisLayout: LayoutDefinition = left.metadata
+    val thatLayout: LayoutDefinition = right.metadata
+
+    val cutRdd =
+      right
+        .flatMap { case (k: K, tile: V) =>
+          val extent = thatLayout.mapTransform(k)
+          thisLayout.mapTransform(extent)
+            .coords
+            .map { case (col, row) =>
+              val outKey = k.setComponent(SpatialKey(col, row))
+              val newTile = tile.prototype(thisLayout.tileCols, thisLayout.tileRows)
+              val merged = newTile.merge(thisLayout.mapTransform(outKey), extent, tile)
+              (outKey, merged)
+            }
+        }
+
+
+    left.withContext { rdd => rdd.merge(cutRdd) }
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/merge/RddLayoutMergeMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/RddLayoutMergeMethods.scala
@@ -17,26 +17,6 @@ class RDDLayoutMergeMethods[
   M: (? => LayoutDefinition)
 ](val self: RDD[(K, V)] with Metadata[M]) extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
 
- def merge(other: RDD[(K, V)] with Metadata[M]) = {
-   val thisLayout: LayoutDefinition = self.metadata
-   val thatLayout: LayoutDefinition = other.metadata
-
-   val cutRdd =
-       other
-         .flatMap { case (k: K, tile: V) =>
-           val extent = thatLayout.mapTransform(k)
-           thisLayout.mapTransform(extent)
-             .coords
-             .map { case (col, row) =>
-             val outKey = k.setComponent(SpatialKey(col, row))
-             val newTile = tile.prototype(thisLayout.tileCols, thisLayout.tileRows)
-             val merged = newTile.merge(thisLayout.mapTransform(outKey), extent, tile)
-             (outKey, merged)
-           }
-       }
-
-
-   self.withContext { rdd => rdd.merge(cutRdd) }
- }
-
+ def merge(other: RDD[(K, V)] with Metadata[M]) =
+   RDDLayoutMerge.merge(self, other)
 }


### PR DESCRIPTION
This is another example of why we don't put functionality into classes that will close over implicit class type parameter context bounds.

Fixes #1567 