### PR TITLE
Mark GeoWave and GeoMesa Experimental

### DIFF
--- a/geomesa/src/main/scala/geotrellis/geomesa/geotools/FeatureToGeoMesaSimpleFeatureMethods.scala
+++ b/geomesa/src/main/scala/geotrellis/geomesa/geotools/FeatureToGeoMesaSimpleFeatureMethods.scala
@@ -1,11 +1,19 @@
 package geotrellis.geomesa.geotools
 
 import geotrellis.proj4.CRS
+import geotrellis.util.annotations.experimental
 import geotrellis.util.MethodExtensions
 import geotrellis.vector.{Feature, Geometry}
+
 import org.opengis.feature.simple.SimpleFeature
 
-trait FeatureToGeoMesaSimpleFeatureMethods[G <: Geometry, T] extends MethodExtensions[Feature[G, T]] {
-  def toSimpleFeature(featureName: String, featureId: Option[String] = None, crs: Option[CRS] = None)(implicit transmute: T => Seq[(String, Any)]): SimpleFeature =
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental trait FeatureToGeoMesaSimpleFeatureMethods[G <: Geometry, T] extends MethodExtensions[Feature[G, T]] {
+
+  /** $experimental */
+  @experimental def toSimpleFeature(featureName: String, featureId: Option[String] = None, crs: Option[CRS] = None)(implicit transmute: T => Seq[(String, Any)]): SimpleFeature =
     GeometryToGeoMesaSimpleFeature(featureName, self.geom, featureId, crs, self.data)
 }

--- a/geomesa/src/main/scala/geotrellis/geomesa/geotools/GeoMesaImplicits.scala
+++ b/geomesa/src/main/scala/geotrellis/geomesa/geotools/GeoMesaImplicits.scala
@@ -2,10 +2,12 @@ package geotrellis.geomesa.geotools
 
 import geotrellis.util.MethodExtensions
 import geotrellis.vector.{Feature, Geometry}
+import geotrellis.util.annotations.experimental
 
-object GeoMesaImplicits extends GeoMesaImplicits
 
-trait GeoMesaImplicits {
+@experimental object GeoMesaImplicits extends GeoMesaImplicits
+
+@experimental trait GeoMesaImplicits {
   implicit class withFeatureToGeoMesaSimpleFeatureMethods[G <: Geometry, T](val self: Feature[G, T])
     extends MethodExtensions[Feature[G, T]]
       with FeatureToGeoMesaSimpleFeatureMethods[G, T]

--- a/geomesa/src/main/scala/geotrellis/geomesa/geotools/GeometryToGeoMesaSimpleFeature.scala
+++ b/geomesa/src/main/scala/geotrellis/geomesa/geotools/GeometryToGeoMesaSimpleFeature.scala
@@ -1,8 +1,9 @@
 package geotrellis.geomesa.geotools
 
 import geotrellis.proj4.{CRS => GCRS}
-import geotrellis.vector.{Geometry, Line, MultiLine, MultiPoint, MultiPolygon, Point, Polygon}
 import geotrellis.spark.util.cache.LRUCache
+import geotrellis.util.annotations.experimental
+import geotrellis.vector.{Geometry, Line, MultiLine, MultiPoint, MultiPolygon, Point, Polygon}
 
 import com.vividsolutions.jts.{geom => jts}
 import org.geotools.feature.simple.{SimpleFeatureBuilder, SimpleFeatureTypeBuilder}
@@ -10,7 +11,11 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.locationtech.geomesa.accumulo.index.Constants
 import com.typesafe.config.ConfigFactory
 
-object GeometryToGeoMesaSimpleFeature {
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeometryToGeoMesaSimpleFeature {
 
   val whenField  = "when"
   val whereField = "where"
@@ -21,7 +26,8 @@ object GeometryToGeoMesaSimpleFeature {
       sizeOf  = {x => 1l}
     )
 
-  def apply(featureName: String, geom: Geometry, featureId: Option[String], crs: Option[GCRS], data: Seq[(String, Any)]): SimpleFeature = {
+  /** $experimental */
+  @experimental def apply(featureName: String, geom: Geometry, featureId: Option[String], crs: Option[GCRS], data: Seq[(String, Any)]): SimpleFeature = {
     val sft = featureTypeCache.getOrInsert(featureName, {
       val sftb = (new SimpleFeatureTypeBuilder).minOccurs(1).maxOccurs(1).nillable(false)
 

--- a/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaFeatureReader.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaFeatureReader.scala
@@ -5,6 +5,7 @@ import geotrellis.spark._
 import geotrellis.util.annotations.experimental
 import geotrellis.vector._
 
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.accumulo.core.client.mapreduce.InputFormatBase
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapreduce.Job
@@ -21,7 +22,10 @@ import scala.reflect.ClassTag
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental class GeoMesaFeatureReader(val instance: GeoMesaInstance)(implicit sc: SparkContext) extends Serializable {
+@experimental class GeoMesaFeatureReader(val instance: GeoMesaInstance)
+  (implicit sc: SparkContext) extends Serializable with LazyLogging {
+
+  logger.error("GeoMesa support is experimental")
 
   /** $experimental */
   @experimental def readSimpleFeatures(

--- a/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaFeatureReader.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaFeatureReader.scala
@@ -2,6 +2,7 @@ package geotrellis.spark.io.geomesa
 
 import geotrellis.geotools._
 import geotrellis.spark._
+import geotrellis.util.annotations.experimental
 import geotrellis.vector._
 
 import org.apache.accumulo.core.client.mapreduce.InputFormatBase
@@ -16,8 +17,14 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.reflect.ClassTag
 
-class GeoMesaFeatureReader(val instance: GeoMesaInstance)(implicit sc: SparkContext) extends Serializable {
-  def readSimpleFeatures(
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental class GeoMesaFeatureReader(val instance: GeoMesaInstance)(implicit sc: SparkContext) extends Serializable {
+
+  /** $experimental */
+  @experimental def readSimpleFeatures(
     featureName: String,
     query: Query,
     simpleFeatureType: SimpleFeatureType,
@@ -38,7 +45,8 @@ class GeoMesaFeatureReader(val instance: GeoMesaInstance)(implicit sc: SparkCont
     sc.newAPIHadoopRDD(job.getConfiguration, classOf[GeoMesaInputFormat], classOf[Text], classOf[SimpleFeature]).map(U => U._2)
   }
 
-  def read[G <: geotrellis.vector.Geometry: ClassTag, D]
+  /** $experimental */
+  @experimental def read[G <: geotrellis.vector.Geometry: ClassTag, D]
     (layerId: LayerId, query: Query, simpleFeatureType: SimpleFeatureType, numPartitions: Option[Int] = None)
     (implicit transmute: Map[String, Any] => D): RDD[Feature[G, D]] =
       readSimpleFeatures(
@@ -49,6 +57,11 @@ class GeoMesaFeatureReader(val instance: GeoMesaInstance)(implicit sc: SparkCont
       ).map(_.toFeature[G, D]())
 }
 
-object GeoMesaFeatureReader {
-  def apply(instance: GeoMesaInstance)(implicit sc: SparkContext): GeoMesaFeatureReader = new GeoMesaFeatureReader(instance)
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeoMesaFeatureReader {
+
+  /** $experimental */
+  @experimental def apply(instance: GeoMesaInstance)(implicit sc: SparkContext): GeoMesaFeatureReader = new GeoMesaFeatureReader(instance)
 }

--- a/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaFeatureWriter.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaFeatureWriter.scala
@@ -5,8 +5,9 @@ import geotrellis.spark._
 import geotrellis.util.annotations.experimental
 import geotrellis.vector._
 
-import org.apache.spark.SparkContext
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
 import org.geotools.data.Transaction
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
@@ -14,7 +15,10 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental class GeoMesaFeatureWriter(val instance: GeoMesaInstance)(implicit sc: SparkContext) extends Serializable {
+@experimental class GeoMesaFeatureWriter(val instance: GeoMesaInstance)
+  (implicit sc: SparkContext) extends Serializable with LazyLogging {
+
+  logger.error("GeoMesa support is experimental")
 
   /** $experimental */
   @experimental def write[G <: Geometry, D: ? => Seq[(String, Any)]]

--- a/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaFeatureWriter.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaFeatureWriter.scala
@@ -1,16 +1,23 @@
 package geotrellis.spark.io.geomesa
 
-import geotrellis.spark._
-import geotrellis.vector._
 import geotrellis.geomesa.geotools._
+import geotrellis.spark._
+import geotrellis.util.annotations.experimental
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.geotools.data.Transaction
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
-class GeoMesaFeatureWriter(val instance: GeoMesaInstance)(implicit sc: SparkContext) extends Serializable {
-  def write[G <: Geometry, D: ? => Seq[(String, Any)]]
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental class GeoMesaFeatureWriter(val instance: GeoMesaInstance)(implicit sc: SparkContext) extends Serializable {
+
+  /** $experimental */
+  @experimental def write[G <: Geometry, D: ? => Seq[(String, Any)]]
     (layerId: LayerId, rdd: RDD[Feature[G, D]])
     (implicit ev: Feature[G, D] => FeatureToGeoMesaSimpleFeatureMethods[G, D]): Unit = {
 
@@ -37,7 +44,12 @@ class GeoMesaFeatureWriter(val instance: GeoMesaInstance)(implicit sc: SparkCont
   }
 }
 
-object GeoMesaFeatureWriter {
-  def apply(instance: GeoMesaInstance)(implicit sc: SparkContext): GeoMesaFeatureWriter =
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeoMesaFeatureWriter {
+
+  /** $experimental */
+  @experimental def apply(instance: GeoMesaInstance)(implicit sc: SparkContext): GeoMesaFeatureWriter =
     new GeoMesaFeatureWriter(instance)
 }

--- a/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaInstance.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaInstance.scala
@@ -3,6 +3,7 @@ package geotrellis.spark.io.geomesa
 import geotrellis.spark.LayerId
 import geotrellis.util.annotations.experimental
 
+import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data.DataStoreFinder
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
 
@@ -12,7 +13,10 @@ import scala.collection.JavaConverters._
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental class GeoMesaInstance(val conf: Map[String, String]) extends Serializable {
+@experimental class GeoMesaInstance(val conf: Map[String, String])
+    extends Serializable with LazyLogging {
+  logger.error("GeoMesa support is experimental")
+
   val SEP = "__.__"
 
   def layerIdString(layerId: LayerId): String = s"${layerId.name}${SEP}${layerId.zoom}"

--- a/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaInstance.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/io/geomesa/GeoMesaInstance.scala
@@ -1,13 +1,18 @@
 package geotrellis.spark.io.geomesa
 
 import geotrellis.spark.LayerId
+import geotrellis.util.annotations.experimental
 
 import org.geotools.data.DataStoreFinder
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
 
 import scala.collection.JavaConverters._
 
-class GeoMesaInstance(val conf: Map[String, String]) extends Serializable {
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental class GeoMesaInstance(val conf: Map[String, String]) extends Serializable {
   val SEP = "__.__"
 
   def layerIdString(layerId: LayerId): String = s"${layerId.name}${SEP}${layerId.zoom}"
@@ -16,8 +21,13 @@ class GeoMesaInstance(val conf: Map[String, String]) extends Serializable {
   def accumuloDataStore = dataStore.asInstanceOf[AccumuloDataStore]
 }
 
-object GeoMesaInstance {
-  def apply(tableName: String, instanceName: String, zookeepers: String, user: String, password: String, useMock: Boolean = false): GeoMesaInstance = {
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeoMesaInstance {
+
+  /** $experimental */
+  @experimental def apply(tableName: String, instanceName: String, zookeepers: String, user: String, password: String, useMock: Boolean = false): GeoMesaInstance = {
     new GeoMesaInstance(Map(
       "instanceId" -> instanceName,
       "zookeepers" -> zookeepers,

--- a/geomesa/src/main/scala/geotrellis/spark/io/geomesa/kryo/KryoRegistrator.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/io/geomesa/kryo/KryoRegistrator.scala
@@ -1,11 +1,19 @@
 package geotrellis.spark.io.geomesa.kryo
 
+import geotrellis.util.annotations.experimental
+
 import com.esotericsoftware.kryo.Kryo
 import org.apache.spark.serializer.{KryoRegistrator => SparkKryoRegistrator}
 import de.javakaffee.kryoserializers._
 
-class KryoRegistrator extends SparkKryoRegistrator {
-  override def registerClasses(kryo: Kryo): Unit = {
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental class KryoRegistrator extends SparkKryoRegistrator {
+
+  /** $experimental */
+  @experimental override def registerClasses(kryo: Kryo): Unit = {
     new geotrellis.spark.io.kryo.KryoRegistrator().registerClasses(kryo)
 
     // SimpleFeatureType requires proper UnmodifiableCollection serializer

--- a/geomesa/src/main/scala/geotrellis/spark/io/geomesa/package.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/io/geomesa/package.scala
@@ -1,7 +1,14 @@
 package geotrellis.spark.io
 
 import geotrellis.geomesa.geotools._
+import geotrellis.util.annotations.experimental
 
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
 package object geomesa extends GeoMesaImplicits {
-  implicit def mapToSeq[K, V](map: Map[K, V]): Seq[(K, V)] = map.toSeq
+
+  /** $experimental */
+  @experimental implicit def mapToSeq[K, V](map: Map[K, V]): Seq[(K, V)] = map.toSeq
 }

--- a/geomesa/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
+++ b/geomesa/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
@@ -8,9 +8,7 @@
 
 package org.locationtech.geomesa.jobs.mapreduce
 
-import java.io._
-import java.lang.Float._
-import java.net.{URL, URLClassLoader}
+import geotrellis.util.annotations.experimental
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.accumulo.core.client.mapreduce.{AbstractInputFormat, AccumuloInputFormat, InputFormatBase, RangeInputSplit}
@@ -32,17 +30,25 @@ import org.locationtech.geomesa.jobs.{GeoMesaConfigurator, JobUtils}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
+import java.io._
+import java.lang.Float._
+import java.net.{URL, URLClassLoader}
+
 import scala.annotation.tailrec
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
 import org.locationtech.geomesa.accumulo.data.tables.GeoMesaTable
 
-object GeoMesaInputFormat extends LazyLogging {
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeoMesaInputFormat extends LazyLogging {
 
   val SYS_PROP_SPARK_LOAD_CP = "org.locationtech.geomesa.spark.load-classpath"
 
-  def configure(job: Job,
+  @experimental def configure(job: Job,
                 dsParams: Map[String, String],
                 featureTypeName: String,
                 filter: Option[String] = None,
@@ -54,12 +60,12 @@ object GeoMesaInputFormat extends LazyLogging {
   }
 
   /**
-    * Configure the input format.
+    * $experimental Configure the input format.
     *
     * This is a single method, as we have to calculate several things to pass to the underlying
     * AccumuloInputFormat, and there is not a good hook to indicate when the config is finished.
     */
-  def configure(job: Job, dsParams: Map[String, String], query: Query): Unit = {
+  @experimental def configure(job: Job, dsParams: Map[String, String], query: Query): Unit = {
 
     val ds = DataStoreFinder.getDataStore(dsParams).asInstanceOf[AccumuloDataStore]
     assert(ds != null, "Invalid data store parameters")
@@ -114,11 +120,12 @@ object GeoMesaInputFormat extends LazyLogging {
   }
 
   /**
-    * This takes any jars that have been loaded by spark in the context classloader and makes them
-    * available to the general classloader. This is required as not all classes (even spark ones) check
-    * the context classloader.
+    * $experimental This takes any jars that have been loaded by spark
+    * in the context classloader and makes them available to the
+    * general classloader. This is required as not all classes (even
+    * spark ones) check the context classloader.
     */
-  def ensureSparkClasspath(): Unit = {
+  @experimental def ensureSparkClasspath(): Unit = {
     val sysLoader = ClassLoader.getSystemClassLoader
     val ccl = Thread.currentThread().getContextClassLoader
     if (ccl == null || !ccl.getClass.getCanonicalName.startsWith("org.apache.spark.")) {
@@ -143,8 +150,10 @@ object GeoMesaInputFormat extends LazyLogging {
 
 /**
   * Input format that allows processing of simple features from GeoMesa based on a CQL query
+  *
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with LazyLogging {
+@experimental class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with LazyLogging {
 
   val delegate = new AccumuloInputFormat
 
@@ -153,7 +162,7 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with LazyLoggi
   var desiredSplitCount: Int = -1
   var table: GeoMesaTable = null
 
-  private def init(conf: Configuration) = if (sft == null) {
+  @experimental private def init(conf: Configuration) = if (sft == null) {
     val params = GeoMesaConfigurator.getDataStoreInParams(conf)
     val ds = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
     sft = ds.getSchema(GeoMesaConfigurator.getFeatureType(conf))
@@ -173,7 +182,7 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with LazyLoggi
     * geomesa, that creates too many mappers. Instead, we try to group the ranges by tservers. We use the
     * number of shards in the schema as a proxy for number of tservers.
     */
-  override def getSplits(context: JobContext): java.util.List[InputSplit] = {
+  @experimental override def getSplits(context: JobContext): java.util.List[InputSplit] = {
     init(context.getConfiguration)
     val accumuloSplits = delegate.getSplits(context)
     // fallback on creating 2 mappers per node if desiredSplits is unset.
@@ -198,7 +207,7 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with LazyLoggi
     splitsSet.toList
   }
 
-  override def createRecordReader(split: InputSplit, context: TaskAttemptContext) = {
+  @experimental override def createRecordReader(split: InputSplit, context: TaskAttemptContext) = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
     init(context.getConfiguration)
@@ -216,12 +225,14 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with LazyLoggi
 }
 
 /**
-  * Record reader that delegates to accumulo record readers and transforms the key/values coming back into
-  * simple features.
+  * Record reader that delegates to accumulo record readers and
+  * transforms the key/values coming back into simple features.
   *
   * @param readers
+  *
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-class GeoMesaRecordReader(sft: SimpleFeatureType,
+@experimental class GeoMesaRecordReader(sft: SimpleFeatureType,
                           table: GeoMesaTable,
                           readers: Array[RecordReader[Key, Value]],
                           hasId: Boolean,
@@ -234,7 +245,7 @@ class GeoMesaRecordReader(sft: SimpleFeatureType,
 
   val getId = table.getIdFromRow(sft)
 
-  override def initialize(split: InputSplit, context: TaskAttemptContext) = {
+  @experimental override def initialize(split: InputSplit, context: TaskAttemptContext) = {
     val splits = split.asInstanceOf[GroupedSplit].splits
     var i = 0
     while (i < splits.length) {
@@ -249,7 +260,7 @@ class GeoMesaRecordReader(sft: SimpleFeatureType,
   /**
     * Advances to the next delegate reader
     */
-  private[this] def nextReader() = {
+  @experimental private[this] def nextReader() = {
     readerIndex = readerIndex + 1
     if (readerIndex < readers.length) {
       currentReader = Some(readers(readerIndex))
@@ -258,19 +269,18 @@ class GeoMesaRecordReader(sft: SimpleFeatureType,
     }
   }
 
-  override def getProgress = if (readers.length == 0) 1f else if (readerIndex < 0) 0f else {
+  @experimental override def getProgress = if (readers.length == 0) 1f else if (readerIndex < 0) 0f else {
     val readersProgress = readerIndex * 1f / readers.length
     val readerProgress = currentReader.map(_.getProgress / readers.length).filterNot(isNaN).getOrElse(0f)
     readersProgress + readerProgress
   }
 
-  override def nextKeyValue() = nextKeyValueInternal()
+  @experimental override def nextKeyValue() = nextKeyValueInternal()
 
   /**
     * Get the next key value from the underlying reader, incrementing the reader when required
     */
-  @tailrec
-  private def nextKeyValueInternal(): Boolean =
+  @tailrec @experimental private def nextKeyValueInternal(): Boolean =
   currentReader match {
     case None => false
     case Some(reader) =>
@@ -286,18 +296,20 @@ class GeoMesaRecordReader(sft: SimpleFeatureType,
       }
   }
 
-  override def getCurrentValue = currentFeature
+  @experimental override def getCurrentValue = currentFeature
 
-  override def getCurrentKey = new Text(currentFeature.getID)
+  @experimental override def getCurrentKey = new Text(currentFeature.getID)
 
-  override def close() = {} // delegate Accumulo readers have a no-op close
+  @experimental override def close() = {} // delegate Accumulo readers have a no-op close
 }
 
 /**
-  * Input split that groups a series of RangeInputSplits. Has to implement Hadoop Writable, thus the vars and
-  * mutable state.
+  * Input split that groups a series of RangeInputSplits. Has to
+  * implement Hadoop Writable, thus the vars and mutable state.
+  *
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-class GroupedSplit extends InputSplit with Writable {
+@experimental class GroupedSplit extends InputSplit with Writable {
 
   // if we're running in spark, we need to load the context classpath before anything else,
   // otherwise we get classloading and serialization issues
@@ -308,17 +320,17 @@ class GroupedSplit extends InputSplit with Writable {
   var location: String = null
   var splits: ArrayBuffer[RangeInputSplit] = ArrayBuffer.empty
 
-  override def getLength =  splits.foldLeft(0L)((l: Long, r: RangeInputSplit) => l + r.getLength)
+  @experimental override def getLength =  splits.foldLeft(0L)((l: Long, r: RangeInputSplit) => l + r.getLength)
 
-  override def getLocations = if (location == null) Array.empty else Array(location)
+  @experimental override def getLocations = if (location == null) Array.empty else Array(location)
 
-  override def write(out: DataOutput) = {
+  @experimental override def write(out: DataOutput) = {
     out.writeUTF(location)
     out.writeInt(splits.length)
     splits.foreach(_.write(out))
   }
 
-  override def readFields(in: DataInput) = {
+  @experimental override def readFields(in: DataInput) = {
     location = in.readUTF()
     splits.clear()
     var i = 0
@@ -331,5 +343,5 @@ class GroupedSplit extends InputSplit with Writable {
     }
   }
 
-  override def toString = s"mapreduce.GroupedSplit[$location](${splits.length})"
+  @experimental override def toString = s"mapreduce.GroupedSplit[$location](${splits.length})"
 }

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveFeatureRDDReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveFeatureRDDReader.scala
@@ -1,12 +1,13 @@
 package geotrellis.spark.io.geowave
 
+import geotrellis.geotools._
 import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.avro.codecs._
 import geotrellis.spark.io.hadoop.formats._
 import geotrellis.spark.util.KryoWrapper
+import geotrellis.util.annotations.experimental
 import geotrellis.vector._
-import geotrellis.geotools._
 
 import org.apache.avro.Schema
 import org.apache.hadoop.io._
@@ -29,10 +30,15 @@ import mil.nga.giat.geowave.core.store.operations.remote.options._
 
 import scala.reflect._
 
-object GeoWaveFeatureRDDReader {
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeoWaveFeatureRDDReader {
 
   /**
-    * Read out an RDD of Vector features from an accumulo geowave store
+    * $experimental Read out an RDD of Vector features from an
+    * accumulo geowave store
     *
     * @param zookeepers            zookeeper master node location
     * @param accumuloInstanceName  name of the accumulo instance to connect to
@@ -46,7 +52,7 @@ object GeoWaveFeatureRDDReader {
     * @tparam G                    the type of geometry to be retrieved through geowave (REQUIRED)
     * @note                        If the above type parameter is not supplied, errors WILL be thrown
     */
-  def read[G <: Geometry : ClassTag](
+  @experimental def read[G <: Geometry : ClassTag](
     zookeepers: String,
     accumuloInstanceName: String,
     accumuloInstanceUser: String,

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveFeatureRDDWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveFeatureRDDWriter.scala
@@ -1,13 +1,14 @@
 package geotrellis.spark.io.geowave
 
+import geotrellis.geotools._
 import geotrellis.spark._
-import geotrellis.spark.io.hadoop.formats._
-import geotrellis.spark.io.index._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.avro.codecs._
+import geotrellis.spark.io.hadoop.formats._
+import geotrellis.spark.io.index._
 import geotrellis.spark.util.KryoWrapper
+import geotrellis.util.annotations.experimental
 import geotrellis.vector._
-import geotrellis.geotools._
 
 import org.apache.hadoop.io._
 import org.apache.hadoop.mapreduce.Job
@@ -27,10 +28,15 @@ import mil.nga.giat.geowave.adapter.vector._
 
 import scala.reflect._
 
-object GeoWaveFeatureRDDWriter {
+
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeoWaveFeatureRDDWriter {
 
   /**
-    * Read out an RDD of Vector features from an accumulo geowave store
+    * $experimental Read out an RDD of Vector features from an
+    * accumulo geowave store
     *
     * @param features              an RDD of [[geotrellis.vector.Feature]] objects to be written
     * @param zookeepers            zookeeper master node location
@@ -43,7 +49,7 @@ object GeoWaveFeatureRDDWriter {
     *
     * @tparam G                    the type of geometry to be retrieved through geowave (REQUIRED)
     */
-  def write[G <: Geometry, D](
+  @experimental def write[G <: Geometry, D](
     features: RDD[Feature[G, D]],
     zookeepers: String,
     accumuloInstanceName: String,

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
@@ -5,8 +5,9 @@ import geotrellis.proj4.LatLng
 import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.vector.Extent
 import geotrellis.spark.io.accumulo.AccumuloAttributeStore
+import geotrellis.util.annotations.experimental
+import geotrellis.vector.Extent
 
 import com.typesafe.scalalogging.LazyLogging
 import com.vividsolutions.jts.geom._
@@ -42,9 +43,13 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 
-object GeowaveAttributeStore {
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeowaveAttributeStore {
 
-  def accumuloRequiredOptions(
+  /** $experimental */
+  @experimental def accumuloRequiredOptions(
     zookeepers: String,
     accumuloInstance: String,
     accumuloUser: String,
@@ -60,7 +65,8 @@ object GeowaveAttributeStore {
     aro
   }
 
-  def basicOperations(
+  /** $experimental */
+  @experimental def basicOperations(
     zookeepers: String,
     accumuloInstance: String,
     accumuloUser: String,
@@ -75,7 +81,8 @@ object GeowaveAttributeStore {
       geowaveNamespace)
   }
 
-  def adapters(bao: BasicAccumuloOperations): Array[RasterDataAdapter] = {
+  /** $experimental */
+  @experimental def adapters(bao: BasicAccumuloOperations): Array[RasterDataAdapter] = {
     val adapters = new AccumuloAdapterStore(bao).getAdapters
     val retval = adapters.asScala
       .map(_.asInstanceOf[RasterDataAdapter])
@@ -84,16 +91,21 @@ object GeowaveAttributeStore {
     adapters.close ; retval
   }
 
-  def primaryIndex = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
+  /** $experimental */
+  @experimental def primaryIndex = (new SpatialDimensionalityTypeProvider.SpatialIndexBuilder).createIndex()
 
-  def subStrategies(idx: PrimaryIndex) = idx
+  /** $experimental */
+  @experimental def subStrategies(idx: PrimaryIndex) = idx
     .getIndexStrategy
     .asInstanceOf[HierarchicalNumericIndexStrategy]
     .getSubStrategies
 
 }
 
-class GeowaveAttributeStore(
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental class GeowaveAttributeStore(
   val zookeepers: String,
   val accumuloInstance: String,
   val accumuloUser: String,
@@ -123,10 +135,12 @@ class GeowaveAttributeStore(
   val dataStore = new AccumuloDataStore(basicAccumuloOperations)
   val dataStatisticsStore = new AccumuloDataStatisticsStore(basicAccumuloOperations)
 
-  def delete(tableName: String) =
+  /** $experimental */
+  @experimental def delete(tableName: String) =
     connector.tableOperations.delete(tableName)
 
-  def boundingBoxes(): Map[ByteArrayId, BoundingBoxDataStatistics[Any]] = {
+  /** $experimental */
+  @experimental def boundingBoxes(): Map[ByteArrayId, BoundingBoxDataStatistics[Any]] = {
     adapters.map({ adapter =>
       val adapterId = adapter.getAdapterId
       val bboxId = BoundingBoxDataStatistics.STATS_ID
@@ -138,7 +152,8 @@ class GeowaveAttributeStore(
     }).toMap
   }
 
-  def leastZooms(): Map[ByteArrayId, Int] = {
+  /** $experimental */
+  @experimental def leastZooms(): Map[ByteArrayId, Int] = {
     adapters.map({ adapter =>
       val adapterId = adapter.getAdapterId
       val bbox = boundingBoxes.getOrElse(adapterId, throw new Exception(s"Unknown Adapter Id $adapterId"))
@@ -165,31 +180,42 @@ class GeowaveAttributeStore(
     }).toMap
   }
 
-  def primaryIndex = GeowaveAttributeStore.primaryIndex
-  def adapters = GeowaveAttributeStore.adapters(basicAccumuloOperations)
-  def subStrategies = GeowaveAttributeStore.subStrategies(primaryIndex)
+  /** $experimental */
+  @experimental def primaryIndex = GeowaveAttributeStore.primaryIndex
 
-  def delete(layerId: LayerId, attributeName: String): Unit =
+  /** $experimental */
+  @experimental def adapters = GeowaveAttributeStore.adapters(basicAccumuloOperations)
+
+  /** $experimental */
+  @experimental def subStrategies = GeowaveAttributeStore.subStrategies(primaryIndex)
+
+  /** $experimental */
+  @experimental def delete(layerId: LayerId, attributeName: String): Unit =
     delegate.delete(layerId, attributeName)
 
-  def delete(layerId: LayerId): Unit = delegate.delete(layerId)
+  /** $experimental */
+  @experimental def delete(layerId: LayerId): Unit = delegate.delete(layerId)
 
-  def readAll[T: JsonFormat](attributeName: String): Map[LayerId, T] =
+  /** $experimental */
+  @experimental def readAll[T: JsonFormat](attributeName: String): Map[LayerId, T] =
     delegate.readAll[T](attributeName)
 
-  def read[T: JsonFormat](layerId: LayerId, attributeName: String): T =
+  /** $experimental */
+  @experimental def read[T: JsonFormat](layerId: LayerId, attributeName: String): T =
     delegate.read[T](layerId, attributeName)
 
-  def write[T: JsonFormat](layerId: LayerId, attributeName: String, value: T): Unit =
+  /** $experimental */
+  @experimental def write[T: JsonFormat](layerId: LayerId, attributeName: String, value: T): Unit =
     delegate.write[T](layerId, attributeName, value)
 
-  def availableAttributes(layerId: LayerId) =
+  /** $experimental */
+  @experimental def availableAttributes(layerId: LayerId) =
     delegate.availableAttributes(layerId)
 
   /**
     * Use GeoWave to see whether a layer really exists.
     */
-  private def gwLayerExists(layerId: LayerId): Boolean = {
+  @experimental private def gwLayerExists(layerId: LayerId): Boolean = {
     val LayerId(name, zoom) = layerId
     val candidateAdapters = adapters.filter(_.getCoverageName == name)
 
@@ -205,16 +231,16 @@ class GeowaveAttributeStore(
   }
 
   /**
-    * Answer whether a layer exists (either in GeoWave or only in the
-    * AttributeStore).
+    * $experimental Answer whether a layer exists (either in GeoWave
+    * or only in the AttributeStore).
     */
-  def layerExists(layerId: LayerId): Boolean =
+  @experimental def layerExists(layerId: LayerId): Boolean =
     gwLayerExists(layerId) || delegate.layerExists(layerId)
 
   /**
     * Use GeoWave to get a list of actual LayerIds.
     */
-  private def gwLayerIds: Seq[LayerId] = {
+  @experimental private def gwLayerIds: Seq[LayerId] = {
     val list =
       for (
         adapter <- adapters;
@@ -233,10 +259,10 @@ class GeowaveAttributeStore(
   }
 
   /**
-    * Return a complete list of LayerIds (those associated with actual
-    * GeoWave layers, as well as those only recorded in the
-    * AttributeStore).
+    * $experimental Return a complete list of LayerIds (those
+    * associated with actual GeoWave layers, as well as those only
+    * recorded in the AttributeStore).
     */
-  def layerIds: Seq[LayerId] =
+  @experimental def layerIds: Seq[LayerId] =
     (gwLayerIds ++ delegate.layerIds).distinct
 }

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveAttributeStore.scala
@@ -113,6 +113,8 @@ import spray.json.DefaultJsonProtocol._
   val geowaveNamespace: String
 ) extends DiscreteLayerAttributeStore with LazyLogging {
 
+  logger.error("GeoWave support is experimental")
+
   val zkInstance = (new ZooKeeperInstance(accumuloInstance, zookeepers))
   val token = new PasswordToken(accumuloPass)
   val connector = zkInstance.getConnector(accumuloUser, token)

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
@@ -12,10 +12,11 @@ import geotrellis.util._
 import geotrellis.util.annotations.experimental
 import geotrellis.vector.Extent
 
+import com.typesafe.scalalogging.LazyLogging
 import com.vividsolutions.jts.geom._
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
-import mil.nga.giat.geowave.core.geotime.store.query.IndexOnlySpatialQuery
 import mil.nga.giat.geowave.core.geotime.ingest._
+import mil.nga.giat.geowave.core.geotime.store.query.IndexOnlySpatialQuery
 import mil.nga.giat.geowave.core.index.ByteArrayId
 import mil.nga.giat.geowave.core.store._
 import mil.nga.giat.geowave.core.store.index.CustomIdIndex
@@ -76,7 +77,10 @@ object GeowaveLayerReader {
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkContext) {
+@experimental class GeowaveLayerReader(val attributeStore: AttributeStore)
+  (implicit sc: SparkContext) extends LazyLogging {
+
+  logger.error("GeoWave support is experimental")
 
   val defaultNumPartitions = sc.defaultParallelism
 

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
@@ -9,6 +9,7 @@ import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index.KeyIndex
 import geotrellis.spark.tiling.{LayoutDefinition, MapKeyTransform}
 import geotrellis.util._
+import geotrellis.util.annotations.experimental
 import geotrellis.vector.Extent
 
 import com.vividsolutions.jts.geom._
@@ -35,19 +36,22 @@ import spray.json._
 import scala.reflect._
 
 
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
 object GeowaveLayerReader {
   private val geometryFactory = new GeometryFactory
   private val tileClassTag = classTag[Tile]
   private val mbtClassTag = classTag[MultibandTile]
 
   /**
-    * Given a map transform and a keybounds, produce a corresponding
-    * jts.Geometry.
+    * $experimental Given a map transform and a keybounds, produce a
+    * corresponding jts.Geometry.
     *
     * @param  mt  The map transform
     * @param  kb  The KeyBounds
     */
-  def keyBoundsToGeometry(mt: MapKeyTransform, kb: KeyBounds[SpatialKey]) = {
+  @experimental def keyBoundsToGeometry(mt: MapKeyTransform, kb: KeyBounds[SpatialKey]) = {
     val KeyBounds(minKey, maxKey) = kb
     val Extent(lng1, lat1, lng2, lat2) = mt(minKey)
     val Extent(lng3, lat3, lng4, lat4) = mt(maxKey)
@@ -69,26 +73,29 @@ object GeowaveLayerReader {
   }
 }
 
-class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkContext) {
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkContext) {
 
   val defaultNumPartitions = sc.defaultParallelism
 
   val gas = attributeStore.asInstanceOf[GeowaveAttributeStore]
 
-  private def adapters = gas.adapters
-  private def basicOperations = gas.basicAccumuloOperations
-  private def bboxMap = gas.boundingBoxes
-  private def index = gas.primaryIndex
-  private def requiredOptions = gas.accumuloRequiredOptions
-  private def substrats = gas.subStrategies
+  @experimental private def adapters = gas.adapters
+  @experimental private def basicOperations = gas.basicAccumuloOperations
+  @experimental private def bboxMap = gas.boundingBoxes
+  @experimental private def index = gas.primaryIndex
+  @experimental private def requiredOptions = gas.accumuloRequiredOptions
+  @experimental private def substrats = gas.subStrategies
 
   /**
-    * Compute the common part of the
+    * $experimental Compute the common part of the
     * org.apache.hadoop.conf.Configuration associated with this layer.
     * This result can be reused by changing the Query and QueryOptions
     * as desired.
     */
-  def computeConfiguration()(implicit sc: SparkContext) = {
+  @experimental def computeConfiguration()(implicit sc: SparkContext) = {
     val pluginOptions = new DataStorePluginOptions
     pluginOptions.setFactoryOptions(requiredOptions)
     val configOptions = pluginOptions.getFactoryOptionsAsMap
@@ -101,12 +108,12 @@ class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkC
   }
 
   /**
-    * Compute the metadata associated with this layer.
+    * $experimental Compute the metadata associated with this layer.
     *
     * @param  adapter  The RasterDataAdapter associated with the chosen layer
     * @param  ranges   The ranges in degrees of longitude and latitude associated with the chosen tier
     */
-  def computeSpatialMetadata(
+  @experimental def computeSpatialMetadata(
     adapter: RasterDataAdapter,
     ranges: Array[Double]
   ): (TileLayerMetadata[SpatialKey], Int, Int) = {
@@ -169,16 +176,16 @@ class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkC
   }
 
   /**
-    * Read particular rasters out of the GeoWave database.  The
-    * particular rasters to read are given by the result of running
-    * the provided LayerQuery.
+    * $experimental Read particular rasters out of the GeoWave
+    * database.  The particular rasters to read are given by the
+    * result of running the provided LayerQuery.
     *
     * @param  id               The LayerId specifying the name and tier to query
     * @param  rasterQuery      Produces a list of rasters to read
     * @param  numPartitions    The number of Spark partitions to use
     * @param  filterIndexOnly  ?
     */
-  def read[
+  @experimental def read[
     K <: SpatialKey,
     V: TileOrMultibandTile: ClassTag,
     M: JsonFormat: GetComponent[?, Bounds[K]]
@@ -244,14 +251,16 @@ class GeowaveLayerReader(val attributeStore: AttributeStore)(implicit sc: SparkC
     new ContextRDD(rdd, md)
   }
 
-  def read[
+  /** $experimental */
+  @experimental def read[
     K <: SpatialKey: Boundable,
     V: TileOrMultibandTile: ClassTag,
     M: JsonFormat: GetComponent[?, Bounds[K]]
   ](id: LayerId): RDD[(K, V)] with Metadata[M] =
     read(id, new LayerQuery[K, M])
 
-  def query[
+  /** $experimental */
+  @experimental def query[
     K <: SpatialKey: Boundable,
     V: TileOrMultibandTile: ClassTag,
     M: JsonFormat: GetComponent[?, Bounds[K]]

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -9,6 +9,7 @@ import geotrellis.spark.io.accumulo._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index.KeyIndex
 import geotrellis.util._
+import geotrellis.util.annotations.experimental
 import geotrellis.vector.Extent
 
 import com.typesafe.scalalogging.LazyLogging
@@ -52,9 +53,13 @@ import resource._
 import spray.json._
 
 
-object GeowaveLayerWriter extends LazyLogging {
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeowaveLayerWriter extends LazyLogging {
 
-  def write[
+  /** $experimental */
+  @experimental def write[
     K <: SpatialKey: ClassTag,
     V: TileOrMultibandTile: ClassTag,
     M: JsonFormat: GetComponent[?, Bounds[K]]
@@ -226,13 +231,17 @@ object GeowaveLayerWriter extends LazyLogging {
   }
 }
 
-class GeowaveLayerWriter(
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental class GeowaveLayerWriter(
   val attributeStore: GeowaveAttributeStore,
   val accumuloWriter: AccumuloWriteStrategy
 )(implicit sc: SparkContext)
     extends LazyLogging {
 
-  def write[
+  /** $experimental */
+  @experimental def write[
     K <: SpatialKey: ClassTag,
     V: TileOrMultibandTile: ClassTag,
     M: JsonFormat: GetComponent[?, Bounds[K]]
@@ -244,7 +253,8 @@ class GeowaveLayerWriter(
         throw new EmptyBoundsError("Cannot write layer with empty bounds.")
     }
 
-  protected def _write[
+  /** $experimental */
+  @experimental protected def _write[
     K <: SpatialKey: ClassTag,
     V: TileOrMultibandTile: ClassTag,
     M: JsonFormat: GetComponent[?, Bounds[K]]

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerWriter.scala
@@ -240,6 +240,8 @@ import spray.json._
 )(implicit sc: SparkContext)
     extends LazyLogging {
 
+  logger.error("GeoWave support is experimental")
+
   /** $experimental */
   @experimental def write[
     K <: SpatialKey: ClassTag,

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveUtil.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveUtil.scala
@@ -1,15 +1,21 @@
 package geotrellis.spark.io.geowave
 
+import geotrellis.util.annotations.experimental
+
 import scala.math.{ abs, pow, round }
 
 
-object GeowaveUtil {
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental object GeowaveUtil {
+
   /**
-    * If an edge or corner of an extent is very close to a split in
+    * $experimental If an edge or corner of an extent is very close to a split in
     * the GeoWave index (for some given number of bits), then it
     * should be snapped to the split to avoid pathological behavior).
     */
-  def rectify(bits: Int)(_x: Double) = {
+  @experimental def rectify(bits: Int)(_x: Double) = {
     val division = if (bits > 0) pow(2, -bits) ; else 1
     val x = (_x / 360.0) / division
     val xPrime = round(x)

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/SerializablePersistable.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/SerializablePersistable.scala
@@ -1,5 +1,7 @@
 package geotrellis.spark.io.geowave
 
+import geotrellis.util.annotations.experimental
+
 import mil.nga.giat.geowave.core.index.Persistable
 import mil.nga.giat.geowave.core.index.PersistenceUtils
 import org.apache.hadoop.io.ObjectWritable
@@ -8,20 +10,25 @@ import org.apache.spark.util.Utils
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
 
-class SerializablePersistable[T <: Persistable](@transient var t: T)
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental class SerializablePersistable[T <: Persistable](@transient var t: T)
     extends Serializable {
 
-  def value: T = t
+  /** $experimental */
+  @experimental def value: T = t
 
-  override def toString: String = t.toString
+  /** $experimental */
+  @experimental override def toString: String = t.toString
 
-  private def writeObject(out: ObjectOutputStream): Unit = {
+  @experimental private def writeObject(out: ObjectOutputStream): Unit = {
     val bytes = PersistenceUtils.toBinary(t)
     out.writeInt(bytes.length)
     out.write(bytes)
   }
 
-  private def readObject(in: ObjectInputStream): Unit = {
+  @experimental private def readObject(in: ObjectInputStream): Unit = {
     val length = in.readInt()
     val bytes = new Array[Byte](length)
     in.readFully(bytes)

--- a/geowave/src/main/scala/geotrellis/spark/io/kryo/GeowaveKryoRegistrator.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/kryo/GeowaveKryoRegistrator.scala
@@ -1,5 +1,7 @@
 package geotrellis.spark.io.kryo
 
+import geotrellis.util.annotations.experimental
+
 import com.esotericsoftware.kryo.io.{ Input, Output }
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Serializer
@@ -13,9 +15,13 @@ import org.geotools.data.DataUtilities
 import org.opengis.feature.simple.SimpleFeatureType
 
 
-// GeoWave registrator
-class GeowaveKryoRegistrator extends KryoRegistrator {
-  override def registerClasses(kryo: Kryo) = {
+/**
+  * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
+  */
+@experimental class GeowaveKryoRegistrator extends KryoRegistrator {
+
+  /** $experimental */
+  @experimental override def registerClasses(kryo: Kryo) = {
     UnmodifiableCollectionsSerializer.registerSerializers(kryo)
     kryo.addDefaultSerializer(classOf[Persistable], new PersistableSerializer())
     kryo.addDefaultSerializer(classOf[GridCoverage2D], new DelegateSerializer[GridCoverage2D]())
@@ -23,8 +29,8 @@ class GeowaveKryoRegistrator extends KryoRegistrator {
     super.registerClasses(kryo)
   }
 
-  //Default serializer for any GeoWave Persistable object
-  private class PersistableSerializer extends Serializer[Persistable] {
+  /** $experimental Default serializer for any GeoWave Persistable object */
+  @experimental private class PersistableSerializer extends Serializer[Persistable] {
     override def write(kryo: Kryo, output: Output, geowaveObj: Persistable): Unit = {
       val bytes = PersistenceUtils.toBinary(geowaveObj)
       output.writeInt(bytes.length)
@@ -41,10 +47,10 @@ class GeowaveKryoRegistrator extends KryoRegistrator {
   }
 
   /**
-    *  Serializer for difficult types.  This simply delegates to Java
-    *  Serialization.
+    *  $experimental Serializer for difficult types.  This simply
+    *  delegates to Java Serialization.
     */
-  private class DelegateSerializer[T] extends Serializer[T] {
+  @experimental private class DelegateSerializer[T] extends Serializer[T] {
     override def write(kryo: Kryo, output: Output, x: T): Unit = {
       val bs = new ByteArrayOutputStream
       val oos = new ObjectOutputStream(bs)

--- a/util/src/main/java/geotrellis/util/annotations/experimental.java
+++ b/util/src/main/java/geotrellis/util/annotations/experimental.java
@@ -1,0 +1,42 @@
+package geotrellis.util.annotations;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Inspired from
+ * https://github.com/ReactiveX/RxJava/blob/1.x/src/main/java/rx/annotations/Experimental.java
+ * which was inspired from
+ * https://code.google.com/p/guava-libraries/source/browse/guava/src/com/google/common/annotations/Beta.java
+ */
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Signifies that a public API (public class, method or field) is will almost certainly
+ * be changed or removed in a future release. An API bearing this annotation should not
+ * be used or relied upon in production code. APIs exposed with this annotation exist
+ * to allow broad testing and feedback on experimental features.
+ **/
+@Retention(RetentionPolicy.CLASS)
+@Target({
+        ElementType.ANNOTATION_TYPE,
+        ElementType.CONSTRUCTOR,
+        ElementType.FIELD,
+        ElementType.METHOD,
+        ElementType.TYPE })
+@Documented
+public @interface experimental {}


### PR DESCRIPTION
Although an `@experimental` decorator has been created and used, this changeset is a largely a cosmetics- and documentation-related one.  That is because giving the decorator any real teeth (e.g. displaying warning at compile-time when experimental features are used) would seem to require writing a compiler plugin.

![c7a004cc-97a1-11e6-99eb-af899eb49d99](https://cloud.githubusercontent.com/assets/11281373/19608901/090efdaa-97a2-11e6-950e-db93e3a6c2d0.png)

Fixes #1677 