### PR TITLE
Added mapBands to MultibandTile, updated doc example using it.

### DIFF
--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/SparkExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/SparkExamples.scala
@@ -101,13 +101,9 @@ object SparkExamples {
           }
           .bufferTiles(neighborhood.extent)
           .mapValues { bufferedTile =>
-            val bands =
-              bufferedTile.tile.bands
-                .map { band =>
-                  band.focalMedian(neighborhood, Some(bufferedTile.targetArea))
-                }
-
-            MultibandTile(bands)
+            bufferedTile.tile.mapBands { case (_, band) =>
+              band.focalMedian(neighborhood, Some(bufferedTile.targetArea))
+            }
           }
         }
   }

--- a/doc-examples/src/test/scala/geotrellis/doc/examples/spark/SparkExamplesTests.scala
+++ b/doc-examples/src/test/scala/geotrellis/doc/examples/spark/SparkExamplesTests.scala
@@ -41,13 +41,9 @@ class SparkExamplesTests extends FunSuite with Matchers with TestEnvironment wit
       }
       .bufferTiles(neighborhood.extent)
       .mapValues { bufferedTile =>
-        val bands =
-          bufferedTile.tile.bands
-            .map { band =>
-              band.focalMax(neighborhood, Some(bufferedTile.targetArea))
-            }
-
-        MultibandTile(bands)
+        bufferedTile.tile.mapBands { (_, band) =>
+          band.focalMax(neighborhood, Some(bufferedTile.targetArea))
+        }
       }
       .collect
       .toMap

--- a/docs/spark/spark-examples.md
+++ b/docs/spark/spark-examples.md
@@ -121,13 +121,9 @@ val resultLayer: MultibandTileLayerRDD[SpaceTimeKey] =
       }
       .bufferTiles(neighborhood.extent)
       .mapValues { bufferedTile =>
-        val bands =
-          bufferedTile.tile.bands
-            .map { band =>
-              band.focalMedian(neighborhood, Some(bufferedTile.targetArea))
-            }
-
-        MultibandTile(bands)
+        bufferedTile.tile.mapBands { case (_, band) =>
+          band.focalMedian(neighborhood, Some(bufferedTile.targetArea))
+        }
       }
     }
 ```

--- a/raster/src/main/scala/geotrellis/raster/MultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/MultibandTile.scala
@@ -72,6 +72,21 @@ trait MultibandTile extends CellGrid with MacroCombinableMultibandTile[Tile] wit
   def convert(newCellType: CellType): MultibandTile
 
   /**
+    * Map over each band, and return a new MultibandTile.
+    *
+    * @param f      A function to apply to each band, given it's band index.
+    *
+    * @return       An ArrayMultibandTile with the resulting tiles.
+    */
+  def mapBands(f: (Int, Tile) => Tile): MultibandTile = {
+    val resultBands = Array.ofDim[Tile](bandCount)
+    cfor(0)(_ < bandCount, _ + 1) { b =>
+      resultBands(b) = f(b, band(b))
+    }
+    ArrayMultibandTile(resultBands)
+  }
+
+  /**
     * Map over a subset of the bands of a multiband tile to create a
     * new integer-valued multiband tile.
     *


### PR DESCRIPTION
There was a spark example in which it was a bit awkward to create a new multiband tile out of a multiband tile by applying a focal median operation over each band. This API addition makes it less awkward.