### PR TITLE
Fix GeoWave Tests

### DIFF
--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geowave" compile || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geowave" compile test:compile || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project cassandra" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project vector-test" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project raster-test" test || { exit 1; }

--- a/geowave/build.sbt
+++ b/geowave/build.sbt
@@ -46,6 +46,8 @@ libraryDependencies ++= Seq(
     excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
       ExclusionRule(organization = "javax.servlet")),
   "com.jsuereth" %% "scala-arm" % "1.4",
+  "de.javakaffee" % "kryo-serializers" % "0.38" exclude("com.esotericsoftware", "kryo"),
+  "com.esotericsoftware" % "kryo-shaded" % "3.0.3",
   spire,
   scalatest % "test")
 

--- a/geowave/src/main/scala/geotrellis/spark/io/kryo/GeowaveKryoRegistrator.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/kryo/GeowaveKryoRegistrator.scala
@@ -8,13 +8,16 @@ import java.io.{ ObjectInputStream, ObjectOutputStream }
 import mil.nga.giat.geowave.core.index.{ Persistable, PersistenceUtils }
 import org.apache.accumulo.core.data.Key
 import org.geotools.coverage.grid.GridCoverage2D
+import org.geotools.data.DataUtilities
+import org.opengis.feature.simple.SimpleFeatureType
 
 
 // GeoWave registrator
 class GeowaveKryoRegistrator extends KryoRegistrator {
   override def registerClasses(kryo: Kryo) = {
     kryo.addDefaultSerializer(classOf[Persistable], new PersistableSerializer())
-    kryo.addDefaultSerializer(classOf[GridCoverage2D], new GridCoverage2DSerializer())
+    kryo.addDefaultSerializer(classOf[GridCoverage2D], new DelegateSerializer[GridCoverage2D]())
+    kryo.addDefaultSerializer(classOf[SimpleFeatureType], new SimpleFeatureTypeSerializer())
     kryo.register(classOf[Key])
     super.registerClasses(kryo)
   }
@@ -36,13 +39,46 @@ class GeowaveKryoRegistrator extends KryoRegistrator {
     }
   }
 
