### PR TITLE
Ingest tiles without CRS in metadata

### DIFF
--- a/s3/src/main/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormat.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormat.scala
@@ -8,13 +8,14 @@ import org.apache.hadoop.mapreduce.{InputSplit, TaskAttemptContext}
 /** Read single band GeoTiff from S3 */
 class GeoTiffS3InputFormat extends S3InputFormat[ProjectedExtent, Tile] {
   def createRecordReader(split: InputSplit, context: TaskAttemptContext) =
-    new GeoTiffS3RecordReader
+    new GeoTiffS3RecordReader(context)
 }
 
-class GeoTiffS3RecordReader extends S3RecordReader[ProjectedExtent, Tile] {
+class GeoTiffS3RecordReader(context: TaskAttemptContext) extends S3RecordReader[ProjectedExtent, Tile] {
   def read(key: String, bytes: Array[Byte]) = {
     val geoTiff = SinglebandGeoTiff(bytes)
+    val inputCrs = TemporalGeoTiffS3InputFormat.getCrs(context)
     val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-    (ProjectedExtent(extent, crs), tile)
+    (ProjectedExtent(extent, inputCrs.fold(crs)(identity)), tile)
   }
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormat.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormat.scala
@@ -16,6 +16,6 @@ class GeoTiffS3RecordReader(context: TaskAttemptContext) extends S3RecordReader[
     val geoTiff = SinglebandGeoTiff(bytes)
     val inputCrs = TemporalGeoTiffS3InputFormat.getCrs(context)
     val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-    (ProjectedExtent(extent, inputCrs.fold(crs)(identity)), tile)
+    (ProjectedExtent(extent, inputCrs.getOrElse(crs)), tile)
   }
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/MultibandGeoTiffS3InputFormat.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/MultibandGeoTiffS3InputFormat.scala
@@ -12,7 +12,7 @@ class MultibandGeoTiffS3InputFormat extends S3InputFormat[ProjectedExtent, Multi
       def read(key: String, bytes: Array[Byte]) = {
         val geoTiff = MultibandGeoTiff(bytes)
         val inputCrs = TemporalGeoTiffS3InputFormat.getCrs(context)
-        val projectedExtent = ProjectedExtent(geoTiff.extent, inputCrs.fold(geoTiff.crs)(identity))
+        val projectedExtent = ProjectedExtent(geoTiff.extent, inputCrs.getOrElse(geoTiff.crs))
         (projectedExtent, geoTiff.tile)
       }
     }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/MultibandGeoTiffS3InputFormat.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/MultibandGeoTiffS3InputFormat.scala
@@ -11,7 +11,8 @@ class MultibandGeoTiffS3InputFormat extends S3InputFormat[ProjectedExtent, Multi
     new S3RecordReader[ProjectedExtent, MultibandTile] {
       def read(key: String, bytes: Array[Byte]) = {
         val geoTiff = MultibandGeoTiff(bytes)
-        val projectedExtent = ProjectedExtent(geoTiff.extent, geoTiff.crs)
+        val inputCrs = TemporalGeoTiffS3InputFormat.getCrs(context)
+        val projectedExtent = ProjectedExtent(geoTiff.extent, inputCrs.fold(geoTiff.crs)(identity))
         (projectedExtent, geoTiff.tile)
       }
     }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormat.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormat.scala
@@ -69,6 +69,6 @@ class TemporalGeoTiffS3RecordReader(context: TaskAttemptContext) extends S3Recor
 
     //WARNING: Assuming this is a single band GeoTiff
     val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-    (TemporalProjectedExtent(extent, inputCrs.fold(crs)(identity), dateTime), tile)
+    (TemporalProjectedExtent(extent, inputCrs.getOrElse(crs), dateTime), tile)
   }
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormat.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/TemporalGeoTiffS3InputFormat.scala
@@ -3,16 +3,18 @@ package geotrellis.spark.io.s3
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff._
 import geotrellis.spark._
+import geotrellis.proj4.CRS
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce._
-
 import java.time.{ZoneOffset, ZonedDateTime}
 import java.time.format.DateTimeFormatter
+
 
 object TemporalGeoTiffS3InputFormat {
   final val GEOTIFF_TIME_TAG = "GEOTIFF_TIME_TAG"
   final val GEOTIFF_TIME_FORMAT = "GEOTIFF_TIME_FORMAT"
+  final val GEOTIFF_CRS = "GEOTIFF_CRS"
 
   def setTimeTag(job: JobContext, timeTag: String): Unit =
     setTimeTag(job.getConfiguration, timeTag)
@@ -26,6 +28,8 @@ object TemporalGeoTiffS3InputFormat {
   def setTimeFormat(conf: Configuration, timeFormat: String): Unit =
     conf.set(GEOTIFF_TIME_FORMAT, timeFormat)
 
+  def setCrs(conf: Configuration, name: String): Unit = conf.set(GEOTIFF_CRS, name)
+
   def getTimeTag(job: JobContext) =
     job.getConfiguration.get(GEOTIFF_TIME_TAG, "TIFFTAG_DATETIME")
 
@@ -33,6 +37,11 @@ object TemporalGeoTiffS3InputFormat {
     val df = job.getConfiguration.get(GEOTIFF_TIME_FORMAT)
     (if (df == null) { DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss") }
     else { DateTimeFormatter.ofPattern(df) }).withZone(ZoneOffset.UTC)
+  }
+
+  def getCrs(job: JobContext): Option[CRS] = {
+    val name = job.getConfiguration.get(GEOTIFF_CRS, "")
+    if(name == "") None else Some(CRS.fromName(name))
   }
 }
 
@@ -56,9 +65,10 @@ class TemporalGeoTiffS3RecordReader(context: TaskAttemptContext) extends S3Recor
 
     val dateTimeString = geoTiff.tags.headTags.getOrElse(timeTag, sys.error(s"There is no tag $timeTag in the GeoTiff header"))
     val dateTime = ZonedDateTime.from(dateFormatter.parse(dateTimeString))
+    val inputCrs = TemporalGeoTiffS3InputFormat.getCrs(context)
 
     //WARNING: Assuming this is a single band GeoTiff
     val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-    (TemporalProjectedExtent(extent, crs, dateTime), tile)
+    (TemporalProjectedExtent(extent, inputCrs.fold(crs)(identity), dateTime), tile)
   }
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/TemporalMultibandGeoTiffS3InputFormat.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/TemporalMultibandGeoTiffS3InputFormat.scala
@@ -21,12 +21,13 @@ class TemporalMultibandGeoTiffS3InputFormat extends S3InputFormat[TemporalProjec
 
         val timeTag = TemporalGeoTiffS3InputFormat.getTimeTag(context)
         val dateFormatter = TemporalGeoTiffS3InputFormat.getTimeFormatter(context)
+        val inputCrs = TemporalGeoTiffS3InputFormat.getCrs(context)
 
         val dateTimeString = geoTiff.tags.headTags.getOrElse(timeTag, sys.error(s"There is no tag $timeTag in the GeoTiff header"))
         val dateTime = ZonedDateTime.parse(dateTimeString, dateFormatter)
 
         val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-        (TemporalProjectedExtent(extent, crs, dateTime), tile)
+        (TemporalProjectedExtent(extent, inputCrs.fold(crs)(identity), dateTime), tile)
       }
     }
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/TemporalMultibandGeoTiffS3InputFormat.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/TemporalMultibandGeoTiffS3InputFormat.scala
@@ -27,7 +27,7 @@ class TemporalMultibandGeoTiffS3InputFormat extends S3InputFormat[TemporalProjec
         val dateTime = ZonedDateTime.parse(dateTimeString, dateFormatter)
 
         val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-        (TemporalProjectedExtent(extent, inputCrs.fold(crs)(identity), dateTime), tile)
+        (TemporalProjectedExtent(extent, inputCrs.getOrElse(crs), dateTime), tile)
       }
     }
 }

