### PR TITLE
[Polygonal Summary] Relax types to anything `Tile`d

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/summary/polygonal/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/summary/polygonal/Implicits.scala
@@ -1,16 +1,23 @@
 package geotrellis.spark.summary.polygonal
 
+import geotrellis.raster._
 import geotrellis.spark._
+import geotrellis.spark.tiling._
 import geotrellis.vector._
+import geotrellis.util._
+
 import org.apache.spark.rdd._
 import scala.reflect._
 
 object Implicits extends Implicits
 
 trait Implicits {
-  implicit class withZonalSummaryTileLayerRDDMethods[K](val self: TileLayerRDD[K])
+  implicit class withZonalSummaryTileLayerRDDMethods[
+    K,
+    M: GetComponent[?, LayoutDefinition]
+  ](val self: RDD[(K, Tile)] with Metadata[M])
     (implicit val keyClassTag: ClassTag[K], implicit val _sc: SpatialComponent[K])
-      extends PolygonalSummaryTileLayerRDDMethods[K] with Serializable
+      extends PolygonalSummaryTileLayerRDDMethods[K, M] with Serializable
 
   implicit class withZonalSummaryFeatureRDDMethods[G <: Geometry, D](val featureRdd: RDD[Feature[G, D]])
       extends PolygonalSummaryFeatureRDDMethods[G, D]

--- a/spark/src/main/scala/geotrellis/spark/summary/polygonal/PolygonalSummaryTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/summary/polygonal/PolygonalSummaryTileRDDMethods.scala
@@ -14,10 +14,9 @@ import org.apache.spark.rdd._
 import scala.reflect.ClassTag
 
 abstract class PolygonalSummaryTileLayerRDDMethods[
-  K: SpatialComponent: ClassTag,
-  V <: CellGrid,
+  K: ClassTag,
   M: GetComponent[?, LayoutDefinition]
-] extends MethodExtensions[ContextRDD[K,V,M]] {
+] extends MethodExtensions[RDD[(K, Tile)] with Metadata[M]] {
   import Implicits._
   protected implicit val _sc: SpatialComponent[K]
 

--- a/spark/src/main/scala/geotrellis/spark/summary/polygonal/PolygonalSummaryTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/summary/polygonal/PolygonalSummaryTileRDDMethods.scala
@@ -4,6 +4,7 @@ import geotrellis.raster.summary.polygonal._
 import geotrellis.raster.histogram._
 import geotrellis.raster._
 import geotrellis.spark._
+import geotrellis.spark.tiling._
 import geotrellis.vector._
 import geotrellis.util._
 
@@ -12,7 +13,11 @@ import org.apache.spark.rdd._
 
 import scala.reflect.ClassTag
 
-abstract class PolygonalSummaryTileLayerRDDMethods[K: ClassTag] extends MethodExtensions[TileLayerRDD[K]] {
+abstract class PolygonalSummaryTileLayerRDDMethods[
+  K: SpatialComponent: ClassTag,
+  V <: CellGrid,
+  M: GetComponent[?, LayoutDefinition]
+] extends MethodExtensions[ContextRDD[K,V,M]] {
   import Implicits._
   protected implicit val _sc: SpatialComponent[K]
 
@@ -37,17 +42,20 @@ abstract class PolygonalSummaryTileLayerRDDMethods[K: ClassTag] extends MethodEx
       .polygonalSummary(multiPolygon, zeroValue)(handler)
 
   def polygonalSummaryByKey[T: ClassTag, L: ClassTag](
-                                                   polygon: Polygon,
-                                                   zeroValue: T,
-                                                   handler: TilePolygonalSummaryHandler[T],
-                                                   fKey: K => L): RDD[(L, T)] = polygonalSummaryByKey(polygon, zeroValue, handler, fKey, None)
+    polygon: Polygon,
+    zeroValue: T,
+    handler: TilePolygonalSummaryHandler[T],
+    fKey: K => L
+  ): RDD[(L, T)] = {
+    polygonalSummaryByKey(polygon, zeroValue, handler, fKey, None)
+  }
 
   def polygonalSummaryByKey[T: ClassTag, L: ClassTag](
-                                                   polygon: Polygon,
-                                                   zeroValue: T,
-                                                   handler: TilePolygonalSummaryHandler[T],
-                                                   fKey: K => L,
-                                                   partitioner: Option[Partitioner]
+    polygon: Polygon,
+    zeroValue: T,
+    handler: TilePolygonalSummaryHandler[T],
+    fKey: K => L,
+    partitioner: Option[Partitioner]
   ): RDD[(L, T)] =
     self
       .asRasters
@@ -55,17 +63,20 @@ abstract class PolygonalSummaryTileLayerRDDMethods[K: ClassTag] extends MethodEx
       .polygonalSummaryByKey(polygon, zeroValue, partitioner)(handler)
 
   def polygonalSummaryByKey[T: ClassTag, L: ClassTag](
-                                                   multiPolygon: MultiPolygon,
-                                                   zeroValue: T,
-                                                   handler: TilePolygonalSummaryHandler[T],
-                                                   fKey: K => L): RDD[(L, T)] = polygonalSummaryByKey(multiPolygon, zeroValue, handler, fKey, None)
+    multiPolygon: MultiPolygon,
+    zeroValue: T,
+    handler: TilePolygonalSummaryHandler[T],
+    fKey: K => L
+  ): RDD[(L, T)] = {
+    polygonalSummaryByKey(multiPolygon, zeroValue, handler, fKey, None)
+  }
 
   def polygonalSummaryByKey[T: ClassTag, L: ClassTag](
-                                                   multiPolygon: MultiPolygon,
-                                                   zeroValue: T,
-                                                   handler: TilePolygonalSummaryHandler[T],
-                                                   fKey: K => L,
-                                                   partitioner: Option[Partitioner]
+    multiPolygon: MultiPolygon,
+    zeroValue: T,
+    handler: TilePolygonalSummaryHandler[T],
+    fKey: K => L,
+    partitioner: Option[Partitioner]
   ): RDD[(L, T)] =
     self
       .asRasters


### PR DESCRIPTION
### TODO
- [x] Relax constraints
- [x] Tests

### Motivation
Previously, the abstact class `PolygonalSummaryTileLayerRDDMethods` required a `TileLayerRDD`, which has certain constraints on what its metadata must contain. This was restrictive, as the `polygonalSummary` methods only require RDDs whose internals can be converted to Rasters. This PR relaxes the type requirements, such that anything that can convert to Rasters can use these summary methods automatically.