### PR TITLE
Add support for 3d points in GeoJson

### DIFF
--- a/vector-test/src/test/scala/spec/geotrellis/vector/io/json/GeometryFormatsSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/io/json/GeometryFormatsSpec.scala
@@ -36,6 +36,19 @@ class GeometryFormatsSpec extends FlatSpec with Matchers with GeoJsonSupport {
     body.convertTo[MultiPoint] should equal (mp)
   }
 
+  it should "handle 3d points by discarding the z-coordinate" in {
+    val mp =
+      MultiPoint(List(Point(0,0), Point(0,1)))
+
+    val body =
+      """{
+        |  "type": "MultiPoint",
+        |  "coordinates": [[0.0, 0.0, 3.0], [0.0, 1.0, 4.0]]
+        |}""".stripMargin.parseJson
+
+    body.convertTo[MultiPoint] should equal (mp)
+  }
+
   it should "know about Lines" in {
     val body =
       """{

--- a/vector-test/src/test/scala/spec/geotrellis/vector/io/json/GeometryFormatsSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/io/json/GeometryFormatsSpec.scala
@@ -39,14 +39,22 @@ class GeometryFormatsSpec extends FlatSpec with Matchers with GeoJsonSupport {
   it should "handle 3d points by discarding the z-coordinate" in {
     val mp =
       MultiPoint(List(Point(0,0), Point(0,1)))
-
-    val body =
+    val mpGJ =
       """{
         |  "type": "MultiPoint",
         |  "coordinates": [[0.0, 0.0, 3.0], [0.0, 1.0, 4.0]]
         |}""".stripMargin.parseJson
 
-    body.convertTo[MultiPoint] should equal (mp)
+    val ml =
+      MultiLine(Line(Point(0,0), Point(0,1)) :: Line(Point(1,0), Point(1,1)) :: Nil)
+    val mlGJ =
+      """{
+        |  "type": "MultiLineString",
+        |  "coordinates": [[[0.0, 0.0, 1.0], [0.0, 1.0, 0.0]], [[1.0, 0.0, 2.0], [1.0, 1.0, -1.0]]]
+        |}""".stripMargin.parseJson
+
+    mlGJ.convertTo[MultiLine] should equal (ml)
+    mpGJ.convertTo[MultiPoint] should equal (mp)
   }
 
   it should "know about Lines" in {

--- a/vector/src/main/scala/geotrellis/vector/io/json/GeometryFormats.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/GeometryFormats.scala
@@ -26,7 +26,9 @@ trait GeometryFormats {
       arr.elements match {
         case Seq(JsNumber(x), JsNumber(y)) =>
           Point(x.toDouble, y.toDouble)
-        case _ => throw new DeserializationException("Point [x,y] coordinates expected")
+        case Seq(JsNumber(x), JsNumber(y), _) =>
+          Point(x.toDouble, y.toDouble)
+        case _ => throw new DeserializationException("Point [x,y] or [x,y,_] coordinates expected")
       }
     case _ => throw new DeserializationException("Point [x,y] coordinates expected")
   }


### PR DESCRIPTION
This PR allows GeoTrellis to read GeoJson with 3-dimensional coordinate information by adopting the approach of throwing out the z-coordinate.  Smarter handling of elevation data will require a more thorough approach, requiring a new Geometry subclass with z-coordinate capabilities, which would necessarily percolate out into the rest of the library.

This PR closes issues #1272.