### PR TITLE
Crop Iterator for GeoTiffs

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/MultibandCropIteratorSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/MultibandCropIteratorSpec.scala
@@ -1,0 +1,120 @@
+package geotrellis.raster.io.geotiff
+
+import geotrellis.raster._
+import geotrellis.raster.testkit._
+import geotrellis.raster.io.geotiff.reader._
+
+import spire.syntax.cfor._
+import org.scalatest._
+
+class MultibandCropIteratorSpec extends FunSpec
+  with Matchers
+  with RasterMatchers
+  with GeoTiffTestUtils {
+
+  describe("Doing a crop iteration on a MultibandGeoTiff") {
+    val path = geoTiffPath("3bands/3bands-striped-band.tif")
+    val geoTiff = MultibandGeoTiff(path)
+    val cols = geoTiff.imageData.cols
+    val rows = geoTiff.imageData.rows
+
+    it("should return the correct col and row iteration numbers for divisble subsections") {
+      val windowedCols = 10
+      val windowedRows = 20
+      val multibandIterator = MultibandCropIterator(geoTiff, windowedCols, windowedRows)
+      val actual = (multibandIterator.colIterations, multibandIterator.rowIterations)
+      val expected = (cols / windowedCols, rows / windowedRows)
+
+      actual should be (expected)
+    }
+
+    it("should return the correct col and row iteration numbers for nondivisble subsections") {
+      val windowedCols = 700
+      val windowedRows = 650
+      val multibandIterator = MultibandCropIterator(geoTiff, windowedCols, windowedRows)
+      val actual = (multibandIterator.colIterations, multibandIterator.rowIterations)
+      val expected = (1, 1)
+
+      actual should be (expected)
+    }
+
+    it("should return the correct windowedGeoTiffs with equal dimensions") {
+      val windowedCols = 10
+      val windowedRows = 10
+      val multibandIterator =
+        MultibandCropIterator(geoTiff, windowedCols, windowedRows)
+
+      val expected: Array[MultibandTile] =
+        Array(geoTiff.crop(0, 0, 10, 10),
+          geoTiff.crop(10, 0, 20, 10),
+          geoTiff.crop(0, 10, 10, 20),
+          geoTiff.crop(10, 10, 20, 20),
+          geoTiff.crop(0, 20, 10, 30),
+          geoTiff.crop(10, 20, 20, 30),
+          geoTiff.crop(0, 30, 10, 40),
+          geoTiff.crop(10, 30, 20, 40))
+
+      val actual: Array[MultibandTile] =
+        Array(multibandIterator.next,
+          multibandIterator.next, 
+          multibandIterator.next, 
+          multibandIterator.next, 
+          multibandIterator.next, 
+          multibandIterator.next, 
+          multibandIterator.next, 
+          multibandIterator.next)
+
+      cfor(0)(_ < actual.length, _ + 1) { i =>
+        assertEqual(expected(i), actual(i))
+      }
+    }
+    
+    it("should return the whole thing if the inputted dimensions are larger than the cols and rows") {
+      val windowedCols = 25
+      val windowedRows = 50
+      val multibandIterator = MultibandCropIterator(geoTiff, windowedCols, windowedRows)
+
+      val expected = geoTiff.tile
+      val actual = multibandIterator.next
+
+      assertEqual(expected, actual)
+    }
+
+    it("should return the correct windowedGeoTiffs with different dimensions") {
+      val windowedCols = 15
+      val windowedRows = 25
+      val multibandIterator =
+        new MultibandCropIterator(geoTiff, windowedCols, windowedRows)
+
+      val expected: Array[MultibandTile] =
+        Array(geoTiff.crop(0, 0, 15, 25),
+          geoTiff.crop(15, 0, 20, 25),
+          geoTiff.crop(0, 25, 15, 40),
+          geoTiff.crop(15, 25, 20, 40))
+
+      val actual: Array[MultibandTile] =
+        Array(multibandIterator.next,
+          multibandIterator.next, 
+          multibandIterator.next, 
+          multibandIterator.next)
+      
+      cfor(0)(_ < actual.length, _ + 1) { i =>
+        assertEqual(expected(i), actual(i))
+      }
+    }
+    
+    it("should say that there is another value when one actually exists") {
+      val windowedCols = 15
+      val windowedRows = 25
+      val multibandIterator =
+        new MultibandCropIterator(geoTiff, windowedCols, windowedRows)
+
+      cfor(0)(_ < 3, _ + 1) { i =>
+        multibandIterator.next
+        multibandIterator.hasNext should be (true)
+      }
+      multibandIterator.next
+      multibandIterator.hasNext should be (false)
+    }
+  }
+}

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/SinglebandCropIteratorSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/SinglebandCropIteratorSpec.scala
@@ -1,0 +1,117 @@
+package geotrellis.raster.io.geotiff
+
+import geotrellis.raster._
+import geotrellis.raster.testkit._
+import geotrellis.raster.io.geotiff.reader._
+
+import spire.syntax.cfor._
+import org.scalatest._
+
+class SinglebandCropIteratorSpec extends FunSpec
+  with Matchers
+  with RasterMatchers
+  with GeoTiffTestUtils {
+
+  describe("Doing a crop iteration on a SinglebandGeoTiff") {
+    val path = geoTiffPath("ls8_int32.tif")
+    val geoTiff = SinglebandGeoTiff(path)
+    val cols = geoTiff.imageData.cols
+    val rows = geoTiff.imageData.rows
+    
+    it("should return the correct col and row iteration numbers for divisble subsections") {
+      val windowedCols = 32
+      val windowedRows = 32
+      val singlebandIterator = new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
+      val actual = (singlebandIterator.colIterations, singlebandIterator.rowIterations)
+      val expected = (16, 16)
+
+      actual should be (expected)
+    }
+
+    it("should return the correct col and row iteration numbers for nondivisble subsections") {
+      val windowedCols = 700
+      val windowedRows = 650
+      val singlebandIterator = new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
+      val actual = (singlebandIterator.colIterations, singlebandIterator.rowIterations)
+      val expected = (1, 1)
+
+      actual should be (expected)
+    }
+
+    it("should return the correct windowedGeoTiffs with equal dimensions") {
+      val windowedCols = 256
+      val windowedRows = 256
+      val singlebandIterator =
+        new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
+
+      val expected: Array[Tile] =
+        Array(geoTiff.crop(0, 0, 256, 256),
+          geoTiff.crop(256, 0, 512, 256),
+          geoTiff.crop(0, 256, 256, 512),
+          geoTiff.crop(256, 256, 512, 512))
+
+      val actual: Array[Tile] =
+        Array(singlebandIterator.next,
+          singlebandIterator.next, 
+          singlebandIterator.next, 
+          singlebandIterator.next)
+
+      cfor(0)(_ < actual.length, _ + 1) { i =>
+        assertEqual(expected(i), actual(i))
+      }
+    }
+    
+    it("should return the whole thing if the inputted dimensions are larger than the cols and rows") {
+      val windowedCols = 950
+      val windowedRows = 1300
+      val singlebandIterator =
+        new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
+
+      val expected = geoTiff.tile
+      val actual = singlebandIterator.next
+
+      assertEqual(expected, actual)
+    }
+    
+    it("should return the correct windowedGeoTiffs with different dimensions") {
+      val windowedCols = 250
+      val windowedRows = 450
+      val singlebandIterator =
+        new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
+
+      val expected: Array[Tile] =
+        Array(geoTiff.crop(0, 0, 250, 450),
+          geoTiff.crop(250, 0, 500, 450),
+          geoTiff.crop(500, 0, 512, 450),
+          geoTiff.crop(0, 450, 250, 512),
+          geoTiff.crop(250, 450, 500, 512),
+          geoTiff.crop(500, 450, 512, 512))
+
+      val actual: Array[Tile] =
+        Array(singlebandIterator.next,
+          singlebandIterator.next, 
+          singlebandIterator.next, 
+          singlebandIterator.next, 
+          singlebandIterator.next, 
+          singlebandIterator.next)
+
+      cfor(0)(_ < actual.length, _ + 1) { i =>
+        assertEqual(expected(i), actual(i))
+      }
+    }
+    
+    it("should say that there is another value when one actually exists") {
+      val windowedCols = 256
+      val windowedRows = 256
+      val singlebandIterator =
+        new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
+
+      cfor(0)(_ < 3, _ + 1) { i =>
+        singlebandIterator.next
+        singlebandIterator.hasNext should be (true)
+      }
+      singlebandIterator.next
+      singlebandIterator.hasNext should be (false)
+    }
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/CropIterator.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/CropIterator.scala
@@ -1,0 +1,74 @@
+package geotrellis.raster.io.geotiff
+
+import geotrellis.raster._
+
+/**
+ * This class is an extension of [[Iterator]] where it takes a GeoTif and the
+ * size of the sub tiles which the file should be broken up into. The returned
+ * values are these sub tiles.
+ *
+ * @param geoTiff: [[GeoTiff]] of type T <: [[CellGrid]]
+ * @param widnowedCols: An Int that is max col size of the sub-tiles.
+ * @param widnowedRows: An Int that is max row size of the sub-tiles.
+ * @return: An [[Iterator]] that conatins [[GeoTiff]]s of type T.
+ */
+abstract class CropIterator[T <: CellGrid](geoTiff: GeoTiff[T],
+  windowedCols: Int,
+  windowedRows: Int) extends Iterator[GeoTiff[T]] {
+
+  private val wholeCols: Int = geoTiff.imageData.cols
+  private val wholeRows: Int = geoTiff.imageData.rows
+
+  def colIterations: Int =
+    if (wholeCols % windowedCols == 0)
+      wholeCols / windowedCols
+    else
+      wholeCols / windowedCols + 1
+  
+  def rowIterations: Int =
+    if (wholeRows % windowedRows == 0)
+      wholeRows / windowedRows
+    else
+      wholeRows / windowedRows + 1
+
+  var colCount: Int = 0
+  var rowCount: Int = 0
+ 
+  var colMin: Int = 0
+  var rowMin: Int = 0
+
+  var colMax: Int = math.min(windowedCols, wholeCols)
+  var rowMax: Int = math.min(windowedRows, wholeRows)
+
+  private var overallColCount: Int = 1
+  private var overallRowCount: Int = 1
+  
+  def adjustValues: Unit = {
+    if (colCount + 1 == colIterations) {
+      colCount = 0
+      rowCount += 1
+      overallColCount += 1
+      overallRowCount += 1
+    } else {
+      colCount += 1
+      overallColCount += 1
+    }
+
+    colMin = math.min(windowedCols * colCount, wholeCols)
+    rowMin = math.min(windowedRows * rowCount, wholeRows)
+
+    colMax =
+      math.min(windowedCols + (windowedCols * colCount), wholeCols)
+    rowMax =
+      math.min(windowedRows + (windowedRows * rowCount), wholeRows)
+  }
+  
+  def hasNext: Boolean =
+    if (overallColCount <= colIterations || overallRowCount <= rowIterations) {
+      true
+    } else {
+      false
+    }
+
+  def next: GeoTiff[T]
+}

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandCropIterator.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandCropIterator.scala
@@ -1,0 +1,53 @@
+package geotrellis.raster.io.geotiff
+
+import geotrellis.util.ByteReader
+import geotrellis.raster._
+
+/**
+ * An extension of [[CropIterator]], this subclass works specifically with
+ * multibandGeoTiffs.
+ *
+ * @param geoTiff: A [[MultibandGeoTiff]] file.
+ * @param widnowedCols: An Int that is max col size of the sub-tiles.
+ * @param widnowedRows: An Int that is max row size of the sub-tiles.
+ * @return: An [[Iterator]] that conatins [[MultibandGeoTiff]]s.
+ *
+ */
+class MultibandCropIterator(geoTiff: MultibandGeoTiff,
+  windowedCols: Int,
+  windowedRows: Int) extends CropIterator(geoTiff, windowedCols, windowedRows) {
+
+  def next: MultibandGeoTiff = {
+    if (hasNext) {
+      if (colCount + 1 > colIterations)
+        adjustValues
+      
+      val result: MultibandGeoTiff = geoTiff.crop(colMin, rowMin, colMax, rowMax)
+      adjustValues
+      result
+    } else {
+      throw new Error("Iterator is empty")
+    }
+  }
+}
+
+/** the companion class of [[MultibandCropIterator]] */
+object MultibandCropIterator {
+  def apply(path: String, dimensions: (Int, Int)): MultibandCropIterator =
+    apply(MultibandGeoTiff.streaming(path), dimensions)
+
+  def apply(path: String, colMax: Int, rowMax: Int): MultibandCropIterator =
+    apply(MultibandGeoTiff.streaming(path), colMax, rowMax)
+
+  def apply(byteReader: ByteReader, dimensions: (Int, Int)): MultibandCropIterator =
+    apply(MultibandGeoTiff.streaming(byteReader), dimensions)
+  
+  def apply(byteReader: ByteReader, colMax: Int, rowMax: Int): MultibandCropIterator =
+    apply(MultibandGeoTiff.streaming(byteReader), colMax, rowMax)
+
+  def apply(geoTiff: MultibandGeoTiff, dimensions: (Int, Int)): MultibandCropIterator =
+    apply(geoTiff: MultibandGeoTiff, dimensions._1, dimensions._2)
+
+  def apply(geoTiff: MultibandGeoTiff, colMax: Int, rowMax: Int): MultibandCropIterator =
+    new MultibandCropIterator(geoTiff: MultibandGeoTiff, colMax, rowMax)
+}

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
@@ -30,6 +30,16 @@ case class MultibandGeoTiff(
 
     MultibandGeoTiff(raster, subExtent, this.crs, this.tags)
   }
+  
+  def crop(colMax: Int, rowMax: Int): MultibandGeoTiff =
+    crop(0, 0, colMax, rowMax)
+
+  def crop(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int): MultibandGeoTiff = {
+    val raster: Raster[MultibandTile] =
+      this.raster.crop(colMin, rowMin, colMax, rowMax)
+
+    MultibandGeoTiff(raster, raster._2, this.crs, this.tags)
+  }
 }
 
 object MultibandGeoTiff {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandCropIterator.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandCropIterator.scala
@@ -1,0 +1,53 @@
+package geotrellis.raster.io.geotiff
+
+import geotrellis.util.ByteReader
+import geotrellis.raster._
+
+/**
+ * An extension of [[CropIterator]], this subclass works specifically with
+ * multibandGeoTiffs.
+ *
+ * @param geoTiff: A [[SinglebandGeoTiff]] file.
+ * @param widnowedCols: An Int that is max col size of the sub-tiles.
+ * @param widnowedRows: An Int that is max row size of the sub-tiles.
+ * @return: An [[Iterator]] that conatins [[SinglebandGeoTiff]]s.
+ *
+ */
+class SinglebandCropIterator(geoTiff: SinglebandGeoTiff,
+  windowedCols: Int,
+  windowedRows: Int) extends CropIterator(geoTiff, windowedCols, windowedRows) {
+
+  def next: SinglebandGeoTiff = {
+    if (hasNext) {
+      if (colCount + 1 > colIterations)
+        adjustValues
+
+      val result: SinglebandGeoTiff = geoTiff.crop(colMin, rowMin, colMax, rowMax)
+      adjustValues
+      result
+    } else {
+      throw new Error("Iterator is empty")
+    }
+  }
+}
+
+/** the companion class of [[SinglebandCropIterator]] */
+object SinglebandCropIterator {
+  def apply(path: String, dimensions: (Int, Int)): SinglebandCropIterator =
+    apply(SinglebandGeoTiff.streaming(path), dimensions)
+
+  def apply(path: String, colMax: Int, rowMax: Int): SinglebandCropIterator =
+    apply(SinglebandGeoTiff.streaming(path), colMax, rowMax)
+
+  def apply(byteReader: ByteReader, dimensions: (Int, Int)): SinglebandCropIterator =
+    apply(SinglebandGeoTiff.streaming(byteReader), dimensions)
+  
+  def apply(byteReader: ByteReader, colMax: Int, rowMax: Int): SinglebandCropIterator =
+    apply(SinglebandGeoTiff.streaming(byteReader), colMax, rowMax)
+
+  def apply(geoTiff: SinglebandGeoTiff, dimensions: (Int, Int)): SinglebandCropIterator =
+    apply(geoTiff: SinglebandGeoTiff, dimensions._1, dimensions._2)
+
+  def apply(geoTiff: SinglebandGeoTiff, colMax: Int, rowMax: Int): SinglebandCropIterator =
+    new SinglebandCropIterator(geoTiff: SinglebandGeoTiff, colMax, rowMax)
+}

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
@@ -30,6 +30,16 @@ case class SinglebandGeoTiff(
 
     SinglebandGeoTiff(raster, subExtent, this.crs)
   }
+  
+  def crop(colMax: Int, rowMax: Int): SinglebandGeoTiff =
+    crop(0, 0, colMax, rowMax)
+
+  def crop(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int): SinglebandGeoTiff = {
+    val raster: Raster[Tile] =
+      this.raster.crop(colMin, rowMin, colMax, rowMax)
+
+    SinglebandGeoTiff(raster, raster._2, this.crs)
+  }
 }
 
 object SinglebandGeoTiff {


### PR DESCRIPTION
This PR adds a `CropIterator` abstract class and its two subclasses: `SinglebandCropIterator` and `MultibandCropIterator`. These new classes are extensions of `Iterator` that will take a GeoTiff and split it into multiple GeoTiffs based on inputted dimensions. The returned values will be these sub-tiles.