### PR TITLE
Reading Big GeoTiffs

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -4,23 +4,88 @@ import geotrellis.util._
 import geotrellis.raster.io.geotiff.reader._
 import geotrellis.raster._
 import geotrellis.raster.testkit._
+import geotrellis.vector.Extent
 
 import org.scalatest._
 
 class BigTiffSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
   describe("Reading BigTiffs") {
-    //val path2 = "raster-test/data/geotiff-test-files/bigtiffs/ls8_int32-big.tif"
-    //val path = "raster-test/data/geotiff-test-files/bigtiffs/bit_striped-big.tif"
-    //val path2 = "raster-test/data/geotiff-test-files/bigtiffs/all-ones-big.tif"
-    //val path2 = "raster-test/data/geotiff-test-files/bigtiffs/alaska-big.tif"
-    val path2 = "raster-test/data/geotiff-test-files/bigtiffs/green-1-big.tif"
+    val smallPath = "raster-test/data/geotiff-test-files/ls8_int32.tif"
+    val bigPath = "raster-test/data/geotiff-test-files/bigtiffs/ls8_int32-big.tif"
 
-    val path = "raster-test/data/geotiff-test-files/ls8_int32.tif"
-    val local = LocalBytesStreamer(path2, 25600000)
-    val reader = StreamByteReader(local)
-    println("\nNot Big")
-    println(TiffTagsReader.read(path2))
-    println("\nBig")
-    println(TiffTagsReader.read(reader))
+    val smallPathMulti = "raster-test/data/geotiff-test-files/multi.tif" 
+    val bigPathMulti = "raster-test/data/geotiff-test-files/bigtiffs/multi-big.tif" 
+
+    val chunkSize = 500
+
+    it("should read in the entire SinglebandGeoTiff") {
+      val local = LocalBytesStreamer(bigPath, chunkSize)
+      val reader = StreamByteReader(local)
+      val actual = SinglebandGeoTiff(reader)
+      val expected = SinglebandGeoTiff(smallPath)
+
+      assertEqual(actual, expected)
+    }
+    
+    it("should read in a cropped SinlebandGeoTiff from the edge") {
+      val local = LocalBytesStreamer(bigPath, chunkSize)
+      val reader = StreamByteReader(local)
+      val tiffTags = TiffTagsReader.read(smallPath)
+      val extent = tiffTags.extent
+      val e = Extent(extent.xmin, extent.ymin, extent.xmin + 100, extent.ymin + 100)
+
+      val actual = SinglebandGeoTiff(reader, e)
+      val expected = SinglebandGeoTiff(smallPath, e)
+
+      assertEqual(actual, expected)
+    }
+    
+    it("should read in a cropped SinglebandGeoTiff in the middle") {
+      val local = LocalBytesStreamer(bigPath, chunkSize)
+      val reader = StreamByteReader(local)
+      val tiffTags = TiffTagsReader.read(smallPath)
+      val extent = tiffTags.extent
+      val e = Extent(extent.xmin + 100 , extent.ymin + 100, extent.xmax - 250, extent.ymax - 250)
+
+      val actual = SinglebandGeoTiff(reader, e)
+      val expected = SinglebandGeoTiff(smallPath, e)
+
+      assertEqual(actual, expected)
+    }
+    
+    it("should read in the entire MultibandGeoTiff") {
+      val local = LocalBytesStreamer(bigPathMulti, chunkSize)
+      val reader = StreamByteReader(local)
+      val actual = MultibandGeoTiff(reader)
+      val expected = MultibandGeoTiff(smallPathMulti)
+
+      assertEqual(actual, expected)
+    }
+
+    it("should read in a cropped MultibandGeoTiff from the edge") {
+      val local = LocalBytesStreamer(bigPathMulti, chunkSize)
+      val reader = StreamByteReader(local)
+      val tiffTags = TiffTagsReader.read(smallPathMulti)
+      val extent = tiffTags.extent
+      val e = Extent(extent.xmin, extent.ymin, extent.xmin + 100, extent.ymin + 100)
+
+      val actual = MultibandGeoTiff(reader, e)
+      val expected = MultibandGeoTiff(smallPathMulti, e)
+
+      assertEqual(actual, expected)
+    }
+    
+    it("should read in a cropped MultibandGeoTiff in the middle") {
+      val local = LocalBytesStreamer(bigPathMulti, chunkSize)
+      val reader = StreamByteReader(local)
+      val tiffTags = TiffTagsReader.read(smallPathMulti)
+      val extent = tiffTags.extent
+      val e = Extent(extent.xmin + 100 , extent.ymin + 100, extent.xmax - 250, extent.ymax - 250)
+
+      val actual = MultibandGeoTiff(reader, e)
+      val expected = MultibandGeoTiff(smallPathMulti, e)
+
+      assertEqual(actual, expected)
+    }
   }
 }

