### PR TITLE
Add target CellType overload to Tile

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
@@ -127,8 +127,8 @@ trait ArrayTile extends Tile with Serializable {
     * @param   f  A function from Int to Int, executed at each point of the tile
     * @return     The result, a [[Tile]]
     */
-  def map(f: Int=>Int): Tile = {
-    val output = ArrayTile.alloc(cellType, cols, rows)
+  def map(ct: CellType)(f: Int=>Int): Tile = {
+    val output = ArrayTile.alloc(ct, cols, rows)
     var i = 0
     val len = size
     while (i < len) {
@@ -145,9 +145,9 @@ trait ArrayTile extends Tile with Serializable {
     * @param   f  A function from Double to Double, executed at each point of the tile
     * @return     The result, a [[Tile]]
     */
-  def mapDouble(f: Double => Double): Tile = {
+  def mapDouble(ct: CellType)(f: Double => Double): Tile = {
     val len = size
-    val tile = ArrayTile.alloc(cellType, cols, rows)
+    val tile = ArrayTile.alloc(ct, cols, rows)
     var i = 0
     while (i < len) {
       tile.updateDouble(i, f(applyDouble(i)))
@@ -218,19 +218,20 @@ trait ArrayTile extends Tile with Serializable {
     * and assign it to the output's (x, y) cell.
     *
     * @param   other  The other Tile
+    * @param   ct   Desired CellType of result tile
     * @param   f      A function from (Int, Int) to Int
     * @return         The result, an Tile
     */
-  def combine(other: Tile)(f: (Int, Int) => Int): Tile = {
+  def combine(other: Tile, ct: CellType)(f: (Int, Int) => Int): Tile = {
     other match {
-      case ar: ArrayTile =>
-        combine(ar)(f)
-      case ct: ConstantTile =>
-        ct.combine(this)(f)
-      case ct: CompositeTile =>
-        ct.combine(this)((z1, z2) => f(z2, z1))
-      case ct: CroppedTile =>
-        ct.combine(this)((z1, z2) => f(z2, z1))
+      case other: ArrayTile =>
+        combine(other, ct)(f)
+      case other: ConstantTile =>
+        other.combine(this, ct)(f)
+      case other: CompositeTile =>
+        other.combine(this, ct)((z1, z2) => f(z2, z1))
+      case other: CroppedTile =>
+        other.combine(this, ct)((z1, z2) => f(z2, z1))
     }
   }
 
@@ -244,10 +245,10 @@ trait ArrayTile extends Tile with Serializable {
     * @param   f      A function from (Double, Double) to Double
     * @return         The result, an ArrayTile
     */
-  def combineDouble(other: ArrayTile)(f: (Double, Double) => Double): ArrayTile = {
+  def combineDouble(other: ArrayTile, ct: CellType)(f: (Double, Double) => Double): ArrayTile = {
     (this, other).assertEqualDimensions
 
-    val output = ArrayTile.alloc(cellType.union(other.cellType), cols, rows)
+    val output = ArrayTile.alloc(ct, cols, rows)
     var i = 0
     val len = size
     while (i < len) {
@@ -267,14 +268,14 @@ trait ArrayTile extends Tile with Serializable {
     * @param   f      A function from (Double, Double) to Double
     * @return         The result, an Tile
     */
-  def combineDouble(other: Tile)(f: (Double, Double) => Double): Tile = {
+  def combineDouble(other: Tile, ct: CellType)(f: (Double, Double) => Double): Tile = {
     other match {
-      case ar: ArrayTile =>
-        combineDouble(ar)(f)
-      case ct: ConstantTile =>
-        ct.combineDouble(this)(f)
-      case ct: CompositeTile =>
-        ct.combineDouble(this)((z1, z2) => f(z2, z1))
+      case other: ArrayTile =>
+        combineDouble(other, ct)(f)
+      case other: ConstantTile =>
+        other.combineDouble(this, ct)(f)
+      case other: CompositeTile =>
+        other.combineDouble(this, ct)((z1, z2) => f(z2, z1))
     }
   }
 

--- a/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
@@ -17,11 +17,8 @@
 package geotrellis.raster
 
 import geotrellis.raster.split.Split
-import geotrellis.vector.Extent
-
 import spire.syntax.cfor._
 
-import scala.collection.mutable
 
 /**
   * The companion object for the [[CompositeTile]] type.
@@ -416,11 +413,12 @@ case class CompositeTile(tiles: Seq[Tile],
     * Map each cell in the given raster to a new one, using the given
     * function.
     *
-    * @param   f  A function from Int to Int, executed at each point of the tile
+    * @param   f      A function from Int to Int, executed at each point of the tile
+    * @param   ct Desired CellType of result tile
     * @return     The result, a [[Tile]]
     */
-  def map(f: Int => Int): Tile = {
-    val result = ArrayTile.alloc(cellType, cols, rows)
+  def map(ct: CellType)(f: Int => Int): Tile = {
+    val result = ArrayTile.alloc(ct, cols, rows)
     val layoutCols = tileLayout.layoutCols
     val layoutRows = tileLayout.layoutRows
     val tileCols = tileLayout.tileCols
@@ -449,8 +447,8 @@ case class CompositeTile(tiles: Seq[Tile],
     * @param   f  A function from Double to Double, executed at each point of the tile
     * @return     The result, a [[Tile]]
     */
-  def mapDouble(f: Double =>Double): Tile = {
-    val result = ArrayTile.alloc(cellType, cols, rows)
+  def mapDouble(ct: CellType)(f: Double =>Double): Tile = {
+    val result = ArrayTile.alloc(ct, cols, rows)
     val layoutCols = tileLayout.layoutCols
     val layoutRows = tileLayout.layoutRows
     val tileCols = tileLayout.tileCols
@@ -537,13 +535,14 @@ case class CompositeTile(tiles: Seq[Tile],
     * assign it to the output's (x, y) cell.
     *
     * @param   other  The other [[Tile]]
+    * @param   ct Desired CellType of result tile
     * @param   f      A function from (Int, Int) to Int, the respective arguments are from the respective Tiles
     * @return         The result, an Tile
     */
-  def combine(other: Tile)(f: (Int, Int) => Int): Tile = {
+  def combine(other: Tile, ct: CellType)(f: (Int, Int) => Int): Tile = {
     (this, other).assertEqualDimensions
 
-    val result = ArrayTile.alloc(cellType, cols, rows)
+    val result = ArrayTile.alloc(ct, cols, rows)
     val layoutCols = tileLayout.layoutCols
     val layoutRows = tileLayout.layoutRows
     val tileCols = tileLayout.tileCols
@@ -575,10 +574,10 @@ case class CompositeTile(tiles: Seq[Tile],
     * @param   f      A function from (Int, Int) to Int, the respective arguments are from the respective Tiles
     * @return         The result, an Tile
     */
-  def combineDouble(other: Tile)(f: (Double, Double) => Double): Tile = {
+  def combineDouble(other: Tile, ct: CellType)(f: (Double, Double) => Double): Tile = {
     (this, other).assertEqualDimensions
 
-    val result = ArrayTile.alloc(cellType, cols, rows)
+    val result = ArrayTile.alloc(ct, cols, rows)
     val layoutCols = tileLayout.layoutCols
     val layoutRows = tileLayout.layoutRows
     val tileCols = tileLayout.tileCols

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -151,7 +151,7 @@ trait ConstantTile extends Tile {
     * @param   f  A function from Int to Int, executed at each point of the tile
     * @return     The result, a [[Tile]]
     */
-  def map(f: Int => Int): Tile = IntConstantTile(f(iVal), cols, rows)
+  def map(ct: CellType)(f: Int => Int): Tile = IntConstantTile(f(iVal), cols, rows)
 
   /**
     * Combine two tiles' cells into new cells using the given integer
@@ -163,7 +163,7 @@ trait ConstantTile extends Tile {
     * @param   f      A function from (Int, Int) to Int
     * @return         The result, an Tile
     */
-  def combine(other: Tile)(f: (Int, Int) => Int): Tile = other.map(z => f(iVal, z))
+  def combine(other: Tile, ct: CellType)(f: (Int, Int) => Int): Tile = other.map(z => f(iVal, z))
 
   /**
     * Map each cell in the given tile to a new one, using the given
@@ -172,7 +172,7 @@ trait ConstantTile extends Tile {
     * @param   f  A function from Double to Double, executed at each point of the tile
     * @return     The result, a [[Tile]]
     */
-  def mapDouble(f: Double => Double): Tile = DoubleConstantTile(f(dVal), cols, rows)
+  def mapDouble(ct: CellType)(f: Double => Double): Tile = DoubleConstantTile(f(dVal), cols, rows)
 
   /**
     * Combine two tiles' cells into new cells using the given double
@@ -184,7 +184,8 @@ trait ConstantTile extends Tile {
     * @param   f      A function from (Int, Int) to Int
     * @return         The result, an Tile
     */
-  def combineDouble(other: Tile)(f: (Double, Double) => Double): Tile = other.mapDouble(z => f(dVal, z))
+  def combineDouble(other: Tile, ct: CellType)(f: (Double, Double) => Double): Tile =
+    other.mapDouble(z => f(dVal, z))
 
   /**
     * Map an [[IntTileMapper]] over the present tile.

--- a/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
@@ -16,12 +16,8 @@
 
 package geotrellis.raster
 
-import geotrellis.raster.resample._
 import geotrellis.vector.Extent
-
 import spire.syntax.cfor._
-import scala.collection.mutable
-
 
 /**
   * The companion object for the [[CroppedTile]] type.
@@ -268,8 +264,8 @@ case class CroppedTile(sourceTile: Tile,
     * @param   f  A function from Int to Int, executed at each point of the tile
     * @return     The result, a [[Tile]]
     */
-  def map(f: Int => Int): Tile = {
-    val tile = ArrayTile.alloc(cellType, cols, rows)
+  def map(target: CellType)(f: Int => Int): Tile = {
+    val tile = ArrayTile.alloc(target, cols, rows)
 
     cfor(0)(_ < rows, _ + 1) { row =>
       cfor(0)(_ < cols, _ + 1) { col =>
@@ -287,8 +283,8 @@ case class CroppedTile(sourceTile: Tile,
     * @param   f  A function from Double to Double, executed at each point of the tile
     * @return     The result, a [[Tile]]
     */
-  def mapDouble(f: Double => Double): Tile = {
-    val tile = ArrayTile.alloc(cellType, cols, rows)
+  def mapDouble(ct: CellType)(f: Double => Double): Tile = {
+    val tile = ArrayTile.alloc(ct, cols, rows)
 
     cfor(0)(_ < rows, _ + 1) { row =>
       cfor(0)(_ < cols, _ + 1) { col =>
@@ -341,10 +337,10 @@ case class CroppedTile(sourceTile: Tile,
     * @param   f      A function from (Int, Int) to Int
     * @return         The result, an Tile
     */
-  def combine(other: Tile)(f: (Int, Int) => Int): Tile = {
+  def combine(other: Tile, ct: CellType)(f: (Int, Int) => Int): Tile = {
     (this, other).assertEqualDimensions
 
-    val tile = ArrayTile.alloc(cellType, cols, rows)
+    val tile = ArrayTile.alloc(ct, cols, rows)
     cfor(0)(_ < rows, _ + 1) { row =>
       cfor(0)(_ < cols, _ + 1) { col =>
         tile.set(col, row, f(get(col, row), other.get(col, row)))
@@ -364,10 +360,10 @@ case class CroppedTile(sourceTile: Tile,
     * @param   f      A function from (Int, Int) to Int
     * @return         The result, an Tile
     */
-  def combineDouble(other: Tile)(f: (Double, Double) => Double): Tile = {
+  def combineDouble(other: Tile, ct: CellType)(f: (Double, Double) => Double): Tile = {
     (this, other).assertEqualDimensions
 
-    val tile = ArrayTile.alloc(cellType, cols, rows)
+    val tile = ArrayTile.alloc(ct, cols, rows)
     cfor(0)(_ < rows, _ + 1) { row =>
       cfor(0)(_ < cols, _ + 1) { col =>
         tile.setDouble(col, row, f(getDouble(col, row), other.getDouble(col, row)))

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
@@ -2,11 +2,7 @@ package geotrellis.raster.io.geotiff
 
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.compression._
-import geotrellis.raster.resample.ResampleMethod
 import geotrellis.raster.split._
-import geotrellis.vector.Extent
-
-import java.util.BitSet
 
 import spire.syntax.cfor._
 
@@ -238,7 +234,7 @@ abstract class GeoTiffTile(
    * @param f: A function that takes an Int and returns an Int
    * @return A [[GeoTiffTile]] that contains the newly mapped values
    */
-  def map(f: Int => Int): GeoTiffTile = {
+  def map(ct: CellType)(f: Int => Int): GeoTiffTile = {
     val arr = Array.ofDim[Array[Byte]](segmentCount)
     val compressor = compression.createCompressor(segmentCount)
     cfor(0)(_ < segmentCount, _ + 1) { segmentIndex =>
@@ -252,7 +248,7 @@ abstract class GeoTiffTile(
       compressor.createDecompressor(),
       segmentLayout,
       compression,
-      cellType
+      ct
     )
   }
 
@@ -263,7 +259,7 @@ abstract class GeoTiffTile(
    * @param f: A function that takes a Double and returns a Double
    * @return A [[GeoTiffTile]] that contains the newly mapped values
    */
-  def mapDouble(f: Double => Double): GeoTiffTile = {
+  def mapDouble(ct: CellType)(f: Double => Double): GeoTiffTile = {
     val arr = Array.ofDim[Array[Byte]](segmentCount)
     val compressor = compression.createCompressor(segmentCount)
     cfor(0)(_ < segmentCount, _ + 1) { segmentIndex =>
@@ -277,7 +273,7 @@ abstract class GeoTiffTile(
       compressor.createDecompressor(),
       segmentLayout,
       compression,
-      cellType
+      ct
     )
   }
 
@@ -392,7 +388,7 @@ abstract class GeoTiffTile(
    * @param f: A function that takes (Int, Int) and returns an Int
    * @return A [[Tile]] that contains the results of the given function
    */
-  def combine(other: Tile)(f: (Int, Int) => Int): Tile =
+  def combine(other: Tile, ct: CellType)(f: (Int, Int) => Int): Tile =
     other match {
       case otherGeoTiff: GeoTiffTile if segmentLayout.tileLayout == otherGeoTiff.segmentLayout.tileLayout =>
         // GeoTiffs with the same segment sizes, can map over segments.
@@ -412,7 +408,7 @@ abstract class GeoTiffTile(
           compressor.createDecompressor(),
           segmentLayout,
           compression,
-          cellType
+          ct
         )
       case _ =>
         this.map { (col, row, z) =>
@@ -428,7 +424,7 @@ abstract class GeoTiffTile(
    * @param f: A function that takes (Double, Double) and returns a Double
    * @return A [[Tile]] that contains the results of the given function
    */
-  def combineDouble(other: Tile)(f: (Double, Double) => Double): Tile =
+  def combineDouble(other: Tile, ct: CellType)(f: (Double, Double) => Double): Tile =
     other match {
       case otherGeoTiff: GeoTiffTile if segmentLayout.tileLayout == otherGeoTiff.segmentLayout.tileLayout =>
         // GeoTiffs with the same segment sizes, can map over segments.
@@ -448,7 +444,7 @@ abstract class GeoTiffTile(
           compressor.createDecompressor(),
           segmentLayout,
           compression,
-          cellType
+          ct
         )
       case _ =>
         this.mapDouble { (col, row, z) =>


### PR DESCRIPTION
Fixes: https://github.com/geotrellis/geotrellis/issues/1410

An acceptable solution is to provide a way to request a target `CellType` in general transformations like `map` and `combine` such that they can be used directly with operation functions. Propagating this extra parameter to the extension methods is too large an impact for an advanced feature.

```scala
trait UseCaseSomething {   
   def tile1: Tile 
   def tile2: Tile  
   tile1.map { x => x + 1 }
    tile1.map(IntCellType) { x => x + 1 }
   tile1.map(IntCellType) (BreakMap.forIntegers(m))
   tile1.map(FloatCellType) (BreakMap.forDouble(m))
     tile1.combine(tile2) { (v1, v2) => v1 + v2 }
    tile1.combine(tile2, IntCellType) { (v1, v2) => v1 + v2 } } 
    tile1.combine(tile2, IntCellType)(Add)
}
```

TODO:
 - [ ] Update tests for `Tile` / `GeoTiffTile` / `ConstantTile` / `CroppedTile` / `CompositeTile`
 - [ ] Fix `ConstantTile` map/combine needs to use `cellType`
 - [ ] `GeoTiff` tile needs to have `map(f, ct)` on `GeoTiffSegments`
 - [ ] Add `CellType` overloads to `MultibandTile`
 - [ ] Add tests to related tiles
 - [ ] Check impacted doc-strings for consistency with arg-list