### PR TITLE
Histograms Over Fractions of RDDs of Tiles

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/summary/StatsTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/summary/StatsTileRDDMethods.scala
@@ -30,11 +30,24 @@ trait StatsTileRDDMethods[K] extends TileRDDMethods[K] {
       .mapValues { case (tile, count) => tile / count}
   }
 
+  /**
+    * Compute the histogram of an RDD of [[Tile]] objects.
+    *
+    * @return  A [[Histogram[Double]]]
+    */
   def histogram(): Histogram[Double] =
     histogram(StreamingHistogram.DEFAULT_NUM_BUCKETS)
 
-  def histogram(numBuckets: Int): Histogram[Double] =
-    self
+  /**
+    * Compute the histogram of an RDD of [[Tile]] objects.
+    *
+    * @param  numBuckets  The number of buckets that the histogram should have
+    * @param  fraction    The fraction of [[Tile]] objects to sample (the default is 100%)
+    * @param  seed        The seed of the RNG which determines which tiles to take the histograms of
+    * @return             A [[Histogram[Double]]]
+    */
+  def histogram(numBuckets: Int, fraction: Double = 1.0, seed: Long = 33): Histogram[Double] =
+    (if (fraction >= 1.0) self; else self.sample(false, fraction, seed))
       .map { case (key, tile) => tile.histogramDouble(numBuckets) }
       .reduce { _ merge _ }
 

--- a/spark/src/test/scala/geotrellis/spark/summary/StatsTileRDDMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/StatsTileRDDMethodsSpec.scala
@@ -97,5 +97,18 @@ class StatsTileRDDMethodsSpec extends FunSpec with TestEnvironment with TestFile
 
       hist.merge(hist2).quantileBreaks(70) should be (hist.quantileBreaks(70))
     }
+
+    it ("should be able to sample a fraction of an RDD to compute a histogram") {
+      val path = "raster-test/data/aspect.tif"
+      val gt = SinglebandGeoTiff(path)
+      val originalRaster = gt.raster.resample(500, 500)
+      val (_, rdd) = createTileLayerRDD(originalRaster, 5, 5, gt.crs)
+
+      val hist1 = rdd.histogram(72)
+      val hist2 = rdd.histogram(72, 1.0/25)
+
+      hist2.totalCount.toDouble should be >= (hist1.totalCount / 25.0)
+      hist2.totalCount.toDouble should be <= (hist1.totalCount / 12.5)
+    }
   }
 }


### PR DESCRIPTION
This changeset provides the capability to compute histograms over a fraction of the tiles in an RDD.

Fixes #1465 