--- a/s3/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
@@ -13,10 +13,10 @@ import org.scalatest._
 class MockGeoTiffS3InputFormat extends GeoTiffS3InputFormat {
   override def getS3Client(credentials: AWSCredentials): S3Client = new MockS3Client
   override def createRecordReader(split: InputSplit, context: TaskAttemptContext) =
-    new MockGeoTiffS3RecordReader
+    new MockGeoTiffS3RecordReader(context)
 }
 
-class MockGeoTiffS3RecordReader extends GeoTiffS3RecordReader {
+class MockGeoTiffS3RecordReader(context: TaskAttemptContext) extends GeoTiffS3RecordReader(context) {
   override def getS3Client(credentials: AWSCredentials): S3Client = new MockS3Client
 }
 

--- a/spark-etl/src/main/resources/input-schema.json
+++ b/spark-etl/src/main/resources/input-schema.json
@@ -11,6 +11,9 @@
     "cache": {
       "type": "string"
     },
+    "crs": {
+      "type": "string"
+    },
     "noData": {
       "type": "integer"
     },

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/Input.scala
@@ -1,6 +1,8 @@
 package geotrellis.spark.etl.config
 
+import geotrellis.proj4.CRS
 import geotrellis.vector.Extent
+
 import org.apache.spark.storage.StorageLevel
 
 case class Input(
@@ -9,5 +11,8 @@ case class Input(
   backend: Backend,
   cache: Option[StorageLevel] = None,
   noData: Option[Double] = None,
-  clip: Option[Extent] = None
-) extends Serializable
+  clip: Option[Extent] = None,
+  crs: Option[String] = None
+) extends Serializable {
+  def getCrs = crs.map(CRS.fromName)
+}

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/json/ConfigFormats.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/json/ConfigFormats.scala
@@ -200,7 +200,8 @@ trait ConfigFormats {
       "backend" -> bf.write(i.backend),
       "cache"   -> i.cache.toJson,
       "noData"  -> i.noData.toJson,
-      "clip"    -> i.clip.toJson
+      "clip"    -> i.clip.toJson,
+      "input"   -> i.crs.toJson
     )
     def read(value: JsValue): Input =
       value match {
@@ -211,7 +212,8 @@ trait ConfigFormats {
             backend = bf.read(fields("backend")),
             cache   = fields.get("cache").map(_.convertTo[StorageLevel]),
             noData  = fields.get("noData").map(_.convertTo[Double]),
-            clip    = fields.get("clip").map(_.convertTo[Extent])
+            clip    = fields.get("clip").map(_.convertTo[Extent]),
+            crs     = fields.get("crs").map(_.convertTo[String])
           )
         case _ =>
           throw new DeserializationException("Input must be a valid json object.")

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/json/ConfigFormats.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/json/ConfigFormats.scala
@@ -201,7 +201,7 @@ trait ConfigFormats {
       "cache"   -> i.cache.toJson,
       "noData"  -> i.noData.toJson,
       "clip"    -> i.clip.toJson,
-      "input"   -> i.crs.toJson
+      "crs"   -> i.crs.toJson
     )
     def read(value: JsValue): Input =
       value match {

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffHadoopInput.scala
@@ -13,6 +13,6 @@ import org.apache.spark.rdd.RDD
 
 class GeoTiffHadoopInput extends HadoopInput[ProjectedExtent, Tile]() {
   val format = "geotiff"
-  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] = sc.hadoopGeoTiffRDD(getPath(conf.input.backend).path)
+  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] = sc.hadoopGeoTiffRDD(getPath(conf.input.backend).path, sc.defaultTiffExtensions, conf.input.crs.fold("")(identity))
 }
 

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffHadoopInput.scala
@@ -13,6 +13,6 @@ import org.apache.spark.rdd.RDD
 
 class GeoTiffHadoopInput extends HadoopInput[ProjectedExtent, Tile]() {
   val format = "geotiff"
-  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] = sc.hadoopGeoTiffRDD(getPath(conf.input.backend).path, sc.defaultTiffExtensions, conf.input.crs.fold("")(identity))
+  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] = sc.hadoopGeoTiffRDD(getPath(conf.input.backend).path, sc.defaultTiffExtensions, conf.input.crs.getOrElse(""))
 }
 

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffSequenceHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffSequenceHadoopInput.scala
@@ -12,12 +12,14 @@ import org.apache.spark.rdd.RDD
 
 class GeoTiffSequenceHadoopInput extends HadoopInput[ProjectedExtent, Tile] {
   val format = "geotiff-sequence"
-  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] =
+  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] = {
+    val inputCrs = conf.input.getCrs
     sc
       .sequenceFile[String, Array[Byte]](getPath(conf.input.backend).path)
       .map { case (path, bytes) =>
         val geotiff = GeoTiffReader.readSingleband(bytes)
-        (ProjectedExtent(geotiff.extent, geotiff.crs), geotiff.tile)
+        (ProjectedExtent(geotiff.extent, inputCrs.fold(geotiff.crs)(identity)), geotiff.tile)
       }
+  }
 }
 

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffSequenceHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffSequenceHadoopInput.scala
@@ -18,7 +18,7 @@ class GeoTiffSequenceHadoopInput extends HadoopInput[ProjectedExtent, Tile] {
       .sequenceFile[String, Array[Byte]](getPath(conf.input.backend).path)
       .map { case (path, bytes) =>
         val geotiff = GeoTiffReader.readSingleband(bytes)
-        (ProjectedExtent(geotiff.extent, inputCrs.fold(geotiff.crs)(identity)), geotiff.tile)
+        (ProjectedExtent(geotiff.extent, inputCrs.getOrElse(geotiff.crs)), geotiff.tile)
       }
   }
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffHadoopInput.scala
@@ -11,5 +11,5 @@ import org.apache.spark.rdd.RDD
 class MultibandGeoTiffHadoopInput extends HadoopInput[ProjectedExtent, MultibandTile] {
   val format = "multiband-geotiff"
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] =
-    sc.hadoopMultibandGeoTiffRDD(getPath(conf.input.backend).path)
+    sc.hadoopMultibandGeoTiffRDD(getPath(conf.input.backend).path, sc.defaultTiffExtensions, conf.input.crs.fold("")(identity))
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffHadoopInput.scala
@@ -11,5 +11,5 @@ import org.apache.spark.rdd.RDD
 class MultibandGeoTiffHadoopInput extends HadoopInput[ProjectedExtent, MultibandTile] {
   val format = "multiband-geotiff"
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] =
-    sc.hadoopMultibandGeoTiffRDD(getPath(conf.input.backend).path, sc.defaultTiffExtensions, conf.input.crs.fold("")(identity))
+    sc.hadoopMultibandGeoTiffRDD(getPath(conf.input.backend).path, sc.defaultTiffExtensions, conf.input.crs.getOrElse(""))
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffSequenceHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffSequenceHadoopInput.scala
@@ -10,11 +10,13 @@ import org.apache.spark.rdd.RDD
 
 class MultibandGeoTiffSequenceHadoopInput extends HadoopInput[ProjectedExtent, MultibandTile] {
   val format = "multiband-geotiff-sequence"
-  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] =
+  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] = {
+    val inputCrs = conf.input.getCrs
     sc
       .sequenceFile[String, Array[Byte]](getPath(conf.input.backend).path)
       .map { case (path, bytes) =>
         val geotiff = GeoTiffReader.readMultiband(bytes)
-        (ProjectedExtent(geotiff.extent, geotiff.crs), geotiff.tile)
+        (ProjectedExtent(geotiff.extent, inputCrs.fold(geotiff.crs)(identity)), geotiff.tile)
       }
+  }
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffSequenceHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffSequenceHadoopInput.scala
@@ -16,7 +16,7 @@ class MultibandGeoTiffSequenceHadoopInput extends HadoopInput[ProjectedExtent, M
       .sequenceFile[String, Array[Byte]](getPath(conf.input.backend).path)
       .map { case (path, bytes) =>
         val geotiff = GeoTiffReader.readMultiband(bytes)
-        (ProjectedExtent(geotiff.extent, inputCrs.fold(geotiff.crs)(identity)), geotiff.tile)
+        (ProjectedExtent(geotiff.extent, inputCrs.getOrElse(geotiff.crs)), geotiff.tile)
       }
   }
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalGeoTiffHadoopInput.scala
@@ -15,6 +15,7 @@ class TemporalGeoTiffHadoopInput extends HadoopInput[TemporalProjectedExtent, Ti
     sc.hadoopTemporalGeoTiffRDD(
       path       = getPath(conf.input.backend).path,
       timeTag    = conf.output.keyIndexMethod.timeTag.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_TAG_DEFAULT),
-      timeFormat = conf.output.keyIndexMethod.timeFormat.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT)
+      timeFormat = conf.output.keyIndexMethod.timeFormat.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT),
+      crs        = conf.input.crs.fold("")(identity)
     )
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalGeoTiffHadoopInput.scala
@@ -16,6 +16,6 @@ class TemporalGeoTiffHadoopInput extends HadoopInput[TemporalProjectedExtent, Ti
       path       = getPath(conf.input.backend).path,
       timeTag    = conf.output.keyIndexMethod.timeTag.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_TAG_DEFAULT),
       timeFormat = conf.output.keyIndexMethod.timeFormat.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT),