--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -1,0 +1,26 @@
+package geotrellis.raster.io.geotiff
+
+import geotrellis.util._
+import geotrellis.raster.io.geotiff.reader._
+import geotrellis.raster._
+import geotrellis.raster.testkit._
+
+import org.scalatest._
+
+class BigTiffSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
+  describe("Reading BigTiffs") {
+    //val path2 = "raster-test/data/geotiff-test-files/bigtiffs/ls8_int32-big.tif"
+    //val path = "raster-test/data/geotiff-test-files/bigtiffs/bit_striped-big.tif"
+    //val path2 = "raster-test/data/geotiff-test-files/bigtiffs/all-ones-big.tif"
+    //val path2 = "raster-test/data/geotiff-test-files/bigtiffs/alaska-big.tif"
+    val path2 = "raster-test/data/geotiff-test-files/bigtiffs/green-1-big.tif"
+
+    val path = "raster-test/data/geotiff-test-files/ls8_int32.tif"
+    val local = LocalBytesStreamer(path2, 25600000)
+    val reader = StreamByteReader(local)
+    println("\nNot Big")
+    println(TiffTagsReader.read(path2))
+    println("\nBig")
+    println(TiffTagsReader.read(reader))
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/ArraySegmentBytes.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/ArraySegmentBytes.scala
@@ -44,15 +44,15 @@ object ArraySegmentBytes {
   def apply(byteReader: ByteReader, tiffTags: TiffTags): ArraySegmentBytes = {
 
       val compressedBytes: Array[Array[Byte]] = {
-        def readSections(offsets: Array[Int],
-          byteCounts: Array[Int]): Array[Array[Byte]] = {
+        def readSections(offsets: Array[Long],
+          byteCounts: Array[Long]): Array[Array[Byte]] = {
             val oldOffset = byteReader.position
 
             val result = Array.ofDim[Array[Byte]](offsets.size)
 
             cfor(0)(_ < offsets.size, _ + 1) { i =>
-              byteReader.position(offsets(i))
-              result(i) = byteReader.getSignedByteArray(byteCounts(i))
+              byteReader.position(offsets(i).toInt)
+              result(i) = byteReader.getSignedByteArray(byteCounts(i).toInt)
             }
 
             byteReader.position(oldOffset)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/BufferSegmentBytes.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/BufferSegmentBytes.scala
@@ -56,8 +56,8 @@ case class BufferSegmentBytes(byteReader: ByteReader, tiffTags: TiffTags) extend
    */
   def getSegment(i: Int) = {
     val oldOffset = byteReader.position
-    byteReader.position(offsets(i))
-    val result = byteReader.getSignedByteArray(byteCounts(i))
+    byteReader.position(offsets(i).toInt)
+    val result = byteReader.getSignedByteArray(byteCounts(i).toInt)
     byteReader.position(oldOffset)
     result
   }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
@@ -277,12 +277,18 @@ object GeoTiffReader {
 
     // Validate Tiff identification number
     val tiffIdNumber = byteReader.getChar
-    if (tiffIdNumber != 42)
-      throw new MalformedGeoTiffException(s"bad identification number (must be 42, was $tiffIdNumber)")
+    if (tiffIdNumber != 42 && tiffIdNumber != 43)
+      throw new MalformedGeoTiffException(s"bad identification number (must be 42 or 43, was $tiffIdNumber)")
 
-    val tagsStartPosition = byteReader.getInt
-
-    val tiffTags = TiffTagsReader.read(byteReader, tagsStartPosition)
+    val tiffTags = 
+      if (tiffIdNumber == 42) {
+        val smallStart = byteReader.getInt
+        TiffTagsReader.read(byteReader, smallStart)
+      } else {
+        byteReader.position(8)
+        val bigStart = byteReader.getLong
+        TiffTagsReader.read(byteReader, bigStart)
+      }
 
     val hasPixelInterleave = tiffTags.hasPixelInterleave
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -29,17 +29,28 @@ object TiffTagsReader {
 
     // Validate GeoTiff identification number
     val geoTiffIdNumber = byteReader.getChar
-    if ( geoTiffIdNumber != 42)
-      throw new MalformedGeoTiffException(s"bad identification number (must be 42, was $geoTiffIdNumber)")
+    if ( geoTiffIdNumber != 42 || geoTiffIdNumber != 43)
+      throw new MalformedGeoTiffException(s"bad identification number (must be 42 or 43, was $geoTiffIdNumber)")
 
-    val tagsStartPosition = byteReader.getInt
+    //val tagsStartPosition =
+    if (geoTiffIdNumber == 42) {
+      val smallOffset = byteReader.getInt
+      read(byteReader, smallOffset)
+    } else {
+      byteReader.position(8)
+      val bigOffset = byteReader.getLong
+      read(byteReader, bigOffset)
+    }
 
-    read(byteReader, tagsStartPosition)
+    //read(byteReader, tagsStartPosition)
   }
 
-  def read(byteReader: ByteReader, tagsStartPosition: Int): TiffTags = {
+  def read[T](byteReader: ByteReader, tagsStartPosition: T): TiffTags = {
 
-    byteReader.position(tagsStartPosition)
+    tagsStartPosition match {
+      case a: Int => byteReader.position(a)
+      case b: Long => byteReader.position(b)
+    }
 
     val tagCount = byteReader.getShort
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -62,12 +62,22 @@ object TiffTagsReader {
 
     cfor(0)(_ < tagCount, _ + 1) { i =>
       val tagMetadata =
-        TiffTagMetadata(
-          byteReader.getUnsignedShort, // Tag
-          byteReader.getUnsignedShort, // Type
-          byteReader.getInt,           // Count
-          byteReader.getInt            // Offset
-        )
+        tagsStartPosition match {
+          case _: Int =>
+            TiffTagMetadata(
+              byteReader.getUnsignedShort, // Tag
+              byteReader.getUnsignedShort, // Type
+              byteReader.getInt,           // Count
+              byteReader.getInt            // Offset
+            )
+          case _: Long =>
+            TiffTagMetadata(
+              byteReader.getUnsignedShort, // Tag
+              byteReader.getUnsignedShort, // Type
+              byteReader.getLong,           // Count
+              byteReader.getLong            // Offset
+            )
+        }
 
       if (tagMetadata.tag == codes.TagCodes.GeoKeyDirectoryTag)
         geoTags = Some(tagMetadata)
@@ -147,7 +157,7 @@ object TiffTagsReader {
 
       val oldPos = byteReader.position
 
-      val numberOfPoints = tagMetadata.length / 6
+      val numberOfPoints = tagMetadata.length.toInt / 6
 
       byteReader.position(tagMetadata.offset)
 
@@ -203,7 +213,7 @@ object TiffTagsReader {
     def readBytesTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
 
-      val bytes = byteReader.getByteArray(tagMetadata.length, tagMetadata.offset)
+      val bytes = byteReader.getByteArray(tagMetadata.length.toInt, tagMetadata.offset.toInt)
 
       tagMetadata.tag match {
         case DotRangeTag => tiffTags &|->
@@ -223,7 +233,7 @@ object TiffTagsReader {
 
       // Read string, but don't read in trailing 0
       val string =
-        byteReader.getString(tagMetadata.length, tagMetadata.offset).substring(0, tagMetadata.length - 1)
+        byteReader.getString(tagMetadata.length.toInt, tagMetadata.offset.toInt).substring(0, tagMetadata.length.toInt - 1)
 
       tagMetadata.tag match {
         case DateTimeTag => tiffTags &|->
@@ -266,8 +276,8 @@ object TiffTagsReader {
 
     def readShortsTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val shorts = byteReader.getShortArray(tagMetadata.length,
-        tagMetadata.offset)
+      val shorts = byteReader.getShortArray(tagMetadata.length.toInt,
+        tagMetadata.offset.toInt)
 
       tagMetadata.tag match {
         case SubfileTypeTag => tiffTags &|->
@@ -421,7 +431,7 @@ object TiffTagsReader {
 
     def readIntsTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val ints = byteReader.getIntArray(tagMetadata.length, tagMetadata.offset)
+      val ints = byteReader.getIntArray(tagMetadata.length.toInt, tagMetadata.offset.toInt)
 
       tagMetadata.tag match {
         case NewSubfileTypeTag => tiffTags &|->
@@ -492,7 +502,7 @@ object TiffTagsReader {
     
     def readLongsTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val longs = byteReader.getLongArray(tagMetadata.length, tagMetadata.offset)
+      val longs = byteReader.getLongArray(tagMetadata.length.toInt, tagMetadata.offset.toInt)
 
       tagMetadata.tag match {
         case StripOffsetsTag => tiffTags &|->
@@ -512,8 +522,8 @@ object TiffTagsReader {
 
     def readFractionalsTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val fractionals = byteReader.getFractionalArray(tagMetadata.length,
-        tagMetadata.offset)
+      val fractionals = byteReader.getFractionalArray(tagMetadata.length.toInt,
+        tagMetadata.offset.toInt)
 
       tagMetadata.tag match {
         case XResolutionTag => tiffTags &|->
@@ -547,8 +557,8 @@ object TiffTagsReader {
 
     def readSignedBytesTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val bytes = byteReader.getSignedByteArray(tagMetadata.length,
-        tagMetadata.offset)
+      val bytes = byteReader.getSignedByteArray(tagMetadata.length.toInt,
+        tagMetadata.offset.toInt)
 
       (tiffTags &|->
         TiffTags._nonStandardizedTags ^|->
@@ -557,7 +567,7 @@ object TiffTagsReader {
 
     def readUndefinedTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val bytes = byteReader.getSignedByteArray(tagMetadata.length, tagMetadata.offset)
+      val bytes = byteReader.getSignedByteArray(tagMetadata.length.toInt, tagMetadata.offset.toInt)
 
       tagMetadata.tag match {
         case JpegTablesTag => tiffTags &|->
@@ -572,8 +582,8 @@ object TiffTagsReader {
 
     def readSignedShortsTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val shorts = byteReader.getSignedShortArray(tagMetadata.length,
-        tagMetadata.offset)
+      val shorts = byteReader.getSignedShortArray(tagMetadata.length.toInt,
+        tagMetadata.offset.toInt)
 
       (tiffTags &|->
         TiffTags._nonStandardizedTags ^|->
@@ -582,8 +592,8 @@ object TiffTagsReader {
 
     def readSignedIntsTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val ints = byteReader.getSignedIntArray(tagMetadata.length,
-        tagMetadata.offset)
+      val ints = byteReader.getSignedIntArray(tagMetadata.length.toInt,
+        tagMetadata.offset.toInt)
 
       (tiffTags &|->
         TiffTags._nonStandardizedTags ^|->
@@ -592,8 +602,8 @@ object TiffTagsReader {
 
     def readSignedFractionalsTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val fractionals = byteReader.getSignedFractionalArray(tagMetadata.length,
-        tagMetadata.offset)
+      val fractionals = byteReader.getSignedFractionalArray(tagMetadata.length.toInt,
+        tagMetadata.offset.toInt)
 
       (tiffTags &|->
         TiffTags._nonStandardizedTags ^|->
@@ -604,8 +614,8 @@ object TiffTagsReader {
 
     def readFloatsTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val floats = byteReader.getFloatArray(tagMetadata.length,
-        tagMetadata.offset)
+      val floats = byteReader.getFloatArray(tagMetadata.length.toInt,
+        tagMetadata.offset.toInt)
 
       (tiffTags &|->
         TiffTags._nonStandardizedTags ^|->
@@ -616,7 +626,7 @@ object TiffTagsReader {
 
     def readDoublesTag(tiffTags: TiffTags,
       tagMetadata: TiffTagMetadata) = {
-      val doubles = byteReader.getDoubleArray(tagMetadata.length, tagMetadata.offset)
+      val doubles = byteReader.getDoubleArray(tagMetadata.length.toInt, tagMetadata.offset.toInt)
 
       tagMetadata.tag match {
         case ModelTransformationTag =>

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -29,7 +29,7 @@ object TiffTagsReader {
 
     // Validate GeoTiff identification number
     val geoTiffIdNumber = byteReader.getChar
-    if ( geoTiffIdNumber != 42 && geoTiffIdNumber != 43)
+    if (geoTiffIdNumber != 42 && geoTiffIdNumber != 43)
       throw new MalformedGeoTiffException(s"bad identification number (must be 42 or 43, was $geoTiffIdNumber)")
 
     if (geoTiffIdNumber == 42) {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -73,10 +73,10 @@ object TiffTagsReader {
             )
           case _: Long =>
             TiffTagMetadata(
-              byteReader.getUnsignedShort, // Tag
-              byteReader.getUnsignedShort, // Type
-              byteReader.getLong,           // Count
-              byteReader.getLong            // Offset
+              byteReader.getUnsignedShort,
+              byteReader.getUnsignedShort,
+              byteReader.getLong,
+              byteReader.getLong
             )
         }
 
@@ -467,10 +467,10 @@ object TiffTagsReader {
           BasicTags._rowsPerStrip set(ints(0))
         case StripOffsetsTag => tiffTags &|->
           TiffTags._basicTags ^|->
-          BasicTags._stripOffsets set(Some(ints/*.map(_.toInt)*/))
+          BasicTags._stripOffsets set(Some(ints))
         case StripByteCountsTag => tiffTags &|->
           TiffTags._basicTags ^|->
-          BasicTags._stripByteCounts set(Some(ints/*.map(_.toInt)*/))
+          BasicTags._stripByteCounts set(Some(ints))
         case FreeOffsetsTag => tiffTags &|->
           TiffTags._nonBasicTags ^|->
           NonBasicTags._freeOffsets set(Some(ints))
@@ -479,10 +479,10 @@ object TiffTagsReader {
           NonBasicTags._freeByteCounts set(Some(ints))
         case TileOffsetsTag => tiffTags &|->
           TiffTags._tileTags ^|->
-          TileTags._tileOffsets set(Some(ints/*.map(_.toInt)*/))
+          TileTags._tileOffsets set(Some(ints))
         case TileByteCountsTag => tiffTags &|->
           TiffTags._tileTags ^|->
-          TileTags._tileByteCounts set(Some(ints/*.map(_.toInt)*/))
+          TileTags._tileByteCounts set(Some(ints))
         case JpegQTablesTag => tiffTags &|->
           TiffTags._jpegTags ^|->
           JpegTags._jpegQTables set(Some(ints))

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -333,10 +333,10 @@ object TiffTagsReader {
           BasicTags._bitsPerSample set(shorts(0))
         case StripOffsetsTag => tiffTags &|->
           TiffTags._basicTags ^|->
-          BasicTags._stripOffsets set(Some(shorts))
+          BasicTags._stripOffsets set(Some(shorts.map(_.toLong)))
         case StripByteCountsTag => tiffTags &|->
           TiffTags._basicTags ^|->
-          BasicTags._stripByteCounts set(Some(shorts))
+          BasicTags._stripByteCounts set(Some(shorts.map(_.toLong)))
         case MinSampleValueTag => tiffTags &|->
           TiffTags._dataSampleFormatTags ^|->
           DataSampleFormatTags._minSampleValue set(Some(shorts.map(_.toLong)))
@@ -358,7 +358,7 @@ object TiffTagsReader {
           NonBasicTags._halftoneHints set(Some(shorts))
         case TileByteCountsTag => tiffTags &|->
           TiffTags._tileTags ^|->
-          TileTags._tileByteCounts set(Some(shorts))
+          TileTags._tileByteCounts set(Some(shorts.map(_.toLong)))
         case DotRangeTag => tiffTags &|->
           TiffTags._cmykTags ^|->
           CmykTags._dotRange set(Some(shorts))
@@ -439,10 +439,10 @@ object TiffTagsReader {
           BasicTags._rowsPerStrip set(ints(0))
         case StripOffsetsTag => tiffTags &|->
           TiffTags._basicTags ^|->
-          BasicTags._stripOffsets set(Some(ints.map(_.toInt)))
+          BasicTags._stripOffsets set(Some(ints/*.map(_.toInt)*/))
         case StripByteCountsTag => tiffTags &|->
           TiffTags._basicTags ^|->
-          BasicTags._stripByteCounts set(Some(ints.map(_.toInt)))
+          BasicTags._stripByteCounts set(Some(ints/*.map(_.toInt)*/))
         case FreeOffsetsTag => tiffTags &|->
           TiffTags._nonBasicTags ^|->
           NonBasicTags._freeOffsets set(Some(ints))
@@ -451,10 +451,10 @@ object TiffTagsReader {
           NonBasicTags._freeByteCounts set(Some(ints))
         case TileOffsetsTag => tiffTags &|->
           TiffTags._tileTags ^|->
-          TileTags._tileOffsets set(Some(ints.map(_.toInt)))
+          TileTags._tileOffsets set(Some(ints/*.map(_.toInt)*/))
         case TileByteCountsTag => tiffTags &|->
           TiffTags._tileTags ^|->
-          TileTags._tileByteCounts set(Some(ints.map(_.toInt)))
+          TileTags._tileByteCounts set(Some(ints/*.map(_.toInt)*/))
         case JpegQTablesTag => tiffTags &|->
           TiffTags._jpegTags ^|->
           JpegTags._jpegQTables set(Some(ints))

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -104,6 +104,12 @@ object TiffTagsReader {
         byteReader.readFloatsTag(tiffTags, tagMetadata)
       case (_, DoublesFieldType) =>
         byteReader.readDoublesTag(tiffTags, tagMetadata)
+      case (_, LongsFieldType) =>
+        byteReader.readIntsTag(tiffTags, tagMetadata)
+      case (_, SignedLongsFieldType) =>
+        byteReader.readIntsTag(tiffTags, tagMetadata)
+      case (_, IFDOffset) =>
+        byteReader.readIntsTag(tiffTags, tagMetadata)
     }
 
   implicit class ByteReaderTagReaderWrapper(val byteReader: ByteReader) extends AnyVal {
@@ -470,6 +476,26 @@ object TiffTagsReader {
         case tag => tiffTags &|->
           TiffTags._nonStandardizedTags ^|->
           NonStandardizedTags._longsMap modify(_ + (tag -> ints.map(_.toLong)))
+      }
+    }
+    
+    def readLongsTag(tiffTags: TiffTags,
+      tagMetadata: TiffTagMetadata) = {
+      val longs = byteReader.getLongArray(tagMetadata.length, tagMetadata.offset)
+
+      tagMetadata.tag match {
+        case StripOffsetsTag => tiffTags &|->
+          TiffTags._basicTags ^|->
+          BasicTags._stripOffsets set(Some(longs))
+        case StripByteCountsTag => tiffTags &|->
+          TiffTags._basicTags ^|->
+          BasicTags._stripByteCounts set(Some(longs))
+        case TileOffsetsTag => tiffTags &|->
+          TiffTags._tileTags ^|->
+          TileTags._tileOffsets set(Some(longs))
+        case TileByteCountsTag => tiffTags &|->
+          TiffTags._tileTags ^|->
+          TileTags._tileByteCounts set(Some(longs))
       }
     }
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/BasicTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/BasicTags.scala
@@ -13,8 +13,8 @@ case class BasicTags(
   resolutionUnit: Option[Int] = None,
   rowsPerStrip: Long = 1,
   samplesPerPixel: Int = 1,
-  stripByteCounts: Option[Array[Int]] = None,
-  stripOffsets: Option[Array[Int]] = None,
+  stripByteCounts: Option[Array[Long]] = None,
+  stripOffsets: Option[Array[Long]] = None,
   xResolution: Option[(Long, Long)] = None,
   yResolution: Option[(Long, Long)] = None
 )

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTagMetadata.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTagMetadata.scala
@@ -3,6 +3,6 @@ package geotrellis.raster.io.geotiff.tags
 case class TiffTagMetadata(
   tag: Int,
   fieldType: Int,
-  length: Int,
-  offset: Int
+  length: Long,
+  offset: Long
 )

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TileTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TileTags.scala
@@ -6,6 +6,6 @@ import monocle.macros.Lenses
 case class TileTags(
   tileWidth: Option[Long] = None,
   tileLength: Option[Long] = None,
-  tileOffsets: Option[Array[Int]] = None,
-  tileByteCounts: Option[Array[Int]] = None
+  tileOffsets: Option[Array[Long]] = None,
+  tileByteCounts: Option[Array[Long]] = None
 )

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/codes/TiffFieldType.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/codes/TiffFieldType.scala
@@ -14,7 +14,7 @@ object TiffFieldType {
   val SignedFractionalsFieldType = 10
   val FloatsFieldType = 11
   val DoublesFieldType = 12
-  val LongsFieldType = 16
+  val LongsFieldType = 16 // This is 64-bits
   val SignedLongsFieldType = 17
   val IFDOffset = 18
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/codes/TiffFieldType.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/codes/TiffFieldType.scala
@@ -14,5 +14,7 @@ object TiffFieldType {
   val SignedFractionalsFieldType = 10
   val FloatsFieldType = 11
   val DoublesFieldType = 12
-
+  val LongsFieldType = 16
+  val SignedLongsFieldType = 17
+  val IFDOffset = 18
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteReaderExtensions.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteReaderExtensions.scala
@@ -41,8 +41,8 @@ trait ByteReaderExtensions {
     final def getUnsignedShort: Int =
       byteReader.getChar.toInt
 
-    final def getByteArray(length: Int): Array[Short] = {
-      val arr = Array.ofDim[Short](length)
+    final def getByteArray(length: Long): Array[Short] = {
+      val arr = Array.ofDim[Short](length.toInt)
 
       cfor(0)( _ < length, _ + 1) { i =>
         arr(i) = ub2s(byteReader.get)
@@ -51,11 +51,11 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getByteArray(length: Int, valueOffset: Int): Array[Short] = {
-      val arr = Array.ofDim[Short](length)
+    final def getByteArray(length: Long, valueOffset: Long): Array[Short] = {
+      val arr = Array.ofDim[Short](length.toInt)
 
       if (length <= 4) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset)
+        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset.toInt)
         cfor(0)( _ < length, _ + 1) { i =>
           arr(i) = ub2s(bb.get)
         }
@@ -73,12 +73,11 @@ trait ByteReaderExtensions {
       arr
     }
 
-
-    final def getShortArray(length: Int, valueOffset: Int): Array[Int] = {
-      val arr = Array.ofDim[Int](length)
+    final def getShortArray(length: Long, valueOffset: Long): Array[Int] = {
+      val arr = Array.ofDim[Int](length.toInt)
 
       if (length <= 2) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset)
+        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset.toInt)
         cfor(0)(_ < length, _ + 1) { i =>
           arr(i) = us2i(bb.getShort)
         }
@@ -97,11 +96,11 @@ trait ByteReaderExtensions {
     }
 
     /** Get these as Longs, since they are unsigned and we might want to deal with values greater than Int.MaxValue */
-    final def getIntArray(length: Int, valueOffset: Int): Array[Long] = {
-      val arr = Array.ofDim[Long](length)
+    final def getIntArray(length: Long, valueOffset: Long): Array[Long] = {
+      val arr = Array.ofDim[Long](length.toInt)
 
       if (length == 1) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset)
+        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset.toInt)
         arr(0) = ui2l(bb.getInt)
       } else {
         val oldPos = byteReader.position
@@ -117,30 +116,30 @@ trait ByteReaderExtensions {
       arr
     }
     
-    final def getLongArray(length: Int, valueOffset: Int): Array[Long] = {
-      val arr = Array.ofDim[Long](length)
+    final def getLongArray(length: Long, valueOffset: Long): Array[Long] = {
+      val arr = Array.ofDim[Long](length.toInt)
 
       if (length <= 8) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset)
+        val bb = ByteBuffer.allocate(4).order(byteReader.order).putLong(0, valueOffset)
         arr(0) = bb.getLong
       } else {
-        val oldPos = byteReader.position
+      val oldPos = byteReader.position
 
-        byteReader.position(valueOffset)
-        cfor(0)(_ < length, _ + 1) { i =>
-          arr(i) = byteReader.getLong
-        }
+      byteReader.position(valueOffset)
+      cfor(0)(_ < length, _ + 1) { i =>
+        arr(i) = byteReader.getLong
+      }
 
-        byteReader.position(oldPos)
+      byteReader.position(oldPos)
       }
 
       arr
     }
 
-    final def getString(length: Int, offset: Int): String = {
+    final def getString(length: Long, offset: Long): String = {
       val sb = new StringBuilder
       if (length <= 4) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset)
+        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset.toInt)
         cfor(0)( _ < length, _ + 1) { i =>
           sb.append(bb.get.toChar)
         }
@@ -158,8 +157,8 @@ trait ByteReaderExtensions {
       sb.toString
     }
 
-    final def getFractionalArray(length: Int, offset: Int): Array[(Long, Long)] = {
-      val arr = Array.ofDim[(Long, Long)](length)
+    final def getFractionalArray(length: Long, offset: Long): Array[(Long, Long)] = {
+      val arr = Array.ofDim[(Long, Long)](length.toInt)
 
       val oldPos = byteReader.position
       byteReader.position(offset)
@@ -173,11 +172,11 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getSignedByteArray(length: Int, valueOffset: Int): Array[Byte] = {
-      val arr = Array.ofDim[Byte](length)
+    final def getSignedByteArray(length: Long, valueOffset: Long): Array[Byte] = {
+      val arr = Array.ofDim[Byte](length.toInt)
 
       if (length <= 4) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset)
+        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset.toInt)
         cfor(0)(_ < length, _ + 1) { i =>
           arr(i) = bb.get
         }
@@ -195,19 +194,19 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getSignedByteArray(length: Int): Array[Byte] = {
-      val arr = Array.ofDim[Byte](length)
+    final def getSignedByteArray(length: Long): Array[Byte] = {
+      val arr = Array.ofDim[Byte](length.toInt)
       cfor(0)(_ < length, _ + 1) { i =>
         arr(i) = byteReader.get
       }
       arr
     }
 
-    final def getSignedShortArray(length: Int, valueOffset: Int): Array[Short] = {
-      val arr = Array.ofDim[Short](length)
+    final def getSignedShortArray(length: Long, valueOffset: Long): Array[Short] = {
+      val arr = Array.ofDim[Short](length.toInt)
 
       if (length <= 2) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset)
+        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset.toInt)
         cfor(0)(_ < length, _ + 1) { i =>
           arr(i) = bb.getShort
         }
@@ -225,11 +224,11 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getSignedIntArray(length: Int, valueOffset: Int): Array[Int] = {
+    final def getSignedIntArray(length: Long, valueOffset: Long): Array[Int] = {
       val arr = Array.ofDim[Int](1)
 
       if (length == 1) {
-        arr(0) = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset).getInt
+        arr(0) = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset.toInt).getInt
       } else {
         val oldPos = byteReader.position
         byteReader.position(valueOffset)
@@ -244,8 +243,8 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getSignedFractionalArray(length: Int, offset: Int): Array[(Int, Int)] = {
-      val arr = Array.ofDim[(Int, Int)](length)
+    final def getSignedFractionalArray(length: Long, offset: Long): Array[(Int, Int)] = {
+      val arr = Array.ofDim[(Int, Int)](length.toInt)
 
       val oldPos = byteReader.position
       byteReader.position(offset)
@@ -259,11 +258,11 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getFloatArray(length: Int, valueOffset: Int): Array[Float] = {
-      val arr = Array.ofDim[Float](length)
+    final def getFloatArray(length: Long, valueOffset: Long): Array[Float] = {
+      val arr = Array.ofDim[Float](length.toInt)
 
       if (length <= 1) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset)
+        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset.toInt)
         cfor(0)(_ < length, _ + 1) { i =>
           arr(i) = bb.getFloat
         }
@@ -280,8 +279,8 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getDoubleArray(length: Int, offset: Int): Array[Double] = {
-      val arr = Array.ofDim[Double](length)
+    final def getDoubleArray(length: Long, offset: Long): Array[Double] = {
+      val arr = Array.ofDim[Double](length.toInt)
 
       val oldPos = byteReader.position
       byteReader.position(offset)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteReaderExtensions.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteReaderExtensions.scala
@@ -116,6 +116,26 @@ trait ByteReaderExtensions {
 
       arr
     }
+    
+    final def getLongArray(length: Int, valueOffset: Int): Array[Long] = {
+      val arr = Array.ofDim[Long](length)
+
+      if (length <= 8) {
+        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, valueOffset)
+        arr(0) = bb.getLong
+      } else {
+        val oldPos = byteReader.position
+
+        byteReader.position(valueOffset)
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = byteReader.getLong
+        }
+
+        byteReader.position(oldPos)
+      }
+
+      arr
+    }
 
     final def getString(length: Int, offset: Int): String = {
       val sb = new StringBuilder

--- a/s3-testkit/src/main/scala/geotrellis/spark/io/s3/testkit/MockS3ByteReader.scala
+++ b/s3-testkit/src/main/scala/geotrellis/spark/io/s3/testkit/MockS3ByteReader.scala
@@ -18,11 +18,11 @@ class MockS3ByteReader(mock: MockS3StreamBytes,
 
   var chunkBuffer = newByteBuffer(chunkArray)
 
-  def position = (offset + chunkBuffer.position).toInt
+  def position = offset + chunkBuffer.position
 
-  def position(newPoint: Int): Buffer = {
+  def position(newPoint: Long): Buffer = {
     if (isContained(newPoint)) {
-      chunkBuffer.position(newPoint - offset.toInt)
+      chunkBuffer.position((newPoint - offset).toInt)
     } else {
       accessCount += 1
       adjustChunk(newPoint)
@@ -33,7 +33,7 @@ class MockS3ByteReader(mock: MockS3StreamBytes,
   private def adjustChunk: Unit =
     adjustChunk(position)
 
-  private def adjustChunk(newPoint: Int): Unit = {
+  private def adjustChunk(newPoint: Long): Unit = {
     accessCount += 1
     chunk = mock.getMappedArray(newPoint)
     chunkBuffer = newByteBuffer
@@ -93,6 +93,6 @@ class MockS3ByteReader(mock: MockS3StreamBytes,
       case None => ByteBuffer.wrap(byteArray)
     }
 
-  def isContained(newPosition: Int): Boolean =
+  def isContained(newPosition: Long): Boolean =
     if (newPosition >= offset && newPosition <= offset + length) true else false
 }

--- a/util/src/main/scala/geotrellis/util/ByteReader.scala
+++ b/util/src/main/scala/geotrellis/util/ByteReader.scala
@@ -9,7 +9,6 @@ import scala.language.implicitConversions
  */
 trait ByteReader {
   def position: Long
-  //def position(i: Int): Buffer
   def position(i: Long): Buffer
 
   def get: Byte
@@ -31,7 +30,6 @@ object ByteReader {
   implicit def byteBuffer2ByteReader(byteBuffer: ByteBuffer): ByteReader = {
     new ByteReader() {
       def position: Long = byteBuffer.position.toLong
-      //def position(i: Int): Buffer = byteBuffer.position(i)
       def position(i: Long): Buffer = byteBuffer.position(i.toInt)
 
       def get = byteBuffer.get

--- a/util/src/main/scala/geotrellis/util/ByteReader.scala
+++ b/util/src/main/scala/geotrellis/util/ByteReader.scala
@@ -8,8 +8,9 @@ import scala.language.implicitConversions
  * source.
  */
 trait ByteReader {
-  def position: Int
-  def position(i: Int): Buffer
+  def position: Long
+  //def position(i: Int): Buffer
+  def position(i: Long): Buffer
 
   def get: Byte
   def getChar: Char
@@ -29,8 +30,9 @@ trait ByteReader {
 object ByteReader {
   implicit def byteBuffer2ByteReader(byteBuffer: ByteBuffer): ByteReader = {
     new ByteReader() {
-      def position: Int = byteBuffer.position
-      def position(i: Int): Buffer = byteBuffer.position(i)
+      def position: Long = byteBuffer.position.toLong
+      //def position(i: Int): Buffer = byteBuffer.position(i)
+      def position(i: Long): Buffer = byteBuffer.position(i.toInt)
 
       def get = byteBuffer.get
       def getChar = byteBuffer.getChar

--- a/util/src/main/scala/geotrellis/util/StreamByteReader.scala
+++ b/util/src/main/scala/geotrellis/util/StreamByteReader.scala
@@ -25,11 +25,11 @@ class StreamByteReader(bytesStreamer: BytesStreamer) extends ByteReader {
       case _ => throw new Exception("incorrect byte order")
     }
 
-  def position: Int = (offset + chunkBuffer.position).toInt
+  def position: Long = offset + chunkBuffer.position
 
-  def position(newPoint: Int): Buffer = {
+  def position(newPoint: Long): Buffer = {
     if (isContained(newPoint)) {
-      chunkBuffer.position(newPoint - offset.toInt)
+      chunkBuffer.position((newPoint - offset).toInt)
     } else {
       adjustChunk(newPoint)
       chunkBuffer.position(0)
@@ -39,7 +39,7 @@ class StreamByteReader(bytesStreamer: BytesStreamer) extends ByteReader {
   private def adjustChunk: Unit =
     adjustChunk(position)
 
-  private def adjustChunk(newPoint: Int): Unit = {
+  private def adjustChunk(newPoint: Long): Unit = {
     chunk = bytesStreamer.getMappedArray(newPoint)
     chunkBuffer = newByteBuffer(chunkArray)
   }
@@ -92,7 +92,7 @@ class StreamByteReader(bytesStreamer: BytesStreamer) extends ByteReader {
   private def newByteBuffer(byteArray: Array[Byte]) =
     ByteBuffer.wrap(byteArray).order(byteOrder)
 
-  private def isContained(newPosition: Int): Boolean =
+  private def isContained(newPosition: Long): Boolean =
     if (newPosition >= offset && newPosition <= offset + length) true else false
 }
 


### PR DESCRIPTION
This PR adds the ability for GeoTrellis to read Big, GeoTiff files. It is important to note that this **will only work with GeoTiffs**. Regular BigTiff files are currently not supported even though their smaller counterparts are. This is an issue that will be addressed and fixed in the near future.