### PR TITLE
Added jai as explicit url dependency, to fix Travis builds.

### DIFF
--- a/shapefile/build.sbt
+++ b/shapefile/build.sbt
@@ -3,7 +3,8 @@ import Dependencies._
 name := "geotrellis-shapefile"
 libraryDependencies ++= Seq(
   "org.geotools" % "gt-shapefile" % Version.geotools,
-  "javax.media" % "jai_core" % "1.1.3"
+  // This is one finicky dependency. Being explicit in hopes it will stop hurting Travis.
+  "javax.media" % "jai_core" % "1.1.3" from "http://download.osgeo.org/webdav/geotools/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar"
 )
 
 resolvers += "Geotools" at "http://download.osgeo.org/webdav/geotools/"


### PR DESCRIPTION
Travis started working again because we explicitly list where to get jai in the geotools subproject; this PR does this for the shapefile project for completeness.