### PR TITLE
Use `collectMetadata` instead of `TileLayerMetadata.fromRdd`

### DIFF
--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/SparkExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/SparkExamples.scala
@@ -43,7 +43,7 @@ object SparkExamples {
     // We gather the metadata that we will be targeting with the tiling here.
     // The return also gives us a zoom level, which we ignore.
     val (_: Int, metadata: TileLayerMetadata[SpatialKey]) =
-      TileLayerMetadata.fromRdd(rdd, layoutScheme)
+      rdd.collectMetadata[SpatialKey](layoutScheme)
 
     // Here we set some options for our tiling.
     // For this example, we will set the target partitioner to one

--- a/docs/spark/spark-examples.md
+++ b/docs/spark/spark-examples.md
@@ -59,7 +59,7 @@ val layoutScheme = FloatingLayoutScheme(512)
 // We gather the metadata that we will be targeting with the tiling here.
 // The return also gives us a zoom level, which we ignore.
 val (_: Int, metadata: TileLayerMetadata[SpatialKey]) =
-  TileLayerMetadata.fromRdd(rdd, layoutScheme)
+  rdd.collectMetadata[SpatialKey](layoutScheme)
 
 // Here we set some options for our tiling.
 // For this example, we will set the target partitioner to one

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
@@ -125,7 +125,7 @@ case class Etl(conf: EtlConf, @transient modules: Seq[TypedModule] = Etl.default
         val reprojected = rdd.reproject(destCrs)
         val (zoom: Int, md: TileLayerMetadata[K]) = scheme match {
           case Left(layoutScheme) => output.maxZoom match {
-            case Some(zoom) =>  TileLayerMetadata.fromRdd(reprojected, ZoomedLayoutScheme(destCrs, output.tileSize), zoom)
+            case Some(zoom) =>  reprojected.collectMetadata(destCrs, output.tileSize, zoom)
             case _ => reprojected.collectMetadata(layoutScheme)
           }
           case Right(layoutDefinition) => reprojected.collectMetadata(layoutDefinition)
@@ -136,7 +136,7 @@ case class Etl(conf: EtlConf, @transient modules: Seq[TypedModule] = Etl.default
 
       case BufferedReproject =>
         val (_, md) = output.maxZoom match {
-          case Some(zoom) =>  TileLayerMetadata.fromRdd(rdd, ZoomedLayoutScheme(destCrs, output.tileSize), zoom)
+          case Some(zoom) => rdd.collectMetadata(destCrs, output.tileSize, zoom)
           case _ => rdd.collectMetadata(FloatingLayoutScheme(output.tileSize))
         }
         val amd = adjustCellType(md)

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/TileLayerRDDBuilders.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/TileLayerRDDBuilders.scala
@@ -144,8 +144,7 @@ trait TileLayerRDDBuilders {
     val layoutScheme = FloatingLayoutScheme(tileLayout.tileCols, tileLayout.tileRows)
     val inputRdd = sc.parallelize(Seq((ProjectedExtent(raster.extent, crs), raster.tile)))
 
-    val (_, metadata) =
-      TileLayerMetadata.fromRdd(inputRdd, crs, layoutScheme)
+    val (_, metadata) = inputRdd.collectMetadata[SpatialKey](crs, layoutScheme)
 
     val tiled: RDD[(SpatialKey, Tile)] = inputRdd.cutTiles(metadata)
 
@@ -191,8 +190,7 @@ trait TileLayerRDDBuilders {
     val layoutScheme = FloatingLayoutScheme(tileLayout.tileCols, tileLayout.tileRows)
     val inputRdd = sc.parallelize(Seq((ProjectedExtent(raster.extent, crs), raster.tile)))
 
-    val (_, metadata) =
-      TileLayerMetadata.fromRdd(inputRdd, crs, layoutScheme)
+    val (_, metadata) = inputRdd.collectMetadata[SpatialKey](crs, layoutScheme)
 
     val tiled: RDD[(SpatialKey, MultibandTile)] = inputRdd.cutTiles(metadata)
 

--- a/spark/src/main/scala/geotrellis/spark/ingest/Ingest.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/Ingest.scala
@@ -70,7 +70,7 @@ object Ingest {
     )
     (sink: (TileLayerRDD[K], Int) => Unit): Unit =
   {
-    val (_, tileLayerMetadata) = TileLayerMetadata.fromRdd(sourceTiles, FloatingLayoutScheme(512))
+    val (_, tileLayerMetadata) = sourceTiles.collectMetadata(FloatingLayoutScheme(512))
     val tiledRdd = sourceTiles.tileToLayout(tileLayerMetadata, resampleMethod).cache()
 
     val contextRdd = new ContextRDD(tiledRdd, tileLayerMetadata)

--- a/spark/src/main/scala/geotrellis/spark/ingest/MultibandIngest.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/MultibandIngest.scala
@@ -27,7 +27,7 @@ object MultibandIngest {
     bufferSize: Option[Int] = None)
     (sink: (MultibandTileLayerRDD[K], Int) => Unit): Unit =
   {
-    val (_, tileLayerMetadata) = TileLayerMetadata.fromRdd(sourceTiles, layoutScheme)
+    val (_, tileLayerMetadata) = sourceTiles.collectMetadata(layoutScheme)
     val tiledRdd = sourceTiles.tileToLayout(tileLayerMetadata, resampleMethod).cache()
     val contextRdd = new ContextRDD(tiledRdd, tileLayerMetadata)
     val (zoom, tileLayerRdd) = bufferSize.fold(contextRdd.reproject(destCRS, layoutScheme))(contextRdd.reproject(destCRS, layoutScheme, _))

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -188,6 +188,11 @@ package object spark
       TileLayerMetadata.fromRdd[K1, V, K2](rdd, layoutScheme)
     }
 
+    def collectMetadata[K2: Boundable: SpatialComponent](crs: CRS, size: Int, zoom: Int)
+        (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): (Int, TileLayerMetadata[K2]) = {
+      TileLayerMetadata.fromRdd[K1, V, K2](rdd, ZoomedLayoutScheme(crs, size), zoom)
+    }
+
     def collectMetadata[K2: Boundable: SpatialComponent](layout: LayoutDefinition)
         (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): TileLayerMetadata[K2] = {
       TileLayerMetadata.fromRdd[K1, V, K2](rdd, layout)

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -107,16 +107,16 @@ object TileRDDReproject {
       targetLayout match {
         case Left(layoutScheme) =>
           // If it's a floating layout scheme, the cell grid will line up and we always want to use nearest neighbor resampling
-          val (z, m) = TileLayerMetadata.fromRdd(reprojectedTiles, destCrs, layoutScheme)
+          val (z, m) = reprojectedTiles.collectMetadata(destCrs, layoutScheme)
           layoutScheme match {
             case _: FloatingLayoutScheme =>
-              val (z, m) = TileLayerMetadata.fromRdd(reprojectedTiles, destCrs, layoutScheme)
+              val (z, m) = reprojectedTiles.collectMetadata(destCrs, layoutScheme)
               (z, m, NearestNeighbor)
             case _ =>
               (z, m, options.rasterReprojectOptions.method)
           }
         case Right(layoutDefinition) =>
-          val m = TileLayerMetadata.fromRdd(reprojectedTiles, destCrs, layoutDefinition)
+          val m = reprojectedTiles.collectMetadata(destCrs, layoutDefinition)
           (0, m, options.rasterReprojectOptions.method)
       }
 

--- a/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
@@ -124,7 +124,7 @@ class TileRDDReprojectSpec extends FunSpec with TestEnvironment {
       val cellSize = CellSize(0.083328250000000, 0.083328250000000)
       val re = RasterExtent(extent, cellSize)
 
-      val (_, md) = TileLayerMetadata.fromRdd(rdd, scheme)
+      val (_, md) = rdd.collectMetadata[SpatialKey](scheme)
       val tiled = ContextRDD(rdd.tileToLayout[SpatialKey](md, NearestNeighbor), md)
       val beforeMetadata = tiled.metadata
 


### PR DESCRIPTION
It turns out that the solution form #1405 was already present in the code.  All uses of `TileLayerMetadata.fromRdd` in the code and the markdown examples have been changed to use the `collectMetadata` methods.

Fixes #1405