-      crs        = conf.input.crs.fold("")(identity)
+      crs        = conf.input.crs.getOrElse("")
     )
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalMultibandGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalMultibandGeoTiffHadoopInput.scala
@@ -17,7 +17,7 @@ class TemporalMultibandGeoTiffHadoopInput extends HadoopInput[TemporalProjectedE
       path       = getPath(conf.input.backend).path,
       timeTag    = conf.output.keyIndexMethod.timeTag.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_TAG_DEFAULT),
       timeFormat = conf.output.keyIndexMethod.timeFormat.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT),
-      crs        = conf.input.crs.fold("")(identity)
+      crs        = conf.input.crs.getOrElse("")
     )
 }
 

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalMultibandGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalMultibandGeoTiffHadoopInput.scala
@@ -16,7 +16,8 @@ class TemporalMultibandGeoTiffHadoopInput extends HadoopInput[TemporalProjectedE
     sc.hadoopTemporalMultibandGeoTiffRDD(
       path       = getPath(conf.input.backend).path,
       timeTag    = conf.output.keyIndexMethod.timeTag.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_TAG_DEFAULT),
-      timeFormat = conf.output.keyIndexMethod.timeFormat.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT)
+      timeFormat = conf.output.keyIndexMethod.timeFormat.getOrElse(TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT),
+      crs        = conf.input.crs.fold("")(identity)
     )
 }
 

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/s3/GeoTiffS3Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/s3/GeoTiffS3Input.scala
@@ -3,7 +3,7 @@ package geotrellis.spark.etl.s3
 import geotrellis.raster.Tile
 import geotrellis.spark.etl.config.EtlConf
 import geotrellis.spark.ingest._
