### PR TITLE
Fix metadata on surface calculations

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalTileLayerCollectionMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalTileLayerCollectionMethods.scala
@@ -1,5 +1,6 @@
 package geotrellis.spark.mapalgebra.focal
 
+import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
 
 trait FocalTileLayerCollectionMethods[K] extends CollectionFocalOperation[K] {
@@ -14,17 +15,25 @@ trait FocalTileLayerCollectionMethods[K] extends CollectionFocalOperation[K] {
   def focalConway() = { val n = Square(1) ; focal(n) { (tile, bounds) => Sum(tile, n, bounds) } }
   def focalConvolve(k: Kernel) = { focal(k) { (tile, bounds) => Convolve(tile, k, bounds) } }
 
+  /** Calculates the aspect of each cell in a raster.
+   *
+   * @see [[geotrellis.raster.mapalgebra.focal.Aspect]]
+   */
   def aspect() = {
     val n = Square(1)
     focalWithCellSize(n) { (tile, bounds, cellSize) =>
       Aspect(tile, n, bounds, cellSize)
-    }
+    }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
   }
 
+  /** Calculates the slope of each cell in a raster.
+   *
+   * @see [[geotrellis.raster.mapalgebra.focal.Slope]]
+   */
   def slope(zFactor: Double = 1.0) = {
     val n = Square(1)
     focalWithCellSize(n) { (tile, bounds, cellSize) =>
       Slope(tile, n, bounds, cellSize, zFactor)
-    }
+    }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalTileLayerRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalTileLayerRDDMethods.scala
@@ -1,5 +1,6 @@
 package geotrellis.spark.mapalgebra.focal
 
+import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
 
 trait FocalTileLayerRDDMethods[K] extends FocalOperation[K] {
@@ -14,17 +15,25 @@ trait FocalTileLayerRDDMethods[K] extends FocalOperation[K] {
   def focalConway() = { val n = Square(1) ; focal(n) { (tile, bounds) => Sum(tile, n, bounds) } }
   def focalConvolve(k: Kernel) = { focal(k) { (tile, bounds) => Convolve(tile, k, bounds) } }
 
+  /** Calculates the aspect of each cell in a raster.
+   *
+   * @see [[geotrellis.raster.mapalgebra.focal.Aspect]]
+   */
   def aspect() = {
     val n = Square(1)
     focalWithCellSize(n) { (tile, bounds, cellSize) =>
       Aspect(tile, n, bounds, cellSize)
-    }
+    }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
   }
 
+  /** Calculates the slope of each cell in a raster.
+   *
+   * @see [[geotrellis.raster.mapalgebra.focal.Slope]]
+   */
   def slope(zFactor: Double = 1.0) = {
     val n = Square(1)
     focalWithCellSize(n) { (tile, bounds, cellSize) =>
       Slope(tile, n, bounds, cellSize, zFactor)
-    }
+    }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/hillshade/HillshadeTileLayerCollectionMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/hillshade/HillshadeTileLayerCollectionMethods.scala
@@ -1,14 +1,20 @@
 package geotrellis.spark.mapalgebra.focal.hillshade
 
+import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
 import geotrellis.raster.mapalgebra.focal.hillshade._
 import geotrellis.spark.mapalgebra.focal._
 
 trait HillshadeTileLayerCollectionMethods[K] extends CollectionFocalOperation[K] {
+
+  /** Calculates the hillshade of each cell in a raster.
+   *
+   * @see [[geotrellis.raster.mapalgebra.focal.Hillshade]]
+   */
   def hillshade(azimuth: Double = 315, altitude: Double = 45, zFactor: Double = 1) = {
     val n = Square(1)
     focalWithCellSize(n) { (tile, bounds, cellSize) =>
       Hillshade(tile, n, bounds, cellSize, azimuth, altitude, zFactor)
-    }
+    }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/hillshade/HillshadeTileLayerRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/hillshade/HillshadeTileLayerRDDMethods.scala
@@ -1,14 +1,20 @@
 package geotrellis.spark.mapalgebra.focal.hillshade
 
+import geotrellis.raster._
 import geotrellis.spark.mapalgebra.focal._
 import geotrellis.raster.mapalgebra.focal.hillshade._
 import geotrellis.raster.mapalgebra.focal._
 
 trait HillshadeTileLayerRDDMethods[K] extends FocalOperation[K] {
+
+  /** Calculates the hillshade of each cell in a raster.
+   *
+   * @see [[geotrellis.raster.mapalgebra.focal.Hillshade]]
+   */
   def hillshade(azimuth: Double = 315, altitude: Double = 45, zFactor: Double = 1) = {
     val n = Square(1)
     focalWithCellSize(n) { (tile, bounds, cellSize) =>
       Hillshade(tile, n, bounds, cellSize, azimuth, altitude, zFactor)
-    }
+    }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/SlopeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/SlopeSpec.scala
@@ -3,6 +3,8 @@ package geotrellis.spark.mapalgebra.focal
 import geotrellis.raster._
 import geotrellis.spark._
 import org.scalatest.FunSpec
+import geotrellis.raster.io.geotiff._
+import java.io._
 
 class SlopeSpec extends FunSpec with TestEnvironment {
 
@@ -15,6 +17,15 @@ class SlopeSpec extends FunSpec with TestEnvironment {
       val path = "aspect.tif"
 
       testGeoTiff(sc, path)(rasterOp, sparkOp)
+    }
+
+    it("should update RDD cellType of DoubleConstantNoDataCellType") {
+      val tile = SinglebandGeoTiff(new File(inputHomeLocalPath, "aspect.tif").getPath).tile
+
+      val (_, rasterRDD) = createTileLayerRDD(tile, 4, 3)
+      val slopeRDD = rasterRDD.slope()
+      slopeRDD.metadata.cellType should be (DoubleConstantNoDataCellType)
+      slopeRDD.collect.head._2.cellType should be (DoubleConstantNoDataCellType)
     }
 
     it("should match gdal computed slope raster (collections api)") {


### PR DESCRIPTION
Fixes: https://github.com/geotrellis/geotrellis/issues/1629

Slope, Aspect and Hillshade operations return tiles with cell type of double.
RDD Metadata of input needs to be adjusted to reflect this change in cell type.
