### PR TITLE
Fix non-exhaustive match

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffMultibandTile.scala
@@ -12,7 +12,7 @@ class UInt16GeoTiffMultibandTile(
   compression: Compression,
   bandCount: Int,
   hasPixelInterleave: Boolean,
-  val cellType: CellType
+  val cellType: UShortCells with NoDataHandling
 ) extends GeoTiffMultibandTile(compressedBytes, decompressor, segmentLayout, compression, bandCount, hasPixelInterleave)
     with UInt16GeoTiffSegmentCollection {
 


### PR DESCRIPTION
This fixes a slight oversight which causes a compiler warning (though, contingently, it happens to be the case that there are no possible runtime errors as a result of this oversight - the only thing that can get passed into this constructor is the type which this PR changes the constructor to expect).