-  // Serializer for GridCoverage2D.  Delegate to Java Serialization.
-  private class GridCoverage2DSerializer extends Serializer[GridCoverage2D] {
-    override def write(kryo: Kryo, output: Output, gc: GridCoverage2D): Unit = {
+  /**
+    * SimpleFeatureType serializer.  This makes use of the
+    * encoding/decoding machinery provied by GeoTools.
+    */
+  private class SimpleFeatureTypeSerializer extends Serializer[SimpleFeatureType] {
+    override def write(kryo: Kryo, output: Output, sft: SimpleFeatureType): Unit = {
+      val name = sft.getTypeName.getBytes
+      val encoding = DataUtilities.encodeType(sft).getBytes
+      output.writeInt(name.length)
+      output.writeBytes(name)
+      output.writeInt(encoding.length)
+      output.writeBytes(encoding)
+    }
+
+    override def read(kryo: Kryo, input: Input, t: Class[SimpleFeatureType]): SimpleFeatureType = {
+      val name = {
+        val length = input.readInt
+        val buffer = new Array[Byte](length); input.read(buffer)
+        new String(buffer)
+      }
+      val encoding = {
+        val length = input.readInt
+        val buffer = new Array[Byte](length); input.read(buffer)
+        new String(buffer)
+      }
+
+      DataUtilities.createType(name, encoding)
+    }
+  }
+
+  /**
+    *  Serializer for difficult types.  This simply delegates to Java
+    *  Serialization.
+    */
+  private class DelegateSerializer[T] extends Serializer[T] {
+    override def write(kryo: Kryo, output: Output, x: T): Unit = {
       val bs = new ByteArrayOutputStream
       val oos = new ObjectOutputStream(bs)
 
-      oos.writeObject(gc)
+      oos.writeObject(x)
 
       val bytes = bs.toByteArray
 
@@ -51,7 +87,7 @@ class GeowaveKryoRegistrator extends KryoRegistrator {
       bs.close ; oos.close
     }
 
-    override def read(kryo: Kryo, input: Input, t: Class[GridCoverage2D]): GridCoverage2D = {
+    override def read(kryo: Kryo, input: Input, t: Class[T]): T = {
       val length = input.readInt
       val bytes = new Array[Byte](length)
 
@@ -59,10 +95,10 @@ class GeowaveKryoRegistrator extends KryoRegistrator {
 
       val bs = new ByteArrayInputStream(bytes)
       val ois = new ObjectInputStream(bs)
-      val gc = ois.readObject.asInstanceOf[GridCoverage2D]
+      val x = ois.readObject.asInstanceOf[T]
 
       bs.close ; ois.close
-      gc
+      x
     }
   }
 

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeoWaveFeatureRDDReaderSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeoWaveFeatureRDDReaderSpec.scala
@@ -42,43 +42,12 @@ object GeoWaveFeatureRDDReaderSpec {
   *  stage for testing. In particular (from the root of the GeoTrellis repository)
   *  `/scripts/runTestDBs` ought to be run prior to this suite's being run.
   */
-class GeoWaveFeatureRDDReaderSpec extends FunSpec { self: Suite =>
+class GeoWaveFeatureRDDReaderSpec
+    extends FunSpec
+    with GeowaveTestEnvironment
+{
+
   import GeoWaveFeatureRDDReaderSpec.id
-  def setKryoRegistrator(conf: SparkConf): Unit =
-    conf.set("spark.kryo.registrator", "geotrellis.spark.io.kryo.KryoRegistrator")
-
-  lazy val _sc: SparkContext = {
-    System.setProperty("spark.driver.port", "0")
-    System.setProperty("spark.hostPort", "0")
-    System.setProperty("spark.ui.enabled", "false")
-
-    val conf = new SparkConf()
-    conf
-      .setMaster("local")
-      .setAppName("Test Context")
-
-    // Shortcut out of using Kryo serialization if we want to test against
-    // java serialization.
-    if(Properties.envOrNone("GEOTRELLIS_USE_JAVA_SER") == None) {
-      conf
-        .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-        .set("spark.kryoserializer.buffer.max", "500m")
-        .set("spark.kryo.registrationRequired","false")
-      setKryoRegistrator(conf)
-    }
-    conf
-      .set("*.sink.servlet.class","")
-
-    val sparkContext = new SparkContext(conf)
-
-    System.clearProperty("spark.driver.port")
-    System.clearProperty("spark.hostPort")
-    System.clearProperty("spark.ui.enabled")
-
-    sparkContext
-  }
-
-  implicit def sc: SparkContext = _sc
 
   describe("GeoTrellis read/write with GeoWave") {
     it("Should roundtrip geowave records in accumulo") {
@@ -93,8 +62,8 @@ class GeoWaveFeatureRDDReaderSpec extends FunSpec { self: Suite =>
         .map { x: Int => Feature(Point(x, 40), Map[String, Any]()) }
         .toArray
       val featureRDD = sc.parallelize(features)
-      val zookeeper = "localhost:20000"
-      val instanceName = "AccumuloInstance"
+      val zookeeper = "localhost:21810"
+      val instanceName = "instance"
       val username = "root"
       val password = "password"
       val featureType = builder.buildFeatureType()

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
@@ -24,7 +24,6 @@ class GeowaveSpatialSpec
     with Matchers
     with BeforeAndAfterAll
     with GeowaveTestEnvironment
-    with TestFiles
 {
 
   val gwNamespace = "TEST"

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeowaveSpatialSpec.scala
@@ -10,7 +10,6 @@ import geotrellis.spark.testfiles.TestFiles
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
 import mil.nga.giat.geowave.core.geotime.ingest._
 import mil.nga.giat.geowave.core.store._
-import mil.nga.giat.geowave.core.store.index.writer.IndexWriter
 import mil.nga.giat.geowave.datastore.accumulo._
 import org.geotools.coverage.grid._
 import org.geotools.gce.geotiff._

--- a/scripts/geowaveTestDB.sh
+++ b/scripts/geowaveTestDB.sh
@@ -6,4 +6,4 @@ docker network create --driver bridge geowave
 docker run -td --restart=always --net=geowave \
        -p 50095:5009 -p 21810:2181 -p 9997:9997 -p 9999:9999 \
        --hostname leader --name leader \
-       jamesmcclain/geowave:8760ce2
+       jamesmcclain/geowave:c127c16


### PR DESCRIPTION
This allows the tests in the GeoWave subproject to pass.  Because there is [currently an incompatibility with the latest versions of GeoWave](https://github.com/ngageoint/geowave/issues/914), an older version of GeoWave must (currently) be built and installed in one's local `~/.m2` repository.  The complete sequence is:

   1. Build an older version of GeoWave locally.  That can be done by pulling down [this repository](https://github.com/jamesmcclain/GeoWaveDocker) and typing `make world`.
   2. Apply the diff listed at the bottom of this comment to this branch
   3. Type `docker run -td --restart=always --net=geowave -p 50095:5009 -p 21810:2181 -p 9997:9997 -p 9999:9999 --hostname leader --name leader jamesmcclain/geowave:c127c16` to start a local GeoWave instance
   4. Type `echo leader localhost > /tmp/hostaliases` to create a host aliases file
   5. Type `HOSTALIASES=/tmp/hostaliases ./sbt -J-Xmx2G "project geowave" clean test` to run the tests

```diff
diff --git a/geowave/build.sbt b/geowave/build.sbt
index a89620b..db5d747 100644
--- a/geowave/build.sbt
+++ b/geowave/build.sbt
@@ -50,11 +50,11 @@ libraryDependencies ++= Seq(
   scalatest % "test")
 
 resolvers ++= Seq(
-  // Resolver.mavenLocal,
+  Resolver.mavenLocal,
   "boundless" at "https://repo.boundlessgeo.com/release",
   "geosolutions" at "http://maven.geo-solutions.it/",
-  "geowave-release" at "http://geowave-maven.s3-website-us-east-1.amazonaws.com/release",
-  "geowave-snapshot" at "http://geowave-maven.s3-website-us-east-1.amazonaws.com/snapshot",
+  // "geowave-release" at "http://geowave-maven.s3-website-us-east-1.amazonaws.com/release",
+  // "geowave-snapshot" at "http://geowave-maven.s3-website-us-east-1.amazonaws.com/snapshot",
   "osgeo" at "http://download.osgeo.org/webdav/geotools/"
 )
```
