### PR TITLE
Hdfs Range Reads

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HdfsUtils.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HdfsUtils.scala
@@ -178,6 +178,21 @@ object HdfsUtils extends LazyLogging {
     bytes
   }
 
+  def readRange(path: Path, start: Long, length: Int, conf: Configuration): Array[Byte] = {
+    val fs: FileSystem = path.getFileSystem(conf)
+    val end: Long = start + length
+    val bytes: Array[Byte] = Array.ofDim[Byte]((end - start).toInt)
+    val stream: FSDataInputStream = fs.open(path)
+
+    try {
+      stream.readFully(start, bytes, 0, length)
+    } finally {
+      stream.close()
+    }
+
+    bytes
+  }
+
   def getLineScanner(path: Path, conf: Configuration): Option[LineScanner] = {
     path.getFileSystem(conf) match {
       case localFS: LocalFileSystem =>

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HdfsUtilsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HdfsUtilsSpec.scala
@@ -18,8 +18,9 @@ class HdfsUtilsSpec extends FunSpec
       zipped.filter(x => x._1 != x._2)
     }
 
-    val hdfsFile = new Path("raster-test/data/geotiff-test-files/ls8_int32.tif")
-    val array = Filesystem.slurp("raster-test/data/geotiff-test-files/ls8_int32.tif")
+    val path = "spark/src/test/resources/all-ones.tif"
+    val hdfsFile = new Path(path)
+    val array = Filesystem.slurp(path)
 
     it("should not crash with unuseful error messages when no files match listFiles") {
       val path = new Path("/this/does/not/exist") // Would be really weird if this did.

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HdfsUtilsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HdfsUtilsSpec.scala
@@ -2,6 +2,7 @@ package geotrellis.spark.io.hadoop
 
 import java.io.IOException
 
+import geotrellis.util.Filesystem
 import geotrellis.spark._
 import org.scalatest._
 import org.apache.hadoop.fs.Path
@@ -11,9 +12,43 @@ class HdfsUtilsSpec extends FunSpec
     with TestEnvironment
 {
   describe("HdfsUtils") {
+
+    def testArrays[T](arr1: Array[T], arr2: Array[T]): Array[(T, T)] = {
+      val zipped = arr1.zip(arr2)
+      zipped.filter(x => x._1 != x._2)
+    }
+
+    val hdfsFile = new Path("raster-test/data/geotiff-test-files/ls8_int32.tif")
+    val array = Filesystem.slurp("raster-test/data/geotiff-test-files/ls8_int32.tif")
+
     it("should not crash with unuseful error messages when no files match listFiles") {
       val path = new Path("/this/does/not/exist") // Would be really weird if this did.
       an[IOException] should be thrownBy { HdfsUtils.listFiles(path, conf) }
+    }
+    
+    it("should read the wole file if given whole file length") {
+      val actual = HdfsUtils.readRange(hdfsFile, 0, array.length, conf)
+      
+      val result = testArrays(array, actual)
+
+      result.length should be (0)
+    }
+    
+    it("should return an Array[Byte] of the correct size") {
+      val actual = HdfsUtils.readRange(hdfsFile, 500, 500, conf)
+      
+      actual.length should be (500)
+    }
+
+    it("should read the correct range of bytes from a file") {
+      val expected = Array.ofDim[Byte](500)
+      val actual = HdfsUtils.readRange(hdfsFile, 500, 500, conf)
+      
+      System.arraycopy(array, 500, expected, 0, expected.length)
+
+      val result = testArrays(expected, actual)
+
+      result.length should be (0)
     }
   }
 }


### PR DESCRIPTION
This PR adds a rangeRead method to HdfsUtils that allows for reading ranges of bytes.