### PR TITLE
Added save action to ETL

### DIFF
--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStore.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStore.scala
@@ -103,18 +103,8 @@ class AccumuloAttributeStore(val connector: Connector, val attributeTable: Strin
     connector.write(attributeTable, mutation)
   }
 
-  def layerExists(layerId: LayerId): Boolean = {
-    val scanner = connector.createScanner(attributeTable, new Authorizations())
-
-    try {
-      scanner.iterator.exists { kv =>
-        val Array(name, zoomStr) = kv.getKey.getRow.toString.split(SEP)
-        layerId == LayerId(name, zoomStr.toInt)
-      }
-    } finally {
-      scanner.close()
-    }
-  }
+  def layerExists(layerId: LayerId): Boolean =
+    !fetch(Some(layerId), AttributeStore.Fields.metadata).isEmpty
 
   def delete(layerId: LayerId): Unit = delete(layerId, None)
 

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraAttributeStore.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraAttributeStore.scala
@@ -129,6 +129,7 @@ class CassandraAttributeStore(val instance: CassandraInstance, val attributeKeys
       QueryBuilder.select.column("layerId")
         .from(attributeKeyspace, attributeTable)
         .where(eqs("layerId", layerIdString(layerId)))
+        .and(eqs("name", AttributeStore.Fields.metadata))
 
     session.execute(query).exists { key =>
       val List(name, zoomStr) = key.getString("layerId").split(SEP).toList

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseAttributeStore.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseAttributeStore.scala
@@ -100,9 +100,8 @@ class HBaseAttributeStore(val instance: HBaseInstance, val attributeTable: Strin
       table.put(put)
     }
 
-  def layerExists(layerId: LayerId): Boolean = instance.withTableConnectionDo(attributeTableName) {
-    !_.get(new Get(layerIdString(layerId))).isEmpty
-  }
+  def layerExists(layerId: LayerId): Boolean =
+    !fetch(Some(layerId), AttributeStore.Fields.metadata).isEmpty
 
   def delete(layerId: LayerId): Unit = delete(layerId, None)
 

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
@@ -79,7 +79,7 @@ class S3AttributeStore(val bucket: String, val prefix: String) extends BlobLayer
   def layerExists(layerId: LayerId): Boolean =
     s3Client
       .listObjectsIterator(bucket, path(prefix, "_attributes"))
-      .exists(_.getKey.endsWith(s"${SEP}${layerId.name}${SEP}${layerId.zoom}.json"))
+      .exists(_.getKey.endsWith(s"${AttributeStore.Fields.metadata}${SEP}${layerId.name}${SEP}${layerId.zoom}.json"))
 
   def delete(layerId: LayerId, attributeName: String): Unit = {
     if(!layerExists(layerId)) throw new LayerNotFoundError(layerId)

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
@@ -168,9 +168,11 @@ case class Etl(conf: EtlConf, @transient modules: Seq[TypedModule] = Etl.default
     * Saves provided RDD to an output module specified by the ETL arguments.
     * This step may perform two to one pyramiding until zoom level 1 is reached.
     *
-    * @param id        Layout ID to b
-    * @param rdd       Tiled raster RDD with TileLayerMetadata
-    * @param postSave  Function to allow saving additional attributes or layers per layer saved.
+    * @param id          Layout ID to b
+    * @param rdd         Tiled raster RDD with TileLayerMetadata
+    * @param saveAction  Function to be called for saving. Defaults to writing the layer.
+    *                    This gives the caller an oppurtunity to modify the layer before writing,
+    *                    or to save additional attributes in the attributes store.
     *
     * @tparam K  Key type with SpatialComponent corresponding LayoutDefinition
     * @tparam V  Tile raster with cells from single tile in LayoutDefinition

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/OutputPlugin.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/OutputPlugin.scala
@@ -8,7 +8,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
 trait OutputPlugin[K, V, M] extends Plugin {
-  import Etl.PostSaveHook
+  import Etl.SaveAction
 
   def name: String
 
@@ -20,12 +20,10 @@ trait OutputPlugin[K, V, M] extends Plugin {
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
     conf: EtlConf,
-    postSave: PostSaveHook[K, V, M] = PostSaveHook.EMPTY[K, V, M]
+    saveAction: SaveAction[K, V, M] = SaveAction.DEFAULT[K, V, M]
   ): Unit = {
     implicit val sc = rdd.sparkContext
-    val w = writer(conf)
-    w.write(id, rdd)
-    postSave(attributes(conf), w, id, rdd)
+    saveAction(attributes(conf), writer(conf), id, rdd)
   }
 
   def suitableFor(name: String): Boolean =

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/OutputPlugin.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/OutputPlugin.scala
@@ -8,15 +8,24 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
 trait OutputPlugin[K, V, M] extends Plugin {
+  import Etl.PostSaveHook
+
   def name: String
 
   def attributes(conf: EtlConf): AttributeStore
 
   def writer(conf: EtlConf)(implicit sc: SparkContext): Writer[LayerId, RDD[(K, V)] with Metadata[M]]
 
-  def apply(id: LayerId, rdd: RDD[(K, V)] with Metadata[M], conf: EtlConf): Unit = {
+  def apply(
+    id: LayerId,
+    rdd: RDD[(K, V)] with Metadata[M],
+    conf: EtlConf,
+    postSave: PostSaveHook[K, V, M] = PostSaveHook.EMPTY[K, V, M]
+  ): Unit = {
     implicit val sc = rdd.sparkContext
-    writer(conf).write(id, rdd)
+    val w = writer(conf)
+    w.write(id, rdd)
+    postSave(attributes(conf), w, id, rdd)
   }
 
   def suitableFor(name: String): Boolean =

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/SpatialRenderOutput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/SpatialRenderOutput.scala
@@ -7,6 +7,7 @@ import geotrellis.raster.render._
 import geotrellis.spark.etl.OutputPlugin
 import geotrellis.spark.io.index.KeyIndexMethod
 import geotrellis.spark._
+import geotrellis.spark.etl.Etl
 import geotrellis.spark.etl.config.{Backend, EtlConf}
 import geotrellis.spark.render._
 import geotrellis.spark.io.hadoop._
@@ -19,6 +20,8 @@ import org.apache.spark.rdd.RDD
 import scala.reflect._
 
 class SpatialRenderOutput extends OutputPlugin[SpatialKey, Tile, TileLayerMetadata[SpatialKey]] {
+  import Etl.PostSaveHook
+
   def name = "render"
   def key = classTag[SpatialKey]
   def attributes(conf: EtlConf) = null
@@ -45,8 +48,9 @@ class SpatialRenderOutput extends OutputPlugin[SpatialKey, Tile, TileLayerMetada
 
   override def apply(
     id: LayerId,
-    rdd: RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]],
-    conf: EtlConf
+    rdd: TileLayerRDD[SpatialKey],
+    conf: EtlConf,
+    postSave: PostSaveHook[SpatialKey, Tile, TileLayerMetadata[SpatialKey]] = PostSaveHook.EMPTY[SpatialKey, Tile, TileLayerMetadata[SpatialKey]]
   ): Unit = {
     val useS3 = getPath(conf.output.backend).path.take(5) == "s3://"
     val images =
@@ -54,16 +58,16 @@ class SpatialRenderOutput extends OutputPlugin[SpatialKey, Tile, TileLayerMetada
           case "png" =>
             parseColorMaps(conf.output.breaks) match {
               case Some(colorMap) =>
-                rdd.asInstanceOf[RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]]].renderPng(colorMap).mapValues(_.bytes)
+                rdd.renderPng(colorMap).mapValues(_.bytes)
               case None =>
-                rdd.asInstanceOf[RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]]].renderPng().mapValues(_.bytes)
+                rdd.renderPng().mapValues(_.bytes)
             }
           case "jpg" =>
             parseColorMaps(conf.output.breaks) match {
               case Some(colorMap) =>
-                rdd.asInstanceOf[RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]]].renderJpg(colorMap).mapValues(_.bytes)
+                rdd.renderJpg(colorMap).mapValues(_.bytes)
               case None =>
-                rdd.asInstanceOf[RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]]].renderJpg().mapValues(_.bytes)
+                rdd.renderJpg().mapValues(_.bytes)
             }
           case "geotiff" =>
             rdd.asInstanceOf[RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]]].renderGeoTiff().mapValues(_.toByteArray)
@@ -79,5 +83,6 @@ class SpatialRenderOutput extends OutputPlugin[SpatialKey, Tile, TileLayerMetada
     }
   }
 
+  // TODO: ??? means that the hierarchy is broke. Pipelining improvements should fix this.
   def writer(conf: EtlConf)(implicit sc: SparkContext) = ???
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/SpatialRenderOutput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/SpatialRenderOutput.scala
@@ -20,7 +20,7 @@ import org.apache.spark.rdd.RDD
 import scala.reflect._
 
 class SpatialRenderOutput extends OutputPlugin[SpatialKey, Tile, TileLayerMetadata[SpatialKey]] {
-  import Etl.PostSaveHook
+  import Etl.SaveAction
 
   def name = "render"
   def key = classTag[SpatialKey]
@@ -50,7 +50,7 @@ class SpatialRenderOutput extends OutputPlugin[SpatialKey, Tile, TileLayerMetada
     id: LayerId,
     rdd: TileLayerRDD[SpatialKey],
     conf: EtlConf,
-    postSave: PostSaveHook[SpatialKey, Tile, TileLayerMetadata[SpatialKey]] = PostSaveHook.EMPTY[SpatialKey, Tile, TileLayerMetadata[SpatialKey]]
+    saveAction: SaveAction[SpatialKey, Tile, TileLayerMetadata[SpatialKey]] = SaveAction.DEFAULT[SpatialKey, Tile, TileLayerMetadata[SpatialKey]]
   ): Unit = {
     val useS3 = getPath(conf.output.backend).path.take(5) == "s3://"
     val images =

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
@@ -65,7 +65,7 @@ class FileAttributeStore(val catalogPath: String) extends BlobLayerAttributeStor
       .listFiles(new WildcardFileFilter(s"${layerId.name}${SEP}${layerId.zoom}${SEP}*.json"): FileFilter)
 
   def layerExists(layerId: LayerId): Boolean =
-    layerAttributeFiles(layerId).nonEmpty
+    attributeFile(layerId, AttributeStore.Fields.metadata).exists
 
   def delete(layerId: LayerId, attributeName: String): Unit = {
     val layerFiles =

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
@@ -99,10 +99,7 @@ class HadoopAttributeStore(val rootPath: Path, val hadoopConfiguration: Configur
   def layerExists(layerId: LayerId): Boolean =
     HdfsUtils
       .listFiles(new Path(attributePath, s"*.json"), hadoopConfiguration)
-      .exists { path: Path =>
-        val List(name, zoomStr) = path.getName.split(SEP).take(2).toList
-        layerId == LayerId(name, zoomStr.toInt)
-      }
+      .exists { _ == attributePath(layerId, AttributeStore.Fields.metadata) }
 
   def delete(layerId: LayerId): Unit = {
     delete(layerId, new Path(s"${layerId.name}${SEP}${layerId.zoom}${SEP}*.json"))

--- a/spark/src/test/scala/geotrellis/spark/io/AttributeStoreSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/AttributeStoreSpec.scala
@@ -18,10 +18,10 @@ abstract class AttributeStoreSpec
   def attributeStore: AttributeStore
 
   it("should write to an attribute store") {
-    attributeStore.write(LayerId("test1", 1), "test-att1", "test")
-    attributeStore.write(LayerId("test2", 2), "test-att1", "test")
-    attributeStore.write(LayerId("test2", 2), "test-att2", "test")
-    attributeStore.write(LayerId("test3", 3), "test-att1", "test")
+    attributeStore.write(LayerId("test1", 1), "metadata", "test")
+    attributeStore.write(LayerId("test2", 2), "metadata", "test")
+    attributeStore.write(LayerId("test2", 2), "metadata", "test")
+    attributeStore.write(LayerId("test3", 3), "metadata", "test")
   }
 
   it("should know that these new IDs exist") {


### PR DESCRIPTION
This feature allows us to include client code in the save process for ETL. Lets us do things like:

```scala
    EtlConf(args) foreach { conf =>
      val etl = Etl(conf)

      val sourceTiles = etl.load[ProjectedExtent, Tile]
      val (zoom, tiled) = etl.tile[ProjectedExtent, Tile, SpatialKey](sourceTiles)

      etl.save[SpatialKey, Tile](LayerId(etl.input.name, zoom), tiled, { (attributeStore, layerWriter, layerId, rdd) =>
        // Save off histogram computed from zoom 9, store in zoom 0's attributes.
        if(layerId.zoom == 9) {
          val histogram = rdd.histogram(512)
          attributeStore.write(
            layerId.copy(zoom = 0),
            "histogram",
            histogram: Histogram[Double])
        }
      })
    }
```

which is otherwise very difficult to do in the ETL context.

__Also in this PR__

Changing the layerExists functionality on AttributeStore to check specifically for the metadata attribute, so that you can store attributes in layer IDs without that layer being considered as existing.