-import geotrellis.spark.io.s3.GeoTiffS3InputFormat
+import geotrellis.spark.io.s3.{GeoTiffS3InputFormat, TemporalGeoTiffS3InputFormat}
 import geotrellis.vector.ProjectedExtent
 
 import org.apache.spark.SparkContext
@@ -11,7 +11,10 @@ import org.apache.spark.rdd.RDD
 
 class GeoTiffS3Input extends S3Input[ProjectedExtent, Tile] {
   val format = "geotiff"
-  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] =
-    sc.newAPIHadoopRDD(configuration(conf.input), classOf[GeoTiffS3InputFormat], classOf[ProjectedExtent], classOf[Tile])
+  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] = {
+    val hadoopConfig = configuration(conf.input)
+    conf.input.crs.foreach(TemporalGeoTiffS3InputFormat.setCrs(hadoopConfig, _))
+    sc.newAPIHadoopRDD(hadoopConfig, classOf[GeoTiffS3InputFormat], classOf[ProjectedExtent], classOf[Tile])
+  }
 }
 

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/s3/MultibandGeoTiffS3Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/s3/MultibandGeoTiffS3Input.scala
@@ -2,7 +2,7 @@ package geotrellis.spark.etl.s3
 
 import geotrellis.raster.MultibandTile
 import geotrellis.spark.etl.config.EtlConf
-import geotrellis.spark.io.s3.MultibandGeoTiffS3InputFormat
+import geotrellis.spark.io.s3.{MultibandGeoTiffS3InputFormat, TemporalGeoTiffS3InputFormat}
 import geotrellis.vector.ProjectedExtent
 
 import org.apache.spark.SparkContext
@@ -10,8 +10,11 @@ import org.apache.spark.rdd.RDD
 
 class MultibandGeoTiffS3Input extends S3Input[ProjectedExtent, MultibandTile] {
   val format = "multiband-geotiff"
-  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] =
+  def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] = {
+    val hadoopConfig = configuration(conf.input)
+    conf.input.crs.foreach(TemporalGeoTiffS3InputFormat.setCrs(hadoopConfig, _))
     sc.newAPIHadoopRDD(
-      configuration(conf.input), classOf[MultibandGeoTiffS3InputFormat], classOf[ProjectedExtent], classOf[MultibandTile]
+      hadoopConfig, classOf[MultibandGeoTiffS3InputFormat], classOf[ProjectedExtent], classOf[MultibandTile]
     )
+  }
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/s3/TemporalGeoTiffS3Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/s3/TemporalGeoTiffS3Input.scala
@@ -12,8 +12,10 @@ import org.apache.spark.rdd.RDD
 class TemporalGeoTiffS3Input extends S3Input[TemporalProjectedExtent, Tile] {
   val format = "temporal-geotiff"
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, Tile)] = {
-    conf.output.keyIndexMethod.timeTag.foreach(TemporalGeoTiffS3InputFormat.setTimeTag(sc.hadoopConfiguration, _))
-    conf.output.keyIndexMethod.timeFormat.foreach(TemporalGeoTiffS3InputFormat.setTimeFormat(sc.hadoopConfiguration, _))
-    sc.newAPIHadoopRDD(configuration(conf.input), classOf[TemporalGeoTiffS3InputFormat], classOf[TemporalProjectedExtent], classOf[Tile])
+    val hadoopConfig = configuration(conf.input)
+    conf.output.keyIndexMethod.timeTag.foreach(TemporalGeoTiffS3InputFormat.setTimeTag(hadoopConfig, _))
+    conf.output.keyIndexMethod.timeFormat.foreach(TemporalGeoTiffS3InputFormat.setTimeFormat(hadoopConfig, _))
+    conf.input.crs.foreach(TemporalGeoTiffS3InputFormat.setCrs(hadoopConfig, _))
+    sc.newAPIHadoopRDD(hadoopConfig, classOf[TemporalGeoTiffS3InputFormat], classOf[TemporalProjectedExtent], classOf[Tile])
   }
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/s3/TemporalMultibandGeoTiffS3Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/s3/TemporalMultibandGeoTiffS3Input.scala
@@ -11,8 +11,10 @@ import org.apache.spark.rdd.RDD
 class TemporalMultibandGeoTiffS3Input extends S3Input[TemporalProjectedExtent, MultibandTile] {
   val format = "temporal-geotiff"
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, MultibandTile)] = {
-    conf.output.keyIndexMethod.timeTag.foreach(TemporalGeoTiffS3InputFormat.setTimeTag(sc.hadoopConfiguration, _))
-    conf.output.keyIndexMethod.timeFormat.foreach(TemporalGeoTiffS3InputFormat.setTimeFormat(sc.hadoopConfiguration, _))
-    sc.newAPIHadoopRDD(configuration(conf.input), classOf[TemporalMultibandGeoTiffS3InputFormat], classOf[TemporalProjectedExtent], classOf[MultibandTile])
+    val hadoopConfig = configuration(conf.input)
+    conf.output.keyIndexMethod.timeTag.foreach(TemporalGeoTiffS3InputFormat.setTimeTag(hadoopConfig, _))
+    conf.output.keyIndexMethod.timeFormat.foreach(TemporalGeoTiffS3InputFormat.setTimeFormat(hadoopConfig, _))
+    conf.input.crs.foreach(TemporalGeoTiffS3InputFormat.setCrs(hadoopConfig, _))
+    sc.newAPIHadoopRDD(hadoopConfig, classOf[TemporalMultibandGeoTiffS3InputFormat], classOf[TemporalProjectedExtent], classOf[MultibandTile])
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopSparkContextMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopSparkContextMethods.scala
@@ -21,7 +21,7 @@ trait HadoopSparkContextMethods {
   def hadoopGeoTiffRDD(path: String, tiffExtension: String): RDD[(ProjectedExtent, Tile)] =
     hadoopGeoTiffRDD(new Path(path), Seq(tiffExtension))
 
-  def hadoopGeoTiffRDD(path: String, tiffExtensions: Seq[String] ): RDD[(ProjectedExtent, Tile)] =
+  def hadoopGeoTiffRDD(path: String, tiffExtensions: Seq[String]): RDD[(ProjectedExtent, Tile)] =
     hadoopGeoTiffRDD(new Path(path), tiffExtensions)
 
   def hadoopGeoTiffRDD(path: Path): RDD[(ProjectedExtent, Tile)] =
@@ -30,13 +30,16 @@ trait HadoopSparkContextMethods {
   def hadoopGeoTiffRDD(path: Path, tiffExtension: String): RDD[(ProjectedExtent, Tile)] =
     hadoopGeoTiffRDD(path, Seq(tiffExtension))
 
-  def hadoopGeoTiffRDD(path: Path, tiffExtensions: Seq[String]): RDD[(ProjectedExtent, Tile)] =
+  def hadoopGeoTiffRDD(path: Path, tiffExtensions: Seq[String], crs: String = ""): RDD[(ProjectedExtent, Tile)] = {
+    val conf = sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions)
+    TemporalGeoTiffInputFormat.setCrs(conf, crs)
     sc.newAPIHadoopRDD(
-      sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions),
+      conf,
       classOf[GeotiffInputFormat],
       classOf[ProjectedExtent],
       classOf[Tile]
     )
+  }
 
   def hadoopTemporalGeoTiffRDD(path: String): RDD[(TemporalProjectedExtent, Tile)] =
     hadoopTemporalGeoTiffRDD(new Path(path), defaultTiffExtensions)
@@ -57,11 +60,13 @@ trait HadoopSparkContextMethods {
     path: Path,
     tiffExtensions: Seq[String] = defaultTiffExtensions,
     timeTag: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_TAG_DEFAULT,
-    timeFormat: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT
+    timeFormat: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT,
+    crs: String = ""
   ): RDD[(TemporalProjectedExtent, Tile)] = {
     val conf = sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions)
     TemporalGeoTiffInputFormat.setTimeTag(conf, timeTag)
     TemporalGeoTiffInputFormat.setTimeFormat(conf, timeFormat)
+    TemporalGeoTiffInputFormat.setCrs(conf, crs)
     sc.newAPIHadoopRDD(
       conf,
       classOf[TemporalGeoTiffInputFormat],
@@ -79,13 +84,16 @@ trait HadoopSparkContextMethods {
   def hadoopMultibandGeoTiffRDD(path: String, tiffExtensions: Seq[String]): RDD[(ProjectedExtent, MultibandTile)] =
     hadoopMultibandGeoTiffRDD(new Path(path), tiffExtensions)
 
-  def hadoopMultibandGeoTiffRDD(path: Path, tiffExtensions: Seq[String] = defaultTiffExtensions): RDD[(ProjectedExtent, MultibandTile)] =
+  def hadoopMultibandGeoTiffRDD(path: Path, tiffExtensions: Seq[String] = defaultTiffExtensions, crs: String = ""): RDD[(ProjectedExtent, MultibandTile)] = {
+    val conf = sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions)
+    TemporalGeoTiffInputFormat.setCrs(conf, crs)
     sc.newAPIHadoopRDD(
-      sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions),
+      conf,
       classOf[MultibandGeoTiffInputFormat],
       classOf[ProjectedExtent],
       classOf[MultibandTile]
     )
+  }
 
   def hadoopTemporalMultibandGeoTiffRDD(path: String): RDD[(TemporalProjectedExtent, MultibandTile)] =
     hadoopTemporalMultibandGeoTiffRDD(new Path(path), defaultTiffExtensions)
@@ -100,11 +108,13 @@ trait HadoopSparkContextMethods {
     path: Path,
     tiffExtensions: Seq[String] = defaultTiffExtensions,
     timeTag: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_TAG_DEFAULT,
-    timeFormat: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT
+    timeFormat: String = TemporalGeoTiffInputFormat.GEOTIFF_TIME_FORMAT_DEFAULT,
+    crs: String = ""
   ): RDD[(TemporalProjectedExtent, MultibandTile)] = {
     val conf = sc.hadoopConfiguration.withInputDirectory(path, tiffExtensions)
     TemporalGeoTiffInputFormat.setTimeTag(conf, timeTag)
     TemporalGeoTiffInputFormat.setTimeFormat(conf, timeFormat)
+    TemporalGeoTiffInputFormat.setCrs(conf, crs)
     sc.newAPIHadoopRDD(
       conf,
       classOf[TemporalMultibandGeoTiffInputFormat],

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/GeotiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/GeotiffInputFormat.scala
@@ -25,7 +25,9 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext
 
 class GeotiffInputFormat extends BinaryFileInputFormat[ProjectedExtent, Tile] {
   def read(bytes: Array[Byte], context: TaskAttemptContext): (ProjectedExtent, Tile) = {
+    val inputCrs = TemporalGeoTiffInputFormat.getCrs(context)
+
     val ProjectedRaster(Raster(tile, extent), crs) = SinglebandGeoTiff(bytes).projectedRaster
-    (ProjectedExtent(extent, crs), tile)
+    (ProjectedExtent(extent, inputCrs.fold(crs)(identity)), tile)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/GeotiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/GeotiffInputFormat.scala
@@ -28,6 +28,6 @@ class GeotiffInputFormat extends BinaryFileInputFormat[ProjectedExtent, Tile] {
     val inputCrs = TemporalGeoTiffInputFormat.getCrs(context)
 
     val ProjectedRaster(Raster(tile, extent), crs) = SinglebandGeoTiff(bytes).projectedRaster
-    (ProjectedExtent(extent, inputCrs.fold(crs)(identity)), tile)
+    (ProjectedExtent(extent, inputCrs.getOrElse(crs)), tile)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/MultibandGeoTiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/MultibandGeoTiffInputFormat.scala
@@ -9,7 +9,8 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext
 
 class MultibandGeoTiffInputFormat extends BinaryFileInputFormat[ProjectedExtent, MultibandTile] {
   def read(bytes: Array[Byte], context: TaskAttemptContext): (ProjectedExtent, MultibandTile) = {
+    val inputCrs = TemporalGeoTiffInputFormat.getCrs(context)
     val gt = MultibandGeoTiff(bytes)
-    (ProjectedExtent(gt.extent, gt.crs), gt.tile)
+    (ProjectedExtent(gt.extent, inputCrs.fold(gt.crs)(identity)), gt.tile)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/MultibandGeoTiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/MultibandGeoTiffInputFormat.scala
@@ -11,6 +11,6 @@ class MultibandGeoTiffInputFormat extends BinaryFileInputFormat[ProjectedExtent,
   def read(bytes: Array[Byte], context: TaskAttemptContext): (ProjectedExtent, MultibandTile) = {
     val inputCrs = TemporalGeoTiffInputFormat.getCrs(context)
     val gt = MultibandGeoTiff(bytes)
-    (ProjectedExtent(gt.extent, inputCrs.fold(gt.crs)(identity)), gt.tile)
+    (ProjectedExtent(gt.extent, inputCrs.getOrElse(gt.crs)), gt.tile)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalGeoTiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalGeoTiffInputFormat.scala
@@ -68,6 +68,6 @@ class TemporalGeoTiffInputFormat extends BinaryFileInputFormat[TemporalProjected
     val dateTime = ZonedDateTime.from(dateFormatter.parse(dateTimeString))
 
     val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-    (TemporalProjectedExtent(extent, inputCrs.fold(crs)(identity), dateTime), tile)
+    (TemporalProjectedExtent(extent, inputCrs.getOrElse(crs), dateTime), tile)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalGeoTiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalGeoTiffInputFormat.scala
@@ -8,6 +8,8 @@ import geotrellis.spark.ingest._
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff._
 import geotrellis.vector._
+import geotrellis.proj4.CRS
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce._
 import java.time.{ZoneOffset, ZonedDateTime}
@@ -16,6 +18,7 @@ object TemporalGeoTiffInputFormat {
   final val GEOTIFF_TIME_TAG = "GEOTIFF_TIME_TAG"
   final val GEOTIFF_TIME_TAG_DEFAULT = "TIFFTAG_DATETIME"
   final val GEOTIFF_TIME_FORMAT = "GEOTIFF_TIME_FORMAT"
+  final val GEOTIFF_CRS = "GEOTIFF_CRS"
   final val GEOTIFF_TIME_FORMAT_DEFAULT = "yyyy:MM:dd HH:mm:ss"
 
   def setTimeTag(job: JobContext, timeTag: String): Unit =
@@ -30,13 +33,20 @@ object TemporalGeoTiffInputFormat {
   def setTimeFormat(conf: Configuration, timeFormat: String): Unit =
     conf.set(GEOTIFF_TIME_FORMAT, timeFormat)
 
+  def setCrs(conf: Configuration, name: String): Unit = conf.set(GEOTIFF_CRS, name)
+
   def getTimeTag(job: JobContext) =
-    job.getConfiguration.get(GEOTIFF_TIME_TAG, GEOTIFF_TIME_TAG_DEFAULT )
+    job.getConfiguration.get(GEOTIFF_TIME_TAG, GEOTIFF_TIME_TAG_DEFAULT)
 
   def getTimeFormatter(job: JobContext): DateTimeFormatter = {
     val df = job.getConfiguration.get(GEOTIFF_TIME_FORMAT)
     (if(df == null) { DateTimeFormatter.ofPattern(GEOTIFF_TIME_FORMAT_DEFAULT) }
     else { DateTimeFormatter.ofPattern(df) }).withZone(ZoneOffset.UTC)
+  }
+
+  def getCrs(job: JobContext): Option[CRS] = {
+    val name = job.getConfiguration.get(GEOTIFF_CRS, "")
+    if(name == "") None else Some(CRS.fromName(name))
   }
 }
 
@@ -52,11 +62,12 @@ class TemporalGeoTiffInputFormat extends BinaryFileInputFormat[TemporalProjected
 
     val timeTag = TemporalGeoTiffInputFormat.getTimeTag(context)
     val dateFormatter = TemporalGeoTiffInputFormat.getTimeFormatter(context)
+    val inputCrs = TemporalGeoTiffInputFormat.getCrs(context)
 
     val dateTimeString = geoTiff.tags.headTags.getOrElse(timeTag, sys.error(s"There is no tag $timeTag in the GeoTiff header"))
     val dateTime = ZonedDateTime.from(dateFormatter.parse(dateTimeString))
 
     val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-    (TemporalProjectedExtent(extent, crs, dateTime), tile)
+    (TemporalProjectedExtent(extent, inputCrs.fold(crs)(identity), dateTime), tile)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalMultibandGeoTiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalMultibandGeoTiffInputFormat.scala
@@ -28,6 +28,6 @@ class TemporalMultibandGeoTiffInputFormat extends BinaryFileInputFormat[Temporal
     val dateTime = ZonedDateTime.from(dateFormatter.parse(dateTimeString))
 
     val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-    (TemporalProjectedExtent(extent, inputCrs.fold(crs)(identity), dateTime), tile)
+    (TemporalProjectedExtent(extent, inputCrs.getOrElse(crs), dateTime), tile)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalMultibandGeoTiffInputFormat.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/formats/TemporalMultibandGeoTiffInputFormat.scala
@@ -22,11 +22,12 @@ class TemporalMultibandGeoTiffInputFormat extends BinaryFileInputFormat[Temporal
 
     val timeTag = TemporalGeoTiffInputFormat.getTimeTag(context)
     val dateFormatter = TemporalGeoTiffInputFormat.getTimeFormatter(context)
+    val inputCrs = TemporalGeoTiffInputFormat.getCrs(context)
 
     val dateTimeString = geoTiff.tags.headTags.getOrElse(timeTag, sys.error(s"There is no tag $timeTag in the GeoTiff header"))
     val dateTime = ZonedDateTime.from(dateFormatter.parse(dateTimeString))
 
     val ProjectedRaster(Raster(tile, extent), crs) = geoTiff.projectedRaster
-    (TemporalProjectedExtent(extent, crs, dateTime), tile)
+    (TemporalProjectedExtent(extent, inputCrs.fold(crs)(identity), dateTime), tile)
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/ingest/IngestSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/ingest/IngestSpec.scala
@@ -13,6 +13,11 @@ class IngestSpec extends FunSpec
   with Matchers
   with TestEnvironment {
   describe("Ingest") {
+    it("should read GeoTiff with overrided input CRS") {
+      val source = sc.hadoopGeoTiffRDD(new Path(inputHome, "all-ones.tif"), sc.defaultTiffExtensions, crs = "EPSG:3857")
+      source.take(1).toList.map { case (k, _) => k.crs.proj4jCrs.getName }.head shouldEqual "EPSG:3857"
+    }
+
     it("should ingest GeoTiff") {
       val source = sc.hadoopGeoTiffRDD(new Path(inputHome, "all-ones.tif"))
       Ingest[ProjectedExtent, SpatialKey](source, LatLng, ZoomedLayoutScheme(LatLng, 512)) { (rdd, zoom) =>


### PR DESCRIPTION
Fixes https://github.com/geotrellis/geotrellis/issues/1414

Double checked that we can read tiffs without crs (crs would be set to `LatLng`), added additional setting `inputCrs` for `S3` and `Hadoop` `InputFormats`.