### PR TITLE
RFC: Tile.withNoData and NoData Constructor

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
@@ -91,18 +91,32 @@ class ArrayTileSpec extends FunSpec
      */
 
     def checkFloatInterpretAs(tile: Tile, udCt: Double => CellType, constCt: CellType) = {
-      tile.foreachDouble { v =>
-        withClue(s"ND=$v") {
-          assert(tile.interpretAs(udCt(v)).interpretAs(constCt).asRawTile equals tile)
-        }
+      for {
+        r <- 0 until tile.rows
+        c <- 0 until tile.cols
+      } {
+        val v = tile.get(c, r)
+        val udTile = tile.interpretAs(udCt(v))
+        val constTile = udTile.interpretAs(constCt)
+        val res = constTile.asRawTile
+        withClue(s"ND=$v") { assert(res equals tile) }
+        val cell = udTile.getDouble(c,r)
+        withClue(s"udTile($c, $r), ND=$v") { assert(isNoData(cell)) }
       }
     }
 
     def checkIntInterpretAs(tile: Tile, udCt: Int => CellType, constCt: CellType) = {
-      tile.foreach { v =>
-        withClue(s"ND=$v") {
-          assert(tile.interpretAs(udCt(v)).interpretAs(constCt).asRawTile equals tile)
-        }
+      for {
+        r <- 0 until tile.rows
+        c <- 0 until tile.cols
+      } {
+        val v = tile.get(c, r)
+        val udTile = tile.interpretAs(udCt(v))
+        val constTile = udTile.interpretAs(constCt)
+        val res = constTile.asRawTile
+        withClue(s"ND=$v") { assert(res equals tile) }
+        val cell = udTile.get(c,r)
+        withClue(s"udTile($c, $r), ND=$v") { assert(isNoData(cell)) }
       }
     }
 

--- a/raster-test/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
@@ -83,5 +83,76 @@ class ArrayTileSpec extends FunSpec
     it("should convert to a DoubleCellType") { checkDouble(DoubleCellType, Array(0, 1, -1, Double.NaN)) }
     it("should convert to a DoubleConstantNoDataCellType") { checkDouble(DoubleConstantNoDataCellType, Array(0, 1, -1, Double.NaN)) }
     it("should convert to a DoubleUserDefinedNoDataCellType") { checkDouble(DoubleUserDefinedNoDataCellType(1), Array(0, Double.NaN, -1, Double.NaN)) }
+
+
+    /*
+    The critical aspect of Tile.interpretAs is that as long as type conversion does not truncate value
+    the interpretations of NoData value will not alter the underlying cell values as happens with Tile.convert
+     */
+
+    def checkFloatInterpretAs(tile: Tile, udCt: Double => CellType, constCt: CellType) = {
+      tile.foreachDouble { v =>
+        withClue(s"ND=$v") {
+          assert(tile.interpretAs(udCt(v)).interpretAs(constCt).asRawTile equals tile)
+        }
+      }
+    }
+
+    def checkIntInterpretAs(tile: Tile, udCt: Int => CellType, constCt: CellType) = {
+      tile.foreach { v =>
+        withClue(s"ND=$v") {
+          assert(tile.interpretAs(udCt(v)).interpretAs(constCt).asRawTile equals tile)
+        }
+      }
+    }
+
+    it("should interpretAs for DoubleCells") {
+      checkFloatInterpretAs(
+        sourceTile,
+        DoubleUserDefinedNoDataCellType,
+        DoubleConstantNoDataCellType)
+    }
+
+    it("should interpretAs for FloatCells") {
+      checkFloatInterpretAs(
+        sourceTile.convert(FloatCellType),
+        x => FloatUserDefinedNoDataCellType(x.toFloat),
+        FloatConstantNoDataCellType)
+    }
+
+    it("should interpretAs for IntCells") {
+      checkIntInterpretAs(
+        sourceTile.convert(IntCellType),
+        IntUserDefinedNoDataCellType,
+        IntConstantNoDataCellType)
+    }
+
+    it("should interpretAs for ShortCells") {
+      checkIntInterpretAs(
+        sourceTile.convert(ShortCellType),
+        x => ShortUserDefinedNoDataCellType(x.toShort),
+        ShortConstantNoDataCellType)
+    }
+
+    it("should interpretAs for UShortCells") {
+      checkIntInterpretAs(
+        sourceTile.convert(UShortCellType),
+        x => UShortUserDefinedNoDataCellType(x.toShort),
+        UShortConstantNoDataCellType)
+    }
+
+    it("should interpretAs for ByteCells") {
+      checkIntInterpretAs(
+        sourceTile.convert(ByteCellType),
+        x => ByteUserDefinedNoDataCellType(x.toByte),
+        ByteConstantNoDataCellType)
+    }
+
+    it("should interpretAs for UByteCells") {
+      checkIntInterpretAs(
+        sourceTile.convert(UByteCellType),
+        x => UByteUserDefinedNoDataCellType(x.toByte),
+        UByteConstantNoDataCellType)
+    }
   }
 }

--- a/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
@@ -64,7 +64,7 @@ trait ArrayTile extends Tile with Serializable {
 
   def asRawTile: ArrayTile
 
-  def interpret(targetCellType: CellType): ArrayTile
+  def interpretAs(targetCellType: CellType): ArrayTile
 
   /**
     * Execute a function on each cell of the [[ArrayTile]].

--- a/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
@@ -39,7 +39,7 @@ trait ArrayTile extends Tile with Serializable {
     * @param   targetCellType  The type of cells that the result should have
     * @return            The new Tile
     */
-  def convert(targetCellType: CellType): Tile = {
+  def convert(targetCellType: CellType): ArrayTile = {
     val tile = ArrayTile.alloc(targetCellType, cols, rows)
 
     if(targetCellType.isFloatingPoint != cellType.isFloatingPoint)
@@ -61,6 +61,10 @@ trait ArrayTile extends Tile with Serializable {
 
     tile
   }
+
+  def asRawTile: ArrayTile
+
+  def interpret(targetCellType: CellType): ArrayTile
 
   /**
     * Execute a function on each cell of the [[ArrayTile]].

--- a/raster/src/main/scala/geotrellis/raster/BitArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/BitArrayTile.scala
@@ -132,7 +132,7 @@ final case class BitArrayTile(val array: Array[Byte], cols: Int, rows: Int)
 
   def asRawTile: BitArrayTile = BitArrayTile(array, cols, rows)
 
-  def interpret(targetCellType: CellType): ArrayTile = {
+  def interpretAs(targetCellType: CellType): ArrayTile = {
     targetCellType match {
       case dt: ByteCells with NoDataHandling =>
         ByteArrayTile(array, cols, rows, dt)

--- a/raster/src/main/scala/geotrellis/raster/BitArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/BitArrayTile.scala
@@ -16,10 +16,6 @@
 
 package geotrellis.raster
 
-import geotrellis.vector.Extent
-
-import spire.syntax.cfor._
-
 
 /**
   * [[ArrayTile]] based on an Array[Byte] as a bitmask; values are 0
@@ -133,6 +129,17 @@ final case class BitArrayTile(val array: Array[Byte], cols: Int, rows: Int)
     * @return  An array of bytes
     */
   def toBytes: Array[Byte] = array.clone
+
+  def asRawTile: BitArrayTile = BitArrayTile(array, cols, rows)
+
+  def interpret(targetCellType: CellType): ArrayTile = {
+    targetCellType match {
+      case dt: ByteCells with NoDataHandling =>
+        ByteArrayTile(array, cols, rows, dt)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
@@ -25,7 +25,7 @@ abstract class ByteArrayTile(val array: Array[Byte], cols: Int, rows: Int)
 
   def asRawTile: ByteArrayTile = ByteArrayTile(array, cols, rows, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): ArrayTile = {
+  def interpretAs(targetCellType: CellType): ArrayTile = {
     targetCellType match {
       case dt: ByteCells with NoDataHandling =>
         ByteArrayTile(array, cols, rows, dt)

--- a/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
@@ -1,11 +1,5 @@
 package geotrellis.raster
 
-import geotrellis.vector.Extent
-import geotrellis.raster.resample._
-
-import spire.syntax.cfor._
-import java.nio.ByteBuffer
-
 
 /**
  * [[ArrayTile]] based on Array[Byte] (each cell as a Byte).
@@ -28,6 +22,17 @@ abstract class ByteArrayTile(val array: Array[Byte], cols: Int, rows: Int)
     * @return  The copy
     */
   def copy: ByteArrayTile = ArrayTile(array.clone, cols, rows)
+
+  def asRawTile: ByteArrayTile = ByteArrayTile(array, cols, rows, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): ArrayTile = {
+    targetCellType match {
+      case dt: ByteCells with NoDataHandling =>
+        ByteArrayTile(array, cols, rows, dt)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/CellType.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellType.scala
@@ -34,6 +34,10 @@ sealed abstract class DataType extends Serializable { self: CellType =>
 
   def bytes = bits / 8
 
+  def withNoNoData: DataType with NoNoData
+
+  def equalDataType(other: DataType): Boolean
+
   /**
     * Union only checks to see that the correct bitsize and int vs
     * floating point values are set.  We can be sure that its
@@ -108,6 +112,8 @@ sealed trait BitCells extends DataType { self: CellType =>
   val bits: Int = 1
   val isFloatingPoint: Boolean = false
   val name = "bool"
+  def withNoNoData = BitCellType
+  def equalDataType(other: DataType) = other.isInstanceOf[BitCells]
 }
 
 /**
@@ -117,6 +123,8 @@ sealed trait ByteCells extends DataType { self: CellType =>
   val bits: Int = 8
   val isFloatingPoint: Boolean = false
   val name = "int8"
+  def withNoNoData = ByteCellType
+  def equalDataType(other: DataType) = other.isInstanceOf[ByteCells]
 }
 
 /**
@@ -126,6 +134,8 @@ sealed trait UByteCells extends DataType { self: CellType =>
   val bits: Int = 8
   val isFloatingPoint: Boolean = false
   val name = "uint8"
+  def withNoNoData = UByteCellType
+  def equalDataType(other: DataType) = other.isInstanceOf[UByteCells]
 }
 
 /**
@@ -135,6 +145,8 @@ sealed trait ShortCells extends DataType { self: CellType =>
   val bits: Int = 16
   val isFloatingPoint: Boolean = false
   val name = "int16"
+  def withNoNoData = ShortCellType
+  def equalDataType(other: DataType) = other.isInstanceOf[ShortCells]
 }
 
 /**
@@ -144,6 +156,8 @@ sealed trait UShortCells extends DataType { self: CellType =>
   val bits: Int = 16
   val isFloatingPoint: Boolean = false
   val name = "uint16"
+  def withNoNoData = UShortCellType
+  def equalDataType(other: DataType) = other.isInstanceOf[UShortCells]
 }
 
 /**
@@ -153,12 +167,17 @@ sealed trait IntCells extends DataType { self: CellType =>
   val bits: Int = 32
   val isFloatingPoint: Boolean = false
   val name = "int32"
+  def withNoNoData = IntCellType
+  def equalDataType(other: DataType) = other.isInstanceOf[IntCells]
+
 }
 
 sealed trait FloatCells extends DataType { self: CellType =>
   val bits: Int = 32
   val isFloatingPoint: Boolean = true
   val name = "float32"
+  def withNoNoData = FloatCellType
+  def equalDataType(other: DataType) = other.isInstanceOf[FloatCells]
 }
 
 /**
@@ -168,6 +187,8 @@ sealed trait DoubleCells extends DataType { self: CellType =>
   val bits: Int = 64
   val isFloatingPoint: Boolean = true
   val name = "float64"
+  def withNoNoData = DoubleCellType
+  def equalDataType(other: DataType) = other.isInstanceOf[DoubleCells]
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
@@ -141,8 +141,8 @@ case class CompositeTile(tiles: Seq[Tile],
   def asRawTile: CompositeTile =
     CompositeTile(tiles.map(_.asRawTile), tileLayout)
 
-  def interpret(targetCellType: CellType): CompositeTile =
-    CompositeTile(tiles.map(_.interpret(targetCellType)), tileLayout)
+  def interpretAs(targetCellType: CellType): CompositeTile =
+    CompositeTile(tiles.map(_.interpretAs(targetCellType)), tileLayout)
 
   /**
     * Another name for the 'mutable' method on this class.

--- a/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
@@ -132,11 +132,17 @@ case class CompositeTile(tiles: Seq[Tile],
     * Returns a [[Tile]] equivalent to this [[CompositeTile]], except
     * with cells of the given type.
     *
-    * @param   cellType  The type of cells that the result should have
-    * @return            The new Tile
+    * @param   targetCellType  The type of cells that the result should have
+    * @return                  The new Tile
     */
   def convert(targetCellType: CellType): Tile =
     mutable(targetCellType)
+
+  def asRawTile: CompositeTile =
+    CompositeTile(tiles.map(_.asRawTile), tileLayout)
+
+  def interpret(targetCellType: CellType): CompositeTile =
+    CompositeTile(tiles.map(_.interpret(targetCellType)), tileLayout)
 
   /**
     * Another name for the 'mutable' method on this class.

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -91,7 +91,7 @@ trait ConstantTile extends Tile {
     }
   }
 
-  def interpret(targetCellType: CellType): Tile =
+  def interpretAs(targetCellType: CellType): Tile =
     asRawTile.convert(targetCellType)
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -29,7 +29,11 @@ import spire.syntax.cfor._
   * The trait underlying constant tile types.
   */
 trait ConstantTile extends Tile {
+
+  /** Precomputed view of tile cells as seen by [[get]] method */
   protected val iVal: Int
+
+  /** Precomputed view of tile cells as seen by [[getDouble]] method */
   protected val dVal: Double
 
   /**
@@ -76,17 +80,19 @@ trait ConstantTile extends Tile {
       logger.warn(s"Conversion from $cellType to $newType may lead to data loss.")
 
     newType match {
-      case BitCellType => BitConstantTile(if (iVal == 0) false else true, cols, rows)
-      case ByteConstantNoDataCellType => ByteConstantTile(i2b(iVal), cols, rows)
-      case UByteConstantNoDataCellType => UByteConstantTile(i2ub(iVal), cols, rows)
-      case ShortConstantNoDataCellType => ShortConstantTile(i2s(iVal), cols, rows)
-      case UShortConstantNoDataCellType => UShortConstantTile(i2us(iVal), cols, rows)
-      case IntConstantNoDataCellType => IntConstantTile(iVal, cols, rows)
-      case FloatConstantNoDataCellType => FloatConstantTile(d2f(dVal), cols, rows)
-      case DoubleConstantNoDataCellType => DoubleConstantTile(dVal, cols, rows)
-      case _ => throw new IllegalArgumentException(s"Unsupported ConstantTile CellType: $newType")
+      case BitCellType => new BitConstantTile(if (iVal == 0) false else true, cols, rows)
+      case ct: ByteCells => ByteConstantTile(iVal.toByte, cols, rows, ct)
+      case ct: UByteCells => UByteConstantTile(iVal.toByte, cols, rows, ct)
+      case ct: ShortCells => ShortConstantTile(iVal.toShort , cols, rows, ct)
+      case ct: UShortCells =>  UShortConstantTile(iVal.toShort , cols, rows, ct)
+      case ct: IntCells =>  IntConstantTile(iVal , cols, rows, ct)
+      case ct: FloatCells => FloatConstantTile(dVal.toFloat , cols, rows, ct)
+      case ct: DoubleCells => DoubleConstantTile(dVal, cols, rows, ct)
     }
   }
+
+  def interpret(targetCellType: CellType): Tile =
+    asRawTile.convert(targetCellType)
 
   /**
     * Execute a function on each cell of the tile.  The function
@@ -259,16 +265,26 @@ case class BitConstantTile(v: Boolean, cols: Int, rows: Int) extends ConstantTil
     * @return  An array of bytes
     */
   def toBytes(): Array[Byte] = Array(iVal.toByte)
+
+  def asRawTile = this
 }
 
 /**
   * The [[ByteConstantTile]] type.
   */
-case class ByteConstantTile(v: Byte, cols: Int, rows: Int) extends ConstantTile {
-  protected val iVal = b2i(v)
-  protected val dVal = b2d(v)
-
-  val cellType = ByteConstantNoDataCellType
+case class ByteConstantTile(v: Byte, cols: Int, rows: Int,
+  val cellType: ByteCells with NoDataHandling = ByteConstantNoDataCellType
+) extends ConstantTile {
+  protected val (iVal: Int, dVal: Double) =
+    cellType match {
+      case _: ConstantNoData =>
+        (b2i(v), b2d(v))
+      case _: NoNoData =>
+        (v.toInt, v.toDouble)
+      case ct: ByteUserDefinedNoDataCellType =>
+        if (ct.noDataValue == v) (Int.MinValue, Double.NaN)
+        else (v.toInt, v.toDouble)
+    }
 
   /**
     * Another name for the 'mutable' method on this class.
@@ -288,16 +304,27 @@ case class ByteConstantTile(v: Byte, cols: Int, rows: Int) extends ConstantTile 
     * @return  An array of bytes
     */
   def toBytes(): Array[Byte] = Array(v)
+
+  def asRawTile = ByteConstantTile(v, cols, rows, ByteCellType)
 }
 
 /**
   * The [[UByteConstantTile]] type.
   */
-case class UByteConstantTile(v: Byte, cols: Int, rows: Int) extends ConstantTile {
-  protected val iVal = ub2i(v)
-  protected val dVal = ub2d(v)
+case class UByteConstantTile(v: Byte, cols: Int, rows: Int,
+  val cellType: UByteCells with NoDataHandling = UByteConstantNoDataCellType
+) extends ConstantTile {
 
-  val cellType = ByteConstantNoDataCellType
+  protected val (iVal: Int, dVal: Double) =
+    cellType match {
+      case _: ConstantNoData =>
+        (ub2i(v), ub2d(v))
+      case _: NoNoData =>
+        (v.toInt, v.toDouble)
+      case ct: UByteUserDefinedNoDataCellType =>
+        if (ct.noDataValue == v) (Int.MinValue, Double.NaN)
+        else (v.toInt, v.toDouble)
+    }
 
   /**
     * Another name for the 'mutable' method on this class.
@@ -328,16 +355,27 @@ case class UByteConstantTile(v: Byte, cols: Int, rows: Int) extends ConstantTile
     */
   def resample(current: Extent, target: RasterExtent, method: ResampleMethod): Tile =
     ByteConstantTile(v, target.cols, target.rows)
+
+  def asRawTile = UByteConstantTile(v, cols, rows, UByteCellType)
 }
 
 /**
   * The [[ShortConstantTile]] type.
   */
-case class ShortConstantTile(v: Short, cols: Int, rows: Int) extends ConstantTile {
-  protected val iVal = s2i(v)
-  protected val dVal = s2d(v)
+case class ShortConstantTile(v: Short, cols: Int, rows: Int,
+  val cellType: ShortCells with NoDataHandling = ShortConstantNoDataCellType
+) extends ConstantTile {
 
-  val cellType = ShortConstantNoDataCellType
+  protected val (iVal: Int, dVal: Double) =
+    cellType match {
+      case _: ConstantNoData =>
+        (s2i(v), s2d(v))
+      case _: NoNoData =>
+        (v.toInt, v.toDouble)
+      case ct: ShortUserDefinedNoDataCellType =>
+        if (ct.noDataValue == v) (Int.MinValue, Double.NaN)
+        else (v.toInt, v.toDouble)
+    }
 
   /**
     * Another name for the 'mutable' method on this class.
@@ -361,16 +399,27 @@ case class ShortConstantTile(v: Short, cols: Int, rows: Int) extends ConstantTil
     ByteBuffer.wrap(arr).asShortBuffer.put(v)
     arr
   }
+
+  def asRawTile = ShortConstantTile(v, cols, rows, ShortCellType)
 }
 
 /**
   * The [[UShortConstantTile]] type.
   */
-case class UShortConstantTile(v: Short, cols: Int, rows: Int) extends ConstantTile {
-  protected val iVal = us2i(v)
-  protected val dVal = us2d(v)
+case class UShortConstantTile(v: Short, cols: Int, rows: Int,
+  val cellType: UShortCells with NoDataHandling = UShortConstantNoDataCellType
+) extends ConstantTile {
 
-  val cellType = ShortConstantNoDataCellType
+  protected val (iVal: Int, dVal: Double) =
+    cellType match {
+      case _: ConstantNoData =>
+        (us2i(v), us2d(v))
+      case _: NoNoData =>
+        (v.toInt, v.toDouble)
+      case ct: UShortUserDefinedNoDataCellType =>
+        if (ct.noDataValue == v) (Int.MinValue, Double.NaN)
+        else (v.toInt, v.toDouble)
+    }
 
   /**
     * Another name for the 'mutable' method on this class.
@@ -405,16 +454,27 @@ case class UShortConstantTile(v: Short, cols: Int, rows: Int) extends ConstantTi
     */
   def resample(current: Extent, target: RasterExtent, method: ResampleMethod): Tile =
     ShortConstantTile(v, target.cols, target.rows)
+
+  def asRawTile = UShortConstantTile(v, cols, rows, UShortCellType)
 }
 
 /**
   * The [[IntConstantTile]] type.
   */
-case class IntConstantTile(v: Int, cols: Int, rows: Int) extends ConstantTile {
-  protected val iVal = v
-  protected val dVal = i2d(v)
+case class IntConstantTile(v: Int, cols: Int, rows: Int,
+  val cellType: IntCells with NoDataHandling = IntConstantNoDataCellType
+) extends ConstantTile {
 
-  val cellType = IntConstantNoDataCellType
+  protected val (iVal: Int, dVal: Double) =
+    cellType match {
+      case _: ConstantNoData =>
+        (v, i2d(v))
+      case _: NoNoData =>
+        (v, v.toDouble)
+      case ct: IntUserDefinedNoDataCellType =>
+        if (ct.noDataValue == v) (Int.MinValue, Double.NaN)
+        else (v.toInt, v.toDouble)
+    }
 
   /**
     * Another name for the 'mutable' method on this class.
@@ -438,16 +498,27 @@ case class IntConstantTile(v: Int, cols: Int, rows: Int) extends ConstantTile {
     ByteBuffer.wrap(arr).asIntBuffer.put(v)
     arr
   }
+
+  def asRawTile = IntConstantTile(v, cols, rows, IntCellType)
 }
 
 /**
   * The [[FloatConstantTile]] type.
   */
-case class FloatConstantTile(v: Float, cols: Int, rows: Int) extends ConstantTile {
-  protected val iVal = f2i(v)
-  protected val dVal = f2d(v)
+case class FloatConstantTile(v: Float, cols: Int, rows: Int,
+  val cellType: FloatCells with NoDataHandling = FloatConstantNoDataCellType
+) extends ConstantTile {
 
-  val cellType = FloatConstantNoDataCellType
+  protected val (iVal: Int, dVal: Double) =
+    cellType match {
+      case _: ConstantNoData =>
+        (f2i(v), f2d(v))
+      case _: NoNoData =>
+        (v.toInt, v.toDouble)
+      case ct: FloatUserDefinedNoDataCellType =>
+        if (ct.noDataValue == v) (Int.MinValue, Double.NaN)
+        else (v.toInt, v.toDouble)
+    }
 
   /**
     * Another name for the 'mutable' method on this class.
@@ -471,16 +542,27 @@ case class FloatConstantTile(v: Float, cols: Int, rows: Int) extends ConstantTil
     ByteBuffer.wrap(arr).asFloatBuffer.put(v)
     arr
   }
+
+  def asRawTile = FloatConstantTile(v, cols, rows, FloatCellType)
 }
 
 /**
   * The [[DoubleConstantTile]] type.
   */
-case class DoubleConstantTile(v: Double, cols: Int, rows: Int) extends ConstantTile {
-  protected val iVal = d2i(v)
-  protected val dVal = v
+case class DoubleConstantTile(v: Double, cols: Int, rows: Int,
+  val cellType: DoubleCells with NoDataHandling = DoubleConstantNoDataCellType
+) extends ConstantTile {
 
-  val cellType = DoubleConstantNoDataCellType
+  protected val (iVal: Int, dVal: Double) =
+    cellType match {
+      case _: ConstantNoData =>
+        (d2i(v), v)
+      case _: NoNoData =>
+        (v.toInt, v)
+      case ct: DoubleUserDefinedNoDataCellType =>
+        if (ct.noDataValue == v) (Int.MinValue, Double.NaN)
+        else (v.toInt, v)
+    }
 
   /**
     * Another name for the 'mutable' method on this class.
@@ -492,7 +574,7 @@ case class DoubleConstantTile(v: Double, cols: Int, rows: Int) extends ConstantT
     *
     * @return  The MutableArrayTile
     */
-  def mutable(): MutableArrayTile = DoubleArrayTile.fill(dVal, cols, rows)
+  def mutable(): MutableArrayTile = DoubleArrayTile.fill(dVal, cols, rows, cellType)
 
   /**
     * Return the underlying data behind this tile as an array.
@@ -501,7 +583,9 @@ case class DoubleConstantTile(v: Double, cols: Int, rows: Int) extends ConstantT
     */
   def toBytes(): Array[Byte] = {
     val arr = Array.ofDim[Byte](cellType.bytes)
-    ByteBuffer.wrap(arr).asDoubleBuffer.put(dVal)
+    ByteBuffer.wrap(arr).asDoubleBuffer.put(v)
     arr
   }
+
+  def asRawTile = DoubleConstantTile(v, cols, rows, DoubleCellType)
 }

--- a/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
@@ -76,6 +76,12 @@ case class CroppedTile(sourceTile: Tile,
   def convert(targetCellType: CellType): Tile =
     mutable(targetCellType)
 
+  def asRawTile =
+    CroppedTile(sourceTile.asRawTile, gridBounds)
+
+  def interpret(targetCellType: CellType) =
+    CroppedTile(sourceTile.interpret(targetCellType), gridBounds)
+
   /**
     * Fetch the datum at the given column and row of the tile.
     *

--- a/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
@@ -79,8 +79,8 @@ case class CroppedTile(sourceTile: Tile,
   def asRawTile =
     CroppedTile(sourceTile.asRawTile, gridBounds)
 
-  def interpret(targetCellType: CellType) =
-    CroppedTile(sourceTile.interpret(targetCellType), gridBounds)
+  def interpretAs(targetCellType: CellType) =
+    CroppedTile(sourceTile.interpretAs(targetCellType), gridBounds)
 
   /**
     * Fetch the datum at the given column and row of the tile.

--- a/raster/src/main/scala/geotrellis/raster/DoubleArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DoubleArrayTile.scala
@@ -16,11 +16,7 @@
 
 package geotrellis.raster
 
-import geotrellis.vector.Extent
-
 import java.nio.ByteBuffer
-import spire.syntax.cfor._
-
 
 /**
  * [[ArrayTile]] based on Array[Double] (each cell as a Double).
@@ -50,6 +46,17 @@ abstract class DoubleArrayTile(val array: Array[Double], cols: Int, rows: Int)
     * @return  The copy
     */
   def copy: ArrayTile = ArrayTile(array.clone, cols, rows)
+
+  def asRawTile: DoubleArrayTile = DoubleArrayTile(array, cols, rows, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): ArrayTile = {
+    targetCellType match {
+      case dt: DoubleCells with NoDataHandling =>
+        DoubleArrayTile(array, cols, rows, dt)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/DoubleArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DoubleArrayTile.scala
@@ -49,7 +49,7 @@ abstract class DoubleArrayTile(val array: Array[Double], cols: Int, rows: Int)
 
   def asRawTile: DoubleArrayTile = DoubleArrayTile(array, cols, rows, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): ArrayTile = {
+  def interpretAs(targetCellType: CellType): ArrayTile = {
     targetCellType match {
       case dt: DoubleCells with NoDataHandling =>
         DoubleArrayTile(array, cols, rows, dt)

--- a/raster/src/main/scala/geotrellis/raster/FloatArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/FloatArrayTile.scala
@@ -16,11 +16,7 @@
 
 package geotrellis.raster
 
-import geotrellis.vector.Extent
-
-import spire.syntax.cfor._
 import java.nio.ByteBuffer
-
 
 /**
   * [[ArrayTile]] based on Array[Float] (each cell as a Float).
@@ -48,6 +44,17 @@ abstract class FloatArrayTile(val array: Array[Float], cols: Int, rows: Int)
     * @return  The copy
     */
   def copy: ArrayTile = ArrayTile(array.clone, cols, rows)
+
+  def asRawTile: FloatArrayTile = FloatArrayTile(array, cols, rows, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType) = {
+    targetCellType match {
+      case dt: FloatCells with NoDataHandling =>
+        FloatArrayTile(array, cols, rows, dt)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/FloatArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/FloatArrayTile.scala
@@ -47,7 +47,7 @@ abstract class FloatArrayTile(val array: Array[Float], cols: Int, rows: Int)
 
   def asRawTile: FloatArrayTile = FloatArrayTile(array, cols, rows, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType) = {
+  def interpretAs(targetCellType: CellType) = {
     targetCellType match {
       case dt: FloatCells with NoDataHandling =>
         FloatArrayTile(array, cols, rows, dt)

--- a/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
@@ -51,14 +51,14 @@ abstract class IntArrayTile(val array: Array[Int], cols: Int, rows: Int)
   def asRawTile: IntArrayTile = IntArrayTile(array, cols, rows, IntCellType)
 
   // This would be pushed to [[Tile]]
-  def withNoData[T: Numeric](v: Option[T]): Tile =  
-   v match { 
-    case Some(nd) => withNoData(nd) 
-    case None => asRawTile 
+  def withNoData[T: Numeric](v: Option[T]): Tile =
+   v match {
+    case Some(nd) => withNoData(nd)
+    case None => asRawTile
    }
-   
-  def withNoData[T: Numeric](v: T): Tile = 
-   IntArrayTile(array, cols, rows, implicitly[Numeric[T]].toInt(v).toShort) 
+
+  def withNoData[T: Numeric](v: T): Tile =
+   IntArrayTile(array, cols, rows, implicitly[Numeric[T]].toInt(v).toShort)
 
   def interpretAs(targetCellType: CellType): ArrayTile = {
     targetCellType match {
@@ -229,18 +229,18 @@ object IntArrayTile {
         new IntUserDefinedNoDataArrayTile(arr, cols, rows, udct)
     }
 
-  def apply(arr: Array[Int], cols: Int, rows: Int, noData: Option[Int]): IntArrayTile = 
+  def apply(arr: Array[Int], cols: Int, rows: Int, noData: Option[Int]): IntArrayTile =
    noData match {
     case Some(nd) if isNoData(nd) =>
-      new IntConstantNoDataArrayTile(arr, cols, rows) 
-    case Some(nd) =>  
-     new IntUserDefinedNoDataArrayTile(arr, cols, rows, IntUserDefinedNoDataCellType(nd)) 
+      new IntConstantNoDataArrayTile(arr, cols, rows)
+    case Some(nd) =>
+     new IntUserDefinedNoDataArrayTile(arr, cols, rows, IntUserDefinedNoDataCellType(nd))
     case None =>
-      new IntRawArrayTile(arr, cols, rows) 
-  }  
+      new IntRawArrayTile(arr, cols, rows)
+  }
 
-  def apply(arr: Array[Int], cols: Int, rows: Int, noData: Int): IntArrayTile = 
-   apply(arr, cols, rows, Some(noData)) 
+  def apply(arr: Array[Int], cols: Int, rows: Int, noData: Int): IntArrayTile =
+   apply(arr, cols, rows, Some(noData))
 
   /**
     * Produce a [[IntArrayTile]] of the specified dimensions.

--- a/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
@@ -50,6 +50,16 @@ abstract class IntArrayTile(val array: Array[Int], cols: Int, rows: Int)
 
   def asRawTile: IntArrayTile = IntArrayTile(array, cols, rows, IntCellType)
 
+  // This would be pushed to [[Tile]]
+  def withNoData[T: Numeric](v: Option[T]): Tile =  
+   v match { 
+    case Some(nd) => withNoData(nd) 
+    case None => asRawTile 
+   }
+   
+  def withNoData[T: Numeric](v: T): Tile = 
+   IntArrayTile(array, cols, rows, implicitly[Numeric[T]].toInt(v).toShort) 
+
   def interpretAs(targetCellType: CellType): ArrayTile = {
     targetCellType match {
       case dt: IntCells with NoDataHandling =>
@@ -218,6 +228,19 @@ object IntArrayTile {
       case udct: IntUserDefinedNoDataCellType =>
         new IntUserDefinedNoDataArrayTile(arr, cols, rows, udct)
     }
+
+  def apply(arr: Array[Int], cols: Int, rows: Int, noData: Option[Int]): IntArrayTile = 
+   noData match {
+    case Some(nd) if isNoData(nd) =>
+      new IntConstantNoDataArrayTile(arr, cols, rows) 
+    case Some(nd) =>  
+     new IntUserDefinedNoDataArrayTile(arr, cols, rows, IntUserDefinedNoDataCellType(nd)) 
+    case None =>
+      new IntRawArrayTile(arr, cols, rows) 
+  }  
+
+  def apply(arr: Array[Int], cols: Int, rows: Int, noData: Int): IntArrayTile = 
+   apply(arr, cols, rows, Some(noData)) 
 
   /**
     * Produce a [[IntArrayTile]] of the specified dimensions.

--- a/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
@@ -16,9 +16,6 @@
 
 package geotrellis.raster
 
-import geotrellis.vector.Extent
-
-import spire.syntax.cfor._
 import java.nio.ByteBuffer
 
 /**
@@ -50,6 +47,17 @@ abstract class IntArrayTile(val array: Array[Int], cols: Int, rows: Int)
     * @return  The copy
     */
   def copy: ArrayTile = ArrayTile(array.clone, cols, rows)
+
+  def asRawTile: IntArrayTile = IntArrayTile(array, cols, rows, IntCellType)
+
+  def interpret(targetCellType: CellType): ArrayTile = {
+    targetCellType match {
+      case dt: IntCells with NoDataHandling =>
+        IntArrayTile(array, cols, rows, dt)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
@@ -50,7 +50,7 @@ abstract class IntArrayTile(val array: Array[Int], cols: Int, rows: Int)
 
   def asRawTile: IntArrayTile = IntArrayTile(array, cols, rows, IntCellType)
 
-  def interpret(targetCellType: CellType): ArrayTile = {
+  def interpretAs(targetCellType: CellType): ArrayTile = {
     targetCellType match {
       case dt: IntCells with NoDataHandling =>
         IntArrayTile(array, cols, rows, dt)

--- a/raster/src/main/scala/geotrellis/raster/PixelInterleaveBandArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/PixelInterleaveBandArrayTile.scala
@@ -46,4 +46,10 @@ class PixelInterleaveBandArrayTile(inner: ArrayTile, bandCount: Int, bandIndex: 
 
     tile
   }
+
+  def asRawTile =
+    PixelInterleaveBandArrayTile(inner.asRawTile, bandCount, bandIndex)
+
+  def interpret(targetCellType: CellType) =
+    PixelInterleaveBandArrayTile(inner.interpret(targetCellType), bandCount, bandIndex)
 }

--- a/raster/src/main/scala/geotrellis/raster/PixelInterleaveBandArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/PixelInterleaveBandArrayTile.scala
@@ -50,6 +50,6 @@ class PixelInterleaveBandArrayTile(inner: ArrayTile, bandCount: Int, bandIndex: 
   def asRawTile =
     PixelInterleaveBandArrayTile(inner.asRawTile, bandCount, bandIndex)
 
-  def interpret(targetCellType: CellType) =
-    PixelInterleaveBandArrayTile(inner.interpret(targetCellType), bandCount, bandIndex)
+  def interpretAs(targetCellType: CellType) =
+    PixelInterleaveBandArrayTile(inner.interpretAs(targetCellType), bandCount, bandIndex)
 }

--- a/raster/src/main/scala/geotrellis/raster/ShortArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ShortArrayTile.scala
@@ -30,7 +30,7 @@ abstract class ShortArrayTile(val array: Array[Short], cols: Int, rows: Int)
 
   def asRawTile: ShortArrayTile = ShortArrayTile(array, cols, rows, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): ArrayTile = {
+  def interpretAs(targetCellType: CellType): ArrayTile = {
     targetCellType match {
       case dt: ShortCells with NoDataHandling =>
         ShortArrayTile(array, cols, rows, dt)

--- a/raster/src/main/scala/geotrellis/raster/ShortArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ShortArrayTile.scala
@@ -1,9 +1,6 @@
 package geotrellis.raster
 
-import geotrellis.vector.Extent
-
 import java.nio.ByteBuffer
-import spire.syntax.cfor._
 
 
 /**
@@ -11,6 +8,7 @@ import spire.syntax.cfor._
  */
 abstract class ShortArrayTile(val array: Array[Short], cols: Int, rows: Int)
     extends MutableArrayTile {
+  val cellType: ShortCells with NoDataHandling
 
   /**
     * Return an array of bytes representing the data behind this
@@ -29,6 +27,17 @@ abstract class ShortArrayTile(val array: Array[Short], cols: Int, rows: Int)
     * @return  The copy
     */
   def copy: ArrayTile = ArrayTile(array.clone, cols, rows)
+
+  def asRawTile: ShortArrayTile = ShortArrayTile(array, cols, rows, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): ArrayTile = {
+    targetCellType match {
+      case dt: ShortCells with NoDataHandling =>
+        ShortArrayTile(array, cols, rows, dt)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/Tile.scala
+++ b/raster/src/main/scala/geotrellis/raster/Tile.scala
@@ -122,11 +122,10 @@ trait Tile extends CellGrid with IterableTile with MappableTile[Tile] with LazyL
   /** Changes the interpretation of the tile cells through changing NoData handling and optionally cell data type.
     * If [[DataType]] portion of the [[CellType]] is unchanged the tile data is not duplicated through conversion.
     * If cell [[DataType]] conversion is required it is done in a naive way, without considering NoData handling.
-    * 
-    * @param targetCellType
-    * @return
+    *
+    * @param targetCellType CellType to be used in interpreting existing cells
     */
-  def interpret(targetCellType: CellType): Tile
+  def interpretAs(targetCellType: CellType): Tile
 
   /**
     * Get value at given coordinates.

--- a/raster/src/main/scala/geotrellis/raster/Tile.scala
+++ b/raster/src/main/scala/geotrellis/raster/Tile.scala
@@ -115,6 +115,19 @@ trait Tile extends CellGrid with IterableTile with MappableTile[Tile] with LazyL
     */
   def convert(cellType: CellType): Tile
 
+
+  /** Return tile tile as raw cell [[Tile]] with No NoData handling */
+  def asRawTile: Tile
+
+  /** Changes the interpretation of the tile cells through changing NoData handling and optionally cell data type.
+    * If [[DataType]] portion of the [[CellType]] is unchanged the tile data is not duplicated through conversion.
+    * If cell [[DataType]] conversion is required it is done in a naive way, without considering NoData handling.
+    * 
+    * @param targetCellType
+    * @return
+    */
+  def interpret(targetCellType: CellType): Tile
+
   /**
     * Get value at given coordinates.
     */

--- a/raster/src/main/scala/geotrellis/raster/UByteArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/UByteArrayTile.scala
@@ -28,7 +28,7 @@ abstract class UByteArrayTile(val array: Array[Byte], cols: Int, rows: Int)
 
   def asRawTile: UByteArrayTile = UByteArrayTile(array, cols, rows, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): ArrayTile = {
+  def interpretAs(targetCellType: CellType): ArrayTile = {
     targetCellType match {
       case dt: UByteCells with NoDataHandling =>
         UByteArrayTile(array, cols, rows, dt)

--- a/raster/src/main/scala/geotrellis/raster/UByteArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/UByteArrayTile.scala
@@ -25,6 +25,17 @@ abstract class UByteArrayTile(val array: Array[Byte], cols: Int, rows: Int)
     * @return  The copy
     */
   def copy = UByteArrayTile(array.clone, cols, rows, cellType)
+
+  def asRawTile: UByteArrayTile = UByteArrayTile(array, cols, rows, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): ArrayTile = {
+    targetCellType match {
+      case dt: UByteCells with NoDataHandling =>
+        UByteArrayTile(array, cols, rows, dt)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/UShortArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/UShortArrayTile.scala
@@ -29,7 +29,7 @@ abstract class UShortArrayTile(val array: Array[Short], cols: Int, rows: Int)
 
   def asRawTile: UShortArrayTile = UShortArrayTile(array, cols, rows, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): ArrayTile = {
+  def interpretAs(targetCellType: CellType): ArrayTile = {
     targetCellType match {
       case dt: UShortCells with NoDataHandling =>
         UShortArrayTile(array, cols, rows, dt)

--- a/raster/src/main/scala/geotrellis/raster/UShortArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/UShortArrayTile.scala
@@ -1,8 +1,5 @@
 package geotrellis.raster
 
-import geotrellis.vector.Extent
-
-import spire.syntax.cfor._
 import java.nio.ByteBuffer
 
 /**
@@ -29,6 +26,17 @@ abstract class UShortArrayTile(val array: Array[Short], cols: Int, rows: Int)
     * @return  The copy
     */
   def copy = UShortArrayTile(array.clone, cols, rows)
+
+  def asRawTile: UShortArrayTile = UShortArrayTile(array, cols, rows, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): ArrayTile = {
+    targetCellType match {
+      case dt: UShortCells with NoDataHandling =>
+        UShortArrayTile(array, cols, rows, dt)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/BitGeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/BitGeoTiffTile.scala
@@ -68,4 +68,17 @@ class BitGeoTiffTile(
     }
     result
   }
+
+
+  def asRawTile: BitGeoTiffTile =
+    new BitGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): Tile = {
+    targetCellType match {
+      case dt: BitCells with NoDataHandling =>
+        new BitGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/BitGeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/BitGeoTiffTile.scala
@@ -73,7 +73,7 @@ class BitGeoTiffTile(
   def asRawTile: BitGeoTiffTile =
     new BitGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): Tile = {
+  def interpretAs(targetCellType: CellType): Tile = {
     targetCellType match {
       case dt: BitCells with NoDataHandling =>
         new BitGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffTile.scala
@@ -97,7 +97,7 @@ class ByteGeoTiffTile(
   def asRawTile: ByteGeoTiffTile =
     new ByteGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): Tile = {
+  def interpretAs(targetCellType: CellType): Tile = {
     targetCellType match {
       case dt: ByteCells with NoDataHandling =>
         new ByteGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/ByteGeoTiffTile.scala
@@ -92,4 +92,17 @@ class ByteGeoTiffTile(
     }
     ByteArrayTile.fromBytes(arr, gridBounds.width, gridBounds.height, cellType)
   }
+
+
+  def asRawTile: ByteGeoTiffTile =
+    new ByteGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): Tile = {
+    targetCellType match {
+      case dt: ByteCells with NoDataHandling =>
+        new ByteGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Float32GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Float32GeoTiffTile.scala
@@ -119,7 +119,7 @@ class Float32GeoTiffTile(
   def asRawTile: Float32GeoTiffTile =
     new Float32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): Tile = {
+  def interpretAs(targetCellType: CellType): Tile = {
     targetCellType match {
       case dt: FloatCells with NoDataHandling =>
         new Float32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Float32GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Float32GeoTiffTile.scala
@@ -114,4 +114,17 @@ class Float32GeoTiffTile(
     }
     FloatArrayTile.fromBytes(arr, gridBounds.width, gridBounds.height, cellType)
   }
+
+
+  def asRawTile: Float32GeoTiffTile =
+    new Float32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): Tile = {
+    targetCellType match {
+      case dt: FloatCells with NoDataHandling =>
+        new Float32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }  
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Float64GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Float64GeoTiffTile.scala
@@ -103,7 +103,7 @@ class Float64GeoTiffTile(
   def asRawTile: Float64GeoTiffTile =
     new Float64GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): Tile = {
+  def interpretAs(targetCellType: CellType): Tile = {
     targetCellType match {
       case dt: DoubleCells with NoDataHandling =>
         new Float64GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Float64GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Float64GeoTiffTile.scala
@@ -99,4 +99,16 @@ class Float64GeoTiffTile(
     }
     DoubleArrayTile.fromBytes(arr, gridBounds.width, gridBounds.height, cellType)
   }
+
+  def asRawTile: Float64GeoTiffTile =
+    new Float64GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): Tile = {
+    targetCellType match {
+      case dt: DoubleCells with NoDataHandling =>
+        new Float64GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Int16GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Int16GeoTiffTile.scala
@@ -95,7 +95,7 @@ class Int16GeoTiffTile(
   def asRawTile: Int16GeoTiffTile =
     new Int16GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): Tile = {
+  def interpretAs(targetCellType: CellType): Tile = {
     targetCellType match {
       case dt: ShortCells with NoDataHandling =>
         new Int16GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Int16GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Int16GeoTiffTile.scala
@@ -91,4 +91,16 @@ class Int16GeoTiffTile(
     }
     ShortArrayTile.fromBytes(arr, gridBounds.width, gridBounds.height, cellType)
   }
+
+  def asRawTile: Int16GeoTiffTile =
+    new Int16GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): Tile = {
+    targetCellType match {
+      case dt: ShortCells with NoDataHandling =>
+        new Int16GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Int32GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Int32GeoTiffTile.scala
@@ -100,4 +100,16 @@ class Int32GeoTiffTile(
     }
     IntArrayTile.fromBytes(arr, gridBounds.width, gridBounds.height, cellType)
   }
+
+  def asRawTile: Int32GeoTiffTile =
+    new Int32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): Tile = {
+    targetCellType match {
+      case dt: IntCells with NoDataHandling =>
+        new Int32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Int32GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Int32GeoTiffTile.scala
@@ -104,7 +104,7 @@ class Int32GeoTiffTile(
   def asRawTile: Int32GeoTiffTile =
     new Int32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): Tile = {
+  def interpretAs(targetCellType: CellType): Tile = {
     targetCellType match {
       case dt: IntCells with NoDataHandling =>
         new Int32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UByteGeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UByteGeoTiffTile.scala
@@ -94,4 +94,16 @@ class UByteGeoTiffTile(
     }
     UByteArrayTile.fromBytes(arr, gridBounds.width, gridBounds.height, cellType)
   }
+
+  def asRawTile: UByteGeoTiffTile =
+    new UByteGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): Tile = {
+    targetCellType match {
+      case dt: UByteCells with NoDataHandling =>
+        new UByteGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UByteGeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UByteGeoTiffTile.scala
@@ -98,7 +98,7 @@ class UByteGeoTiffTile(
   def asRawTile: UByteGeoTiffTile =
     new UByteGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): Tile = {
+  def interpretAs(targetCellType: CellType): Tile = {
     targetCellType match {
       case dt: UByteCells with NoDataHandling =>
         new UByteGeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTile.scala
@@ -87,4 +87,16 @@ class UInt16GeoTiffTile(
     }
     UShortArrayTile.fromBytes(arr, gridBounds.width, gridBounds.height, cellType)
   }
+
+  def asRawTile: UInt16GeoTiffTile =
+    new UInt16GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): Tile = {
+    targetCellType match {
+      case dt: UShortCells with NoDataHandling =>
+        new UInt16GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTile.scala
@@ -91,7 +91,7 @@ class UInt16GeoTiffTile(
   def asRawTile: UInt16GeoTiffTile =
     new UInt16GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): Tile = {
+  def interpretAs(targetCellType: CellType): Tile = {
     targetCellType match {
       case dt: UShortCells with NoDataHandling =>
         new UInt16GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffTile.scala
@@ -57,4 +57,16 @@ class UInt32GeoTiffTile(
     }
     FloatArrayTile(arr, gridBounds.width, gridBounds.height, cellType)
   }
+
+  def asRawTile: UInt32GeoTiffTile =
+    new UInt32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
+
+  def interpret(targetCellType: CellType): Tile = {
+    targetCellType match {
+      case dt: FloatCells with NoDataHandling =>
+        new UInt32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)
+      case _ =>
+        asRawTile.convert(targetCellType)
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffTile.scala
@@ -61,7 +61,7 @@ class UInt32GeoTiffTile(
   def asRawTile: UInt32GeoTiffTile =
     new UInt32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, cellType.withNoNoData)
 
-  def interpret(targetCellType: CellType): Tile = {
+  def interpretAs(targetCellType: CellType): Tile = {
     targetCellType match {
       case dt: FloatCells with NoDataHandling =>
         new UInt32GeoTiffTile(segmentBytes, decompressor, segmentLayout, compression, dt.withNoNoData)


### PR DESCRIPTION
Requires: https://github.com/geotrellis/geotrellis/pull/1702

##  Adding  .withNoData methods on Tile

Because `Tile.withNoData` has to be pushed up it must be generic on the no data value:

```scala
def withNoData[T: Numeric](v: T): Tile = 
  IntArrayTile(array, cols, rows, implicitly[Numeric[T]].toInt(v).toShort) 
```

This would be useful if you wanted to write code setting NoData value to some "safe"/common value like `0` without having to match on the `CellType` and construct a type.

However, that may result in coercion when assigning NoData value:

```scala
val tile: Tile = IntArrayTile(array, cols, rows)
tile.withNoData(3.5) // IntUserDefinedNoDataArrayTile(3)
tile.withNoData(None) //IntCellType
tile.asRawTile // IntCellType
```

I think the coercion is intuitive and "correct" so this API seems like it should be flushed out.

## NoData Constructors

Working with our CellType constructs is a bit of a pain and in places where it is obvious what we mean and type safety is assured this apply overload provides a really intuitive interface:

```scala
  def apply(arr: Array[Int], cols: Int, rows: Int, noData: Option[Int]): IntArrayTile = 
   noData match {
    case Some(nd) if isNoData(nd) =>
      new IntConstantNoDataArrayTile(arr, cols, rows) 
    case Some(nd) =>  
     new IntUserDefinedNoDataArrayTile(arr, cols, rows, IntUserDefinedNoDataCellType(nd)) 
    case None =>
      new IntRawArrayTile(arr, cols, rows) 
  }  
```

Putting this as PR for discussions because there are tradeoffs involved.