### PR TITLE
Fix Spark Etl

### DIFF
--- a/spark-etl/build.sbt
+++ b/spark-etl/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 name := "geotrellis-spark-etl"
 libraryDependencies ++= Seq(
-  "org.rogach" %% "scallop" % "1.0.0",
+  "org.rogach" %% "scallop" % "1.0.1",
   sparkCore % "provided",
   logging,
   scalatest % "test")

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/EtlConf.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/EtlConf.scala
@@ -84,6 +84,8 @@ class EtlConf(args: Seq[String]) extends ScallopConf(args){
 
   implicit def crsConverter: ValueConverter[CRS] = singleArgConverter[CRS](CRS.fromName)
   implicit def storageLevelConvert: ValueConverter[StorageLevel] = singleArgConverter[StorageLevel](StorageLevel.fromString)
+
+  verify()
 }
 object EtlConf {
   def layoutSchemeConverter = new ValueConverter[LayoutSchemeProvider] {


### PR DESCRIPTION
Since Scallaop 1.x automatic verification of configuration objects no longer works - now we must call `.verify()` function manually. Updates Scallop and fixes EtlConf class.