### PR TITLE
Create query after table is populated in slick test.

### DIFF
--- a/slick/src/test/scala/geotrellis/slick/PostgisSpec.scala
+++ b/slick/src/test/scala/geotrellis/slick/PostgisSpec.scala
@@ -107,10 +107,11 @@ class PostgisSpec extends FlatSpec with ShouldMatchers with TestDatabase with Sc
     // Make sure things are clean
     // we probably shouldn't need this
     try { db.run(CityTable.schema.drop) } catch { case e: Throwable =>  }
-    val q1 = for { c <- CityTable } yield c
+
     createSchema()
     db.run(CityTable ++= data.map{ d => (0, d._1, d._2) }).futureValue
 
+    val q1 = for { c <- CityTable } yield c
     db.run(q1.result).futureValue.toList.length should equal (data.length)
 
     val q2 = for { c <- CityTable } yield c


### PR DESCRIPTION
There's one slick test that fails Travis off and on; on inspection, the only thing I can see off about it is that it creates a query before creating the schema and populating the table. This is more correct, but I'm unsure it will solve our Travis woes; one can only hope.