### PR TITLE
More Joda serializers

### DIFF
--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -4,7 +4,7 @@ name := "geotrellis-spark"
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % Version.spark % "provided",
   "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
-  "de.javakaffee" % "kryo-serializers" % "0.28" exclude("com.esotericsoftware.kryo", "kryo") exclude("com.esotericsoftware", "kryo"),
+  "de.javakaffee" % "kryo-serializers" % "0.38" exclude("com.esotericsoftware.kryo", "kryo") exclude("com.esotericsoftware", "kryo"),
   "com.esotericsoftware.kryo" % "kryo" % "2.21",
   "com.google.uzaygezen" % "uzaygezen-core" % "0.2",
   logging,

--- a/spark/src/main/scala/geotrellis/spark/io/kryo/KryoRegistrator.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/kryo/KryoRegistrator.scala
@@ -128,6 +128,7 @@ class KryoRegistrator extends SparkKryoRegistrator {
     kryo.register(classOf[geotrellis.spark.SpatialKey])
     kryo.register(classOf[geotrellis.spark.SpaceTimeKey])
     kryo.register(classOf[org.joda.time.DateTime], new jodatime.JodaDateTimeSerializer)
+    kryo.register(classOf[org.joda.time.LocalDate], new jodatime.JodaLocalDateSerializer)
     kryo.register(classOf[org.joda.time.Interval], new jodatime.JodaIntervalSerializer)
     kryo.register(classOf[geotrellis.spark.io.index.rowmajor.RowMajorSpatialKeyIndex])
     kryo.register(classOf[geotrellis.spark.io.index.zcurve.ZSpatialKeyIndex])


### PR DESCRIPTION
### Motivation
Kryo and JodaTime do not get along. We use the [kryo-serializers](https://github.com/magro/kryo-serializers) library to provide extra serializers for Joda types. This PR bumps the version we depend on, and registers an additional serializer necessary for internal projects.