### PR TITLE
Histogram Matching

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/matching/HistogramMatchingSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/matching/HistogramMatchingSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.matching
+
+import geotrellis.raster._
+import geotrellis.raster.histogram.StreamingHistogram
+
+import org.scalatest._
+
+
+class HistogramMatchingSpec extends FunSpec with Matchers
+{
+  describe("Histogram Matching") {
+
+    val sourceHistogram = {
+      val h = StreamingHistogram(42)
+      h.countItem(1, 1)
+      h.countItem(2, 2)
+      h.countItem(4, 3)
+      h.countItem(8, 4)
+      h.countItem(16, 5)
+      h
+    }
+
+    val targetHistogram = {
+      val h = StreamingHistogram(42)
+      h.countItem(1, 1)
+      h.countItem(2, 2)
+      h.countItem(3, 3)
+      h.countItem(4, 4)
+      h.countItem(5, 5)
+      h
+    }
+
+    val sourceHistograms = List(sourceHistogram, sourceHistogram)
+    val targetHistograms = List(targetHistogram, targetHistogram)
+
+    it("should work on floating-point rasters") {
+      val tile = DoubleArrayTile(Array[Double](16, 1, 2, 4, 8, 16), 2, 3)
+      val actual = tile.matchHistogram(sourceHistogram, targetHistogram)
+      val expected = DoubleArrayTile(Array[Double](5, 1, 2, 3, 4, 5), 2, 3)
+
+      actual.toArray.toList should be (expected.toArray.toList)
+    }
+
+    it("should work on unsigned integral rasters") {
+      val tile = UShortArrayTile(Array[Short](16, 1, 2, 4, 8, 16), 2, 3)
+      val actual = tile.matchHistogram(sourceHistogram, targetHistogram)
+      val expected = UShortArrayTile(Array[Short](5, 1, 2, 3, 4, 5), 2, 3)
+
+      actual.toArray.toList should be (expected.toArray.toList)
+    }
+
+    it("should work on signed integral rasters") {
+      val tile = ShortArrayTile(Array[Short](16, 1, 2, 4, 8, 16), 2, 3)
+      val actual = tile.matchHistogram(sourceHistogram, targetHistogram)
+      val expected = ShortArrayTile(Array[Short](5, 1, 2, 3, 4, 5), 2, 3)
+
+      actual.toArray.toList should be (expected.toArray.toList)
+    }
+
+    it("should work on multiband tiles") {
+      val band1 = ShortArrayTile(Array[Short](16, 1, 2, 4, 8, 16), 2, 3)
+      val band2 = ShortArrayTile(Array[Short](4, 8, 16, 16, 1, 2), 2, 3)
+      val tile = ArrayMultibandTile(band1, band2)
+      val actual = tile.matchHistogram(sourceHistograms, targetHistograms).bands.flatMap({ _.toArray.toList })
+      val expected = List(5, 1, 2, 3, 4, 5, 3, 4, 5, 5, 1, 2)
+
+      actual should be (expected)
+    }
+
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/equalization/HistogramEqualization.scala
+++ b/raster/src/main/scala/geotrellis/raster/equalization/HistogramEqualization.scala
@@ -15,7 +15,7 @@ object HistogramEqualization {
     * Comparison class for sorting an array of (label, cdf(label))
     * pairs by their label.
     */
-  private class _cmp extends java.util.Comparator[(Double, Double)] {
+  class BucketComparator extends java.util.Comparator[(Double, Double)] {
     // Compare the (label, cdf(label)) pairs by their labels
     def compare(left: (Double, Double), right: (Double, Double)): Int = {
       if (left._1 < right._1) -1
@@ -24,13 +24,13 @@ object HistogramEqualization {
     }
   }
 
-  private val cmp = new _cmp()
+  private val cmp = new BucketComparator()
 
   /**
     * An implementation of the transformation T referred to in the
     * citation given above.
     */
-  private def _T(cellType: CellType, cdf: Array[(Double, Double)])(x: Double): Double = {
+  private def transform(cellType: CellType, cdf: Array[(Double, Double)])(x: Double): Double = {
     val i = java.util.Arrays.binarySearch(cdf, (x, 0.0), cmp)
     val bits = cellType.bits
     val smallestCdf = cdf(0)._2
@@ -83,8 +83,8 @@ object HistogramEqualization {
     * @return            A singleband tile with improved contrast
     */
   def apply[T <: AnyVal](tile: Tile, histogram: Histogram[T]): Tile = {
-    val T = _T(tile.cellType, histogram.cdf)_
-    tile.mapDouble(T)
+    val localTransform = transform(tile.cellType, histogram.cdf)_
+    tile.mapDouble(localTransform)
   }
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/equalization/HistogramEqualization.scala
+++ b/raster/src/main/scala/geotrellis/raster/equalization/HistogramEqualization.scala
@@ -12,10 +12,10 @@ import geotrellis.raster.histogram.StreamingHistogram
 object HistogramEqualization {
 
   /**
-    * Comparison class for sorting an array of (label, cdf(label))
-    * pairs by their label.
+    * Comparison class for sorting an array of (x, cdf(x))
+    * pairs by x label.
     */
-  class BucketComparator extends java.util.Comparator[(Double, Double)] {
+  private class BucketComparator extends java.util.Comparator[(Double, Double)] {
     // Compare the (label, cdf(label)) pairs by their labels
     def compare(left: (Double, Double), right: (Double, Double)): Int = {
       if (left._1 < right._1) -1
@@ -24,13 +24,18 @@ object HistogramEqualization {
     }
   }
 
-  private val cmp = new BucketComparator()
+  private val cmp = new BucketComparator
 
   /**
-    * An implementation of the transformation T referred to in the
-    * citation given above.
+    * Given a [[CellType]] and a CDF, this function produces a
+    * function that takes an intensity x to CDF(x).
+    *
+    * @param  cellType  The CellType in which the intensity x is given
+    * @param  cdf       The CDF
+    * @param  x         An intensity value which is mapped to CDF(x) by the returned function
+    * @return           A function from Double => Double which maps x to CDF(x)
     */
-  private def transform(cellType: CellType, cdf: Array[(Double, Double)])(x: Double): Double = {
+  @inline def intensityToCdf(cellType: CellType, cdf: Array[(Double, Double)])(x: Double): Double = {
     val i = java.util.Arrays.binarySearch(cdf, (x, 0.0), cmp)
     val bits = cellType.bits
     val smallestCdf = cdf(0)._2
@@ -51,17 +56,40 @@ object HistogramEqualization {
         val t = (x - cdf0) / (cdf1 - cdf0)
         (1.0-t)*cdf0 + t*cdf1
       }
-    val normalizedCdf = math.max(0.0, math.min(1.0, (rawCdf - smallestCdf) / (1.0 - smallestCdf)))
+
+    math.max(0.0, math.min(1.0, (rawCdf - smallestCdf) / (1.0 - smallestCdf)))
+  }
+
+  /**
+    * Given a [[CellType]] and an intensity value in the unit
+    * interval, this function returns an corresponding intensity value
+    * appropriately scaled for the given cell type.
+    */
+  @inline def toIntensity(cellType: CellType, x: Double): Double = {
+    val bits = cellType.bits
 
     cellType match {
-      case _: FloatCells => (Float.MaxValue * (2*normalizedCdf - 1.0))
-      case _: DoubleCells => (Double.MaxValue * (2*normalizedCdf - 1.0))
+      case _: FloatCells => (Float.MaxValue * (2*x - 1.0))
+      case _: DoubleCells => (Double.MaxValue * (2*x - 1.0))
       case _: BitCells | _: UByteCells | _: UShortCells =>
-        ((1<<bits) - 1) * normalizedCdf
+        ((1<<bits) - 1) * x
       case _: ByteCells | _: ShortCells | _: IntCells =>
-        (((1<<bits) - 1) * normalizedCdf) - (1<<(bits-1))
+        (((1<<bits) - 1) * x) - (1<<(bits-1))
     }
   }
+
+  /**
+    * When a function from intensity to the CDF is given as input,
+    * this function implements of the transformation T referred to
+    * in the citation given above.
+    *
+    * @param  cellType  The [[CellType]] of the output of the returned function
+    * @param  fn        A function from Double => Double which takes an intensity value x to CDF(x)
+    * @param  x         A value CDF(x) which is mapped to an intensity value
+    * @return           A function Double => Double which takes CDF(x) and returns an intensity value
+    */
+  @inline private def transform(cellType: CellType, fn: (Double => Double))(x: Double): Double =
+    toIntensity(cellType, fn(x))
 
   /**
     * Given a [[Tile]], return a Tile with an equalized histogram.
@@ -83,7 +111,8 @@ object HistogramEqualization {
     * @return            A singleband tile with improved contrast
     */
   def apply[T <: AnyVal](tile: Tile, histogram: Histogram[T]): Tile = {
-    val localTransform = transform(tile.cellType, histogram.cdf)_
+    val localIntensityToCdf = intensityToCdf(tile.cellType, histogram.cdf)_
+    val localTransform = transform(tile.cellType, localIntensityToCdf)_
     tile.mapDouble(localTransform)
   }
 

--- a/raster/src/main/scala/geotrellis/raster/equalization/HistogramEqualization.scala
+++ b/raster/src/main/scala/geotrellis/raster/equalization/HistogramEqualization.scala
@@ -103,7 +103,8 @@ object HistogramEqualization {
   }
 
   /**
-    * Given a [[Tile]] and a [[Histogram[T]]], return a Tile with an
+    * Given a [[Tile]] and a
+    * [[geotrellis.raster.histogram.Histogram]], return a Tile with an
     * equalized histogram.
     *
     * @param  tile       A singleband tile
@@ -129,8 +130,9 @@ object HistogramEqualization {
   }
 
   /**
-    * Given a [[MultibandTile]] and a [[Histogram[T]]] for each of its
-    * bands, return a MultibandTile whose bands all have equalized
+    * Given a [[MultibandTile]] and a
+    * [[geotrellis.raster.histogram.Histogram]] for each of its bands,
+    * return a MultibandTile whose bands all have equalized
     * histograms.
     *
     * @param  tile        A multiband tile

--- a/raster/src/main/scala/geotrellis/raster/equalization/SinglebandEqualizationMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/equalization/SinglebandEqualizationMethods.scala
@@ -8,8 +8,8 @@ import geotrellis.util.MethodExtensions
 trait SinglebandEqualizationMethods extends MethodExtensions[Tile] {
 
   /**
-    * Given a [[StreamingHistogram]] derived from this [[Tile]],
-    * equalize the histogram of this tile.
+    * Given a [[geotrellis.raster.histogram.Histogram]] which
+    * summarizes this [[Tile]], equalize the histogram of this tile.
     *
     * @param  histogram  The histogram of this tile
     */

--- a/raster/src/main/scala/geotrellis/raster/equalization/SinglebandEqualizationMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/equalization/SinglebandEqualizationMethods.scala
@@ -1,6 +1,6 @@
 package geotrellis.raster.equalization
 
-import geotrellis.raster.histogram.StreamingHistogram
+import geotrellis.raster.histogram._
 import geotrellis.raster.Tile
 import geotrellis.util.MethodExtensions
 
@@ -13,7 +13,7 @@ trait SinglebandEqualizationMethods extends MethodExtensions[Tile] {
     *
     * @param  histogram  The histogram of this tile
     */
-  def equalize(histogram: StreamingHistogram): Tile = HistogramEqualization(self, histogram)
+  def equalize[T <: AnyVal](histogram: Histogram[T]): Tile = HistogramEqualization(self, histogram)
 
   /**
     * Equalize the histogram of this [[Tile]].

--- a/raster/src/main/scala/geotrellis/raster/histogram/StreamingHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/StreamingHistogram.scala
@@ -605,10 +605,10 @@ class StreamingHistogram(
     percentileBreaks(List(q)).head
 
   /**
-    * This method return the (approximate) quantile breaks of the
+    * This method returns the (approximate) quantile breaks of the
     * distribution of points that the histogram has seen so far.  It
     * is guaranteed that no value in the returned array will be
-    * outside the range minimum-maximum range of values seen.
+    * outside the minimum-maximum range of values seen.
     *
     * @param  num  The number of breaks desired
     */

--- a/raster/src/main/scala/geotrellis/raster/matching/HistogramMatching.scala
+++ b/raster/src/main/scala/geotrellis/raster/matching/HistogramMatching.scala
@@ -44,6 +44,17 @@ object HistogramMatching {
     else targetCdf(i)._1
   }
 
+  /**
+    * Given a [[Tile]], a source
+    * [[geotrellis.raster.histogram.Histogram]] (ostensibly that of
+    * the tile), and a target histogram, this function produces a tile
+    * whose histogram has been matched to the target histogram.
+    *
+    * @param  tile             The source tile
+    * @param  sourceHistogram  The ostensible histogram of the tile
+    * @param  targetHistogram  The target histogram of the output tile
+    * @return                  The histogram-matched tile
+    */
   def apply[T1 <: AnyVal, T2 <: AnyVal](
     tile: Tile,
     sourceHistogram: Histogram[T1],
@@ -56,6 +67,16 @@ object HistogramMatching {
     tile.mapDouble(localTransform)
   }
 
+  /**
+    * Given a [[Tile]] and a target
+    * [[geotrellis.raster.histogram.Histogram]], this function
+    * produces a tile whose histogram has been matched to the target
+    * histogram.
+    *
+    * @param  tile             The source tile
+    * @param  targetHistogram  The target histogram of the output tile
+    * @return                  The histogram-matched tile
+    */
   def apply[T <: AnyVal](tile: Tile, targetHistogram: Histogram[T]): Tile =
     HistogramMatching(
       tile,
@@ -63,6 +84,18 @@ object HistogramMatching {
       targetHistogram
     )
 
+  /**
+    * Given a [[MultibandTile]], a sequence of source
+    * [[geotrellis.raster.histogram.Histogram]] objects (ostensibly
+    * those of the bands of the tile), and a sequence of target
+    * histograms, this function produces a tile whose bands have been
+    * respectively matched to the target histograms.
+    *
+    * @param  tile              The source tile
+    * @param  sourceHistograms  The ostensible histograms of the bands of the tile
+    * @param  targetHistograms  The target histograms for the bands of the output tile
+    * @return                   The histogram-matched tile
+    */
   def apply[T1 <: AnyVal, T2 <: AnyVal](
     tile: MultibandTile,
     sourceHistograms: Seq[Histogram[T1]],
@@ -76,6 +109,16 @@ object HistogramMatching {
         })
     )
 
+  /**
+    * Given a [[MultibandTile]], and a sequence of target
+    * [[geotrellis.raster.histogram.Histogram]] objects, this function
+    * produces a tile whose bands have been respectively matched to
+    * the target histograms.
+    *
+    * @param  tile              The source tile
+    * @param  targetHistograms  The target histograms for the bands of the output tile
+    * @return                   The histogram-matched tile
+    */
   def apply[T <: AnyVal](
     tile: MultibandTile,
     targetHistograms: Seq[Histogram[T]]

--- a/raster/src/main/scala/geotrellis/raster/matching/HistogramMatching.scala
+++ b/raster/src/main/scala/geotrellis/raster/matching/HistogramMatching.scala
@@ -1,0 +1,94 @@
+package geotrellis.raster.matching
+
+import geotrellis.raster._
+import geotrellis.raster.histogram.Histogram
+import geotrellis.raster.histogram.StreamingHistogram
+import geotrellis.raster.equalization.HistogramEqualization._
+
+
+/**
+  * Uses the approach given here:
+  * http://fourier.eng.hmc.edu/e161/lectures/contrast_transform/node3.html
+  */
+object HistogramMatching {
+
+  /**
+    * Comparison class for sorting an array of (x, cdf(x))
+    * pairs by cdf(x).
+    */
+  private class BucketComparator extends java.util.Comparator[(Double, Double)] {
+    // Compare the (label, cdf(label)) pairs by their labels
+    def compare(left: (Double, Double), right: (Double, Double)): Int = {
+      if (left._2 < right._2) -1
+      else if (left._2 > right._2) 1
+      else 0
+    }
+  }
+
+  private val cmp = new BucketComparator
+
+  /**
+    * An implementation of the compound transformation referred to in
+    * the citation given above.  The idea is to transform from the
+    * source histogram to an equalized one, then transform from the
+    * equalized one to the target one via the inverse of the
+    * transformation that would equalize the target one.
+    */
+  @inline private def transform(
+    targetCdf: Array[(Double, Double)], fn: (Double => Double)
+  )(x: Double): Double = {
+    val cdfx = fn(x)
+    val i = java.util.Arrays.binarySearch(targetCdf, (0.0, cdfx), cmp)
+
+    if (i < 0) targetCdf(math.min(-(i+1), targetCdf.length-1))._1
+    else targetCdf(i)._1
+  }
+
+  def apply[T1 <: AnyVal, T2 <: AnyVal](
+    tile: Tile,
+    sourceHistogram: Histogram[T1],
+    targetHistogram: Histogram[T2]
+  ): Tile = {
+    val cellType = tile.cellType
+    val localIntensityToCdf = intensityToCdf(cellType, sourceHistogram.cdf)_
+    val localTransform = transform(targetHistogram.cdf, localIntensityToCdf)_
+
+    tile.mapDouble(localTransform)
+  }
+
+  def apply[T <: AnyVal](tile: Tile, targetHistogram: Histogram[T]): Tile =
+    HistogramMatching(
+      tile,
+      StreamingHistogram.fromTile(tile, 1<<17),
+      targetHistogram
+    )
+
+  def apply[T1 <: AnyVal, T2 <: AnyVal](
+    tile: MultibandTile,
+    sourceHistograms: Seq[Histogram[T1]],
+    targetHistograms: Seq[Histogram[T2]]
+  ): MultibandTile =
+    MultibandTile(
+      tile.bands
+        .zip(sourceHistograms.zip(targetHistograms))
+        .map({ case (tile, (source, target)) =>
+          HistogramMatching(tile, source, target)
+        })
+    )
+
+  def apply[T <: AnyVal](
+    tile: MultibandTile,
+    targetHistograms: Seq[Histogram[T]]
+  ): MultibandTile =
+    MultibandTile(
+      tile.bands
+        .zip(targetHistograms)
+        .map({ case (tile, target) =>
+          HistogramMatching(
+            tile,
+            StreamingHistogram.fromTile(tile, 1<<17),
+            target
+          )
+        })
+    )
+}

--- a/raster/src/main/scala/geotrellis/raster/matching/MultibandMatchingMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/matching/MultibandMatchingMethods.scala
@@ -1,0 +1,17 @@
+package geotrellis.raster.matching
+
+import geotrellis.raster.histogram.StreamingHistogram
+import geotrellis.raster.MultibandTile
+import geotrellis.util.MethodExtensions
+
+
+trait MultibandMatchingMethods extends MethodExtensions[MultibandTile] {
+
+  def matchHistogram(targetHistograms: Seq[StreamingHistogram]): MultibandTile =
+    HistogramMatching(self, targetHistograms)
+
+  def matchHistogram(
+    sourceHistograms: Seq[StreamingHistogram],
+    targetHistograms: Seq[StreamingHistogram]
+  ): MultibandTile = HistogramMatching(self, sourceHistograms, targetHistograms)
+}

--- a/raster/src/main/scala/geotrellis/raster/matching/SinglebandMatchingMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/matching/SinglebandMatchingMethods.scala
@@ -1,0 +1,16 @@
+package geotrellis.raster.matching
+
+import geotrellis.raster.histogram.StreamingHistogram
+import geotrellis.raster.Tile
+import geotrellis.util.MethodExtensions
+
+
+trait SinglebandMatchingMethods extends MethodExtensions[Tile] {
+
+  def matchHistogram(targetHistogram: StreamingHistogram): Tile =
+    HistogramMatching(self, targetHistogram)
+
+  def matchHistogram(sourceHistogram: StreamingHistogram, targetHistogram: StreamingHistogram): Tile =
+    HistogramMatching(self, sourceHistogram, targetHistogram)
+
+}

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -60,6 +60,7 @@ package object raster
       with mapalgebra.local.LocalMethods
       with mapalgebra.zonal.ZonalMethods
       with mask.SinglebandTileMaskMethods
+      with matching.SinglebandMatchingMethods
       with merge.SinglebandTileMergeMethods
       with prototype.SinglebandTilePrototypeMethods
       with regiongroup.RegionGroupMethods
@@ -79,6 +80,7 @@ package object raster
       with crop.MultibandTileCropMethods
       with equalization.MultibandEqualizationMethods
       with mask.MultibandTileMaskMethods
+      with matching.MultibandMatchingMethods
       with merge.MultibandTileMergeMethods
       with prototype.MultibandTilePrototypeMethods
       with render.MultibandColorMethods

--- a/raster/src/main/scala/geotrellis/raster/sigmoidal/MultibandSigmoidalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/sigmoidal/MultibandSigmoidalMethods.scala
@@ -21,5 +21,19 @@ import geotrellis.util.MethodExtensions
 
 
 trait MultibandSigmoidalMethods extends MethodExtensions[MultibandTile] {
+
+  /**
+    * Given the parameters alpha and beta, perform the sigmoidal
+    * contrast computation on each band and return the result as a
+    * multiband tile.
+    *
+    * The approach used is described here:
+    * https://www.imagemagick.org/Usage/color_mods/#sigmoidal
+    *
+    * @param  alpha  The center around-which the stretch is performed (given as a fraction)
+    * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @return        The output tile
+    */
   def sigmoidal(alpha: Double, beta: Double): MultibandTile = SigmoidalContrast(self, alpha, beta)
+
 }

--- a/raster/src/main/scala/geotrellis/raster/sigmoidal/SinglebandSigmoidalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/sigmoidal/SinglebandSigmoidalMethods.scala
@@ -21,5 +21,18 @@ import geotrellis.util.MethodExtensions
 
 
 trait SinglebandSigmoidalMethods extends MethodExtensions[Tile] {
+
+  /**
+    * Given the parameters alpha and beta, perform the sigmoidal
+    * contrast computation and return the result as a tile.
+    *
+    * The approach used is described here:
+    * https://www.imagemagick.org/Usage/color_mods/#sigmoidal
+    *
+    * @param  alpha  The center around-which the stretch is performed (given as a fraction)
+    * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @return        The output tile
+    */
   def sigmoidal(alpha: Double, beta: Double): Tile = SigmoidalContrast(self, alpha, beta)
+
 }

--- a/spark/src/main/scala/geotrellis/spark/equalization/RDDHistogramEqualization.scala
+++ b/spark/src/main/scala/geotrellis/spark/equalization/RDDHistogramEqualization.scala
@@ -19,9 +19,9 @@ object RDDHistogramEqualization {
   }
 
   /**
-    * Given an RDD of [[Tile]] objects, return another RDD of tiles
-    * where the respective tiles have had their histograms equalized
-    * the joint histogram of all of the tiles.
+    * Given an RDD of Tile objects, return another RDD of tiles where
+    * the respective tiles have had their histograms equalized the
+    * joint histogram of all of the tiles.
     *
     * @param  rdd  An RDD of tile objects
     */
@@ -36,8 +36,8 @@ object RDDHistogramEqualization {
   }
 
   /**
-    * Given an RDD of [[Tile]] objects and a [[Histogram]] derived
-    * from all of the tiles, return another RDD of tiles where the
+    * Given an RDD of Tile objects and a Histogram which summarizes
+    * all of the tiles, return another RDD of tiles where the
     * respective tiles have had their histograms equalized.
     *
     * @param  rdd        An RDD of tile objects
@@ -55,7 +55,7 @@ object RDDHistogramEqualization {
   }
 
   /**
-    * Given an RDD of [[MultibandTile]] objects, return another RDD of
+    * Given an RDD of MultibandTile objects, return another RDD of
     * multiband tiles where the respective bands of the respective
     * tiles have been equalized according to a joint histogram of the
     * bands of the input RDD.
@@ -77,11 +77,10 @@ object RDDHistogramEqualization {
   }
 
   /**
-    * Given an RDD of [[MultibandTile]] objects and a sequence of
-    * [[Histogram]] objects (on per band) derived from all of the
-    * tiles, return another RDD of multiband tiles where the
-    * respective bands of the respective tiles have had their
-    * histograms equalized.
+    * Given an RDD of MultibandTile objects and a sequence of
+    * Histogram objects (on per band) derived from all of the tiles,
+    * return another RDD of multiband tiles where the respective bands
+    * of the respective tiles have had their histograms equalized.
     *
     * @param  rdd         An RDD of tile objects
     * @param  histograms  A histogram derived from the whole RDD of tiles

--- a/spark/src/main/scala/geotrellis/spark/equalization/RDDMultibandEqualizationMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/equalization/RDDMultibandEqualizationMethods.scala
@@ -12,16 +12,16 @@ trait RDDMultibandEqualizationMethods[K, M] extends MethodExtensions[RDD[(K, Mul
 
   /**
     * Equalize the histograms of the respective bands of the RDD of
-    * [[MultibandTile]] objects using one joint histogram derived from
+    * MultibandTile objects using one joint histogram derived from
     * each band of the input RDD.
     */
   def equalize(): RDD[(K, MultibandTile)] with Metadata[M] =
     RDDHistogramEqualization.multiband(self)
 
   /**
-    * Given a sequence of [[StreamingHistogram]] objects (one per
-    * band), equalize the histograms of the respective bands of the
-    * RDD of [[MultibandTile]] objects.
+    * Given a sequence of Histogram objects (one per band), equalize
+    * the histograms of the respective bands of the RDD of
+    * MultibandTile objects.
     *
     * @param  histograms  A sequence of histograms
     */

--- a/spark/src/main/scala/geotrellis/spark/equalization/RDDSinglebandEqualizationMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/equalization/RDDSinglebandEqualizationMethods.scala
@@ -11,16 +11,16 @@ import org.apache.spark.rdd.RDD
 trait RDDSinglebandEqualizationMethods[K, M] extends MethodExtensions[RDD[(K, Tile)] with Metadata[M]] {
 
   /**
-    * Equalize the histograms of the respective [[Tile]] objects in
-    * the RDD using one joint histogram derived from the entire source
+    * Equalize the histograms of the respective Tile objects in the
+    * RDD using one joint histogram derived from the entire source
     * RDD.
     */
   def equalize(): RDD[(K, Tile)] with Metadata[M] =
     RDDHistogramEqualization.singleband(self)
 
   /**
-    * Given a histogram derived form the source RDD of [[Tile]]
-    * objects, equalize the respective histograms of the RDD of tiles.
+    * Given a histogram derived form the source RDD of Tile objects,
+    * equalize the respective histograms of the RDD of tiles.
     *
     * @param  histogram  A histogram
     */

--- a/spark/src/main/scala/geotrellis/spark/matching/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/matching/Implicits.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.matching
+
+import geotrellis.raster._
+import geotrellis.spark._
+
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+
+object Implicits extends Implicits
+
+trait Implicits {
+
+  implicit class withRDDSinglebandMatchingMethods[K, V: (? => Tile)](
+    val self: RDD[(K, V)]
+  ) extends RDDSinglebandMatchingMethods[K, V]
+
+  implicit class withRDDMultibandMatchingMethods[K, V: (? => MultibandTile)](
+    val self: RDD[(K, V)]
+  ) extends RDDMultibandMatchingMethods[K, V]
+
+}

--- a/spark/src/main/scala/geotrellis/spark/matching/RDDHistogramMatching.scala
+++ b/spark/src/main/scala/geotrellis/spark/matching/RDDHistogramMatching.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.matching
+
+import geotrellis.raster._
+import geotrellis.raster.histogram._
+import geotrellis.raster.matching.HistogramMatching
+import geotrellis.spark._
+import geotrellis.spark.summary._
+
+import org.apache.spark.rdd.RDD
+
+
+object RDDHistogramMatching {
+
+  private def computeHistogram[K, V: (? => Tile)](rdd: RDD[(K, V)]): StreamingHistogram =
+    rdd
+      .map({ case (_, v) => StreamingHistogram.fromTile(v, 1<<8) })
+      .reduce(_ + _)
+
+  private def computeHistograms[K, V: (? => MultibandTile)](
+    rdd: RDD[(K, V)],
+    bandCount: Int
+  ): Seq[StreamingHistogram] =
+    (0 until bandCount).map({ i =>
+      rdd.map({ case (_, v) => StreamingHistogram.fromTile(v.bands(i), 1<<8) })
+        .reduce(_ + _)
+    })
+
+  def singleband[T1 <: AnyVal, T2 <: AnyVal, K, V: (? => Tile)](
+    rdd: RDD[(K, V)],
+    sourceHistogram: Histogram[T1],
+    targetHistogram: Histogram[T2]
+  ): RDD[(K, Tile)] =
+    rdd.map({ case (key, tile) =>
+      (key, HistogramMatching(tile, sourceHistogram, targetHistogram)) })
+
+  def singleband[T <: AnyVal, K, V: (? => Tile)](
+    rdd: RDD[(K, V)],
+    targetHistogram: Histogram[T]
+  ): RDD[(K, Tile)] = {
+    val sourceHistogram = computeHistogram(rdd)
+    singleband(rdd, sourceHistogram, targetHistogram)
+  }
+
+  def multiband[T1 <: AnyVal, T2 <: AnyVal, K, V: (? => MultibandTile)](
+    rdd: RDD[(K, V)],
+    sourceHistograms: Seq[Histogram[T1]],
+    targetHistograms: Seq[Histogram[T2]]
+  ): RDD[(K, MultibandTile)] =
+    rdd.map({ case (key, tile: MultibandTile) =>
+      (key, HistogramMatching(tile, sourceHistograms, targetHistograms)) })
+
+  def multiband[T <: AnyVal, K, V: (? => MultibandTile)](
+    rdd: RDD[(K, V)],
+    targetHistograms: Seq[Histogram[T]]
+  ): RDD[(K, MultibandTile)] = {
+    val sourceHistograms = computeHistograms(rdd, targetHistograms.length)
+    multiband(rdd, sourceHistograms, targetHistograms)
+  }
+
+}

--- a/spark/src/main/scala/geotrellis/spark/matching/RDDHistogramMatching.scala
+++ b/spark/src/main/scala/geotrellis/spark/matching/RDDHistogramMatching.scala
@@ -41,6 +41,17 @@ object RDDHistogramMatching {
         .reduce(_ + _)
     })
 
+  /**
+    * Given an RDD of key-tile pairs, a source histogram (ostensibly
+    * that of the tiles in the RDD), and a target histogram, this
+    * function produces an RDD of key-tile pairs where the histograms
+    * of the result tiles have been matched to the target histogram.
+    *
+    * @param  rdd              The key-tile pairs
+    * @param  sourceHistogram  The ostensible histogram of the tiles of the RDD
+    * @param  targetHistogram  The histogram that the tiles should be matched to
+    * @return                  An RDD key-tile pairs where the histograms have been matched
+    */
   def singleband[T1 <: AnyVal, T2 <: AnyVal, K, V: (? => Tile)](
     rdd: RDD[(K, V)],
     sourceHistogram: Histogram[T1],
@@ -49,6 +60,15 @@ object RDDHistogramMatching {
     rdd.map({ case (key, tile) =>
       (key, HistogramMatching(tile, sourceHistogram, targetHistogram)) })
 
+  /**
+    * Given an RDD of key-tile pairs and a target histogram, this
+    * function produces an RDD of key-tile pairs where the histograms
+    * of the result tiles have been matched to the target histogram.
+    *
+    * @param  rdd              The key-tile pairs
+    * @param  targetHistogram  The histogram that the tiles should be matched to
+    * @return                  An RDD key-tile pairs where the histograms have been matched
+    */
   def singleband[T <: AnyVal, K, V: (? => Tile)](
     rdd: RDD[(K, V)],
     targetHistogram: Histogram[T]
@@ -57,6 +77,19 @@ object RDDHistogramMatching {
     singleband(rdd, sourceHistogram, targetHistogram)
   }
 
+  /**
+    * Given an RDD of key-MultibandTile pairs, a sequence of source
+    * histograms (ostensibly those of the bands of the tiles in the
+    * RDD), and a sequence of target histograms (of the bands of the
+    * tiles), this function produces an RDD of key-MultibandTile pairs
+    * where the histograms of the bands of the result tiles have been
+    * matched to the respective target histograms.
+    *
+    * @param  rdd               The key-MultibandTile pairs
+    * @param  sourceHistograms  The ostensible histograms of the bands of the tiles of the RDD
+    * @param  targetHistograms  The histograms that the bands of the the tiles should be matched to
+    * @return                   An RDD key-MultibandTile pairs where the bands of the histograms have been matched
+    */
   def multiband[T1 <: AnyVal, T2 <: AnyVal, K, V: (? => MultibandTile)](
     rdd: RDD[(K, V)],
     sourceHistograms: Seq[Histogram[T1]],
@@ -65,6 +98,17 @@ object RDDHistogramMatching {
     rdd.map({ case (key, tile: MultibandTile) =>
       (key, HistogramMatching(tile, sourceHistograms, targetHistograms)) })
 
+  /**
+    * Given an RDD of key-MultibandTile pairs and a sequence of target
+    * histograms (of the bands of the tiles), this function produces
+    * an RDD of key-MultibandTile pairs where the histograms of the
+    * bands of the result tiles have been matched to the respective
+    * target histograms.
+    *
+    * @param  rdd               The key-MultibandTile pairs
+    * @param  targetHistograms  The histograms that the bands of the the tiles should be matched to
+    * @return                   An RDD key-MultibandTile pairs where the bands of the histograms have been matched
+    */
   def multiband[T <: AnyVal, K, V: (? => MultibandTile)](
     rdd: RDD[(K, V)],
     targetHistograms: Seq[Histogram[T]]

--- a/spark/src/main/scala/geotrellis/spark/matching/RDDMultibandMatchingMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/matching/RDDMultibandMatchingMethods.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.matching
+
+import geotrellis.raster._
+import geotrellis.raster.histogram._
+import geotrellis.spark._
+import geotrellis.util.MethodExtensions
+
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+
+abstract class RDDMultibandMatchingMethods[K, V: (? => MultibandTile)] extends MethodExtensions[RDD[(K, V)]] {
+
+  def matchHistogram[T <: AnyVal](targetHistograms: Seq[Histogram[T]]): RDD[(K, MultibandTile)] =
+    RDDHistogramMatching.multiband(self, targetHistograms)
+
+  def matchHistogram[T1 <: AnyVal, T2 <: AnyVal](
+    sourceHistograms: Seq[Histogram[T1]],
+    targetHistograms: Seq[Histogram[T2]]
+  ): RDD[(K, MultibandTile)] =
+    RDDHistogramMatching.multiband(self, sourceHistograms, targetHistograms)
+
+}

--- a/spark/src/main/scala/geotrellis/spark/matching/RDDMultibandMatchingMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/matching/RDDMultibandMatchingMethods.scala
@@ -28,9 +28,30 @@ import scala.reflect.ClassTag
 
 abstract class RDDMultibandMatchingMethods[K, V: (? => MultibandTile)] extends MethodExtensions[RDD[(K, V)]] {
 
+  /**
+    * Given a sequence of target histograms (of the bands of the
+    * tiles), this function produces an RDD of key-MultibandTile pairs
+    * where the histograms of the bands of the result tiles have been
+    * matched to the respective target histograms.
+    *
+    * @param  targetHistograms  The histograms that the bands of the the tiles should be matched to
+    * @return                   An RDD key-MultibandTile pairs where the bands of the histograms have been matched
+    */
   def matchHistogram[T <: AnyVal](targetHistograms: Seq[Histogram[T]]): RDD[(K, MultibandTile)] =
     RDDHistogramMatching.multiband(self, targetHistograms)
 
+  /**
+    * Given a sequence of source histograms (ostensibly those of the
+    * bands of the tiles in the RDD), and a sequence of target
+    * histograms (of the bands of the tiles), this function produces
+    * an RDD of key-MultibandTile pairs where the histograms of the
+    * bands of the result tiles have been matched to the respective
+    * target histograms.
+    *
+    * @param  sourceHistograms  The ostensible histograms of the bands of the tiles of the RDD
+    * @param  targetHistograms  The histograms that the bands of the the tiles should be matched to
+    * @return                   An RDD key-MultibandTile pairs where the bands of the histograms have been matched
+    */
   def matchHistogram[T1 <: AnyVal, T2 <: AnyVal](
     sourceHistograms: Seq[Histogram[T1]],
     targetHistograms: Seq[Histogram[T2]]

--- a/spark/src/main/scala/geotrellis/spark/matching/RDDSinglebandMatchingMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/matching/RDDSinglebandMatchingMethods.scala
@@ -28,9 +28,27 @@ import scala.reflect.ClassTag
 
 abstract class RDDSinglebandMatchingMethods[K, V: (? => Tile)] extends MethodExtensions[RDD[(K, V)]] {
 
+  /**
+    * Given a target histogram, this function produces an RDD of
+    * key-tile pairs where the histograms of the result tiles have
+    * been matched to the target histogram.
+    *
+    * @param  targetHistogram  The histogram that the tiles should be matched to
+    * @return                  An RDD key-tile pairs where the histograms have been matched
+    */
   def matchHistogram[T <: AnyVal](targetHistogram: Histogram[T]): RDD[(K, Tile)] =
     RDDHistogramMatching.singleband(self, targetHistogram)
 
+  /**
+    * Given a source histogram (ostensibly that of the tiles in the
+    * RDD), and a target histogram, this function produces an RDD of
+    * key-tile pairs where the histograms of the result tiles have
+    * been matched to the target histogram.
+    *
+    * @param  sourceHistogram  The ostensible histogram of the tiles of the RDD
+    * @param  targetHistogram  The histogram that the tiles should be matched to
+    * @return                  An RDD key-tile pairs where the histograms have been matched
+    */
   def matchHistogram[T1 <: AnyVal, T2 <: AnyVal](
     sourceHistogram: Histogram[T1],
     targetHistogram: Histogram[T2]

--- a/spark/src/main/scala/geotrellis/spark/matching/RDDSinglebandMatchingMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/matching/RDDSinglebandMatchingMethods.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.matching
+
+import geotrellis.raster._
+import geotrellis.raster.histogram._
+import geotrellis.spark._
+import geotrellis.util.MethodExtensions
+
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+
+abstract class RDDSinglebandMatchingMethods[K, V: (? => Tile)] extends MethodExtensions[RDD[(K, V)]] {
+
+  def matchHistogram[T <: AnyVal](targetHistogram: Histogram[T]): RDD[(K, Tile)] =
+    RDDHistogramMatching.singleband(self, targetHistogram)
+
+  def matchHistogram[T1 <: AnyVal, T2 <: AnyVal](
+    sourceHistogram: Histogram[T1],
+    targetHistogram: Histogram[T2]
+  ): RDD[(K, Tile)] =
+    RDDHistogramMatching.singleband(self, sourceHistogram, targetHistogram)
+
+}

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -49,6 +49,7 @@ package object spark
     with mapalgebra.local.temporal.Implicits
     with mapalgebra.zonal.Implicits
     with mask.Implicits
+    with matching.Implicits
     with merge.Implicits
     with partition.Implicits
     with reproject.Implicits

--- a/spark/src/main/scala/geotrellis/spark/sigmoidal/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/sigmoidal/Implicits.scala
@@ -26,11 +26,11 @@ object Implicits extends Implicits
 
 trait Implicits {
 
-  implicit class withRDDSinglebandSigmoidalMethods[K, M](
-    val self: RDD[(K, Tile)] with Metadata[M]
-  ) extends RDDSinglebandSigmoidalMethods[K, M]
+  implicit class withRDDSinglebandSigmoidalMethods[K, V: (? => Tile)](
+    val self: RDD[(K, V)]
+  ) extends RDDSinglebandSigmoidalMethods[K, V]
 
-  implicit class withRDDMultibandSigmoidalMethods[K, M](
-    val self: RDD[(K, MultibandTile)] with Metadata[M]
-  ) extends RDDMultibandSigmoidalMethods[K, M]
+  implicit class withRDDMultibandSigmoidalMethods[K, V: (? => MultibandTile)](
+    val self: RDD[(K, V)]
+  ) extends RDDMultibandSigmoidalMethods[K, V]
 }

--- a/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDMultibandSigmoidalMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDMultibandSigmoidalMethods.scala
@@ -24,6 +24,20 @@ import org.apache.spark.rdd.RDD
 
 
 abstract class RDDMultibandSigmoidalMethods[K, V: (? => MultibandTile)] extends MethodExtensions[RDD[(K, V)]] {
+
+  /**
+    * Given parameters alpha and beta, return an RDD of tiles where
+    * the sigmoidal contrast operation has been performed on each band
+    * of each tile.
+    *
+    * The approach used is described here:
+    * https://www.imagemagick.org/Usage/color_mods/#sigmoidal
+    *
+    * @param  alpha  The center around-which the stretch is performed (given as a fraction)
+    * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @return        An RDD of output tiles
+    */
   def sigmoidal(alpha: Double, beta: Double): RDD[(K, MultibandTile)] =
     RDDSigmoidalContrast.multiband(self, alpha, beta)
+
 }

--- a/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDMultibandSigmoidalMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDMultibandSigmoidalMethods.scala
@@ -23,7 +23,7 @@ import geotrellis.util.MethodExtensions
 import org.apache.spark.rdd.RDD
 
 
-trait RDDMultibandSigmoidalMethods[K, M] extends MethodExtensions[RDD[(K, MultibandTile)]] {
+abstract class RDDMultibandSigmoidalMethods[K, V: (? => MultibandTile)] extends MethodExtensions[RDD[(K, V)]] {
   def sigmoidal(alpha: Double, beta: Double): RDD[(K, MultibandTile)] =
     RDDSigmoidalContrast.multiband(self, alpha, beta)
 }

--- a/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDSigmoidalContrast.scala
+++ b/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDSigmoidalContrast.scala
@@ -26,7 +26,7 @@ import org.apache.spark.rdd.RDD
 object RDDSigmoidalContrast {
 
   /**
-    * Given an RDD of [[Tile]] objects and parameters alpha and beta,
+    * Given an RDD of Tile objects and parameters alpha and beta,
     * return an RDD of tiles upon-which the sigmoidal contrast
     * operation has been performed.
     *
@@ -45,8 +45,8 @@ object RDDSigmoidalContrast {
     rdd.map({ case (key, tile: Tile) => (key, SigmoidalContrast(tile, alpha, beta)) })
 
   /**
-    * Given an RDD of [[MultibandTile]] objects and parameters alpha
-    * and beta, return an RDD of tiles where the sigmoidal contrast
+    * Given an RDD of MultibandTile objects and parameters alpha and
+    * beta, return an RDD of tiles where the sigmoidal contrast
     * operation has been performed on each band of each tile.
     *
     * The approach used is described here:

--- a/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDSigmoidalContrast.scala
+++ b/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDSigmoidalContrast.scala
@@ -22,8 +22,6 @@ import geotrellis.spark._
 
 import org.apache.spark.rdd.RDD
 
-import scala.reflect._
-
 
 object RDDSigmoidalContrast {
 
@@ -40,7 +38,7 @@ object RDDSigmoidalContrast {
     * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
     * @return        An RDD of output tiles
     */
-  def singleband[K, V: (? => Tile): ClassTag, M](
+  def singleband[K, V: (? => Tile)](
     rdd: RDD[(K, V)],
     alpha: Double, beta: Double
   ): RDD[(K, Tile)] =
@@ -59,7 +57,7 @@ object RDDSigmoidalContrast {
     * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
     * @return        An RDD of output tiles
     */
-  def multiband[K, V: (? => MultibandTile): ClassTag, M](
+  def multiband[K, V: (? => MultibandTile)](
     rdd: RDD[(K, V)],
     alpha: Double, beta: Double
   ): RDD[(K, MultibandTile)] =

--- a/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDSinglebandSigmoidalMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDSinglebandSigmoidalMethods.scala
@@ -24,6 +24,19 @@ import org.apache.spark.rdd.RDD
 
 
 abstract class RDDSinglebandSigmoidalMethods[K, V: (? => Tile)] extends MethodExtensions[RDD[(K, V)]] {
+
+  /**
+    * Given parameters alpha and beta, return an RDD of tiles
+    * upon-which the sigmoidal contrast operation has been performed.
+    *
+    * The approach used is described here:
+    * https://www.imagemagick.org/Usage/color_mods/#sigmoidal
+    *
+    * @param  alpha  The center around-which the stretch is performed (given as a fraction)
+    * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @return        An RDD of output tiles
+    */
   def sigmoidal(alpha: Double, beta: Double): RDD[(K, Tile)] =
     RDDSigmoidalContrast.singleband(self, alpha, beta)
+
 }

--- a/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDSinglebandSigmoidalMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/sigmoidal/RDDSinglebandSigmoidalMethods.scala
@@ -23,7 +23,7 @@ import geotrellis.util.MethodExtensions
 import org.apache.spark.rdd.RDD
 
 
-trait RDDSinglebandSigmoidalMethods[K, M] extends MethodExtensions[RDD[(K, Tile)]] {
+abstract class RDDSinglebandSigmoidalMethods[K, V: (? => Tile)] extends MethodExtensions[RDD[(K, V)]] {
   def sigmoidal(alpha: Double, beta: Double): RDD[(K, Tile)] =
     RDDSigmoidalContrast.singleband(self, alpha, beta)
 }

--- a/spark/src/test/scala/geotrellis/spark/matching/RDDHistogramMatchingSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/matching/RDDHistogramMatchingSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016 Azavea.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.matching
+
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.raster.histogram.StreamingHistogram
+
+import org.scalatest._
+
+
+class RDDHistogramMatchingSpec extends FunSpec
+    with Matchers
+    with TestEnvironment {
+
+    val sourceHistogram = {
+      val h = StreamingHistogram(42)
+      h.countItem(1, 1)
+      h.countItem(2, 2)
+      h.countItem(4, 3)
+      h.countItem(8, 4)
+      h.countItem(16, 5)
+      h
+    }
+
+    val targetHistogram = {
+      val h = StreamingHistogram(42)
+      h.countItem(1, 1)
+      h.countItem(2, 2)
+      h.countItem(3, 3)
+      h.countItem(4, 4)
+      h.countItem(5, 5)
+      h
+    }
+
+  val sourceHistograms = List(sourceHistogram, sourceHistogram)
+  val targetHistograms = List(targetHistogram, targetHistogram)
+
+  describe("RDD Histogram Matching") {
+
+    it("should work with floating-point rasters") {
+      val tile1 = DoubleArrayTile(Array[Double](16, 1, 2), 1, 3).asInstanceOf[Tile]
+      val tile2 = DoubleArrayTile(Array[Double](4, 8, 16), 1, 3).asInstanceOf[Tile]
+      val rdd = ContextRDD(sc.parallelize(List((SpatialKey(0,0), tile1), (SpatialKey(0,0), tile2))), 33)
+      val actual = rdd.matchHistogram(sourceHistogram, targetHistogram).flatMap({ _._2.toArray.toList }).collect
+      val expected = List[Double](5, 1, 2, 3, 4, 5)
+
+      actual should be (expected)
+    }
+
+    it("should work with unsigned integral rasters") {
+      val tile1 = UShortArrayTile(Array[Short](16, 1, 2), 1, 3).asInstanceOf[Tile]
+      val tile2 = UShortArrayTile(Array[Short](4, 8, 16), 1, 3).asInstanceOf[Tile]
+      val rdd = ContextRDD(sc.parallelize(List((SpatialKey(0,0), tile1), (SpatialKey(0,0), tile2))), 33)
+      val actual = rdd.matchHistogram(sourceHistogram, targetHistogram).flatMap({ _._2.toArray.toList }).collect
+      val expected = List[Double](5, 1, 2, 3, 4, 5)
+
+      actual should be (expected)
+    }
+
+    it("should work with signed integral rasters") {
+      val tile1 = ShortArrayTile(Array[Short](16, 1, 2), 1, 3).asInstanceOf[Tile]
+      val tile2 = ShortArrayTile(Array[Short](4, 8, 16), 1, 3).asInstanceOf[Tile]
+      val rdd = ContextRDD(sc.parallelize(List((SpatialKey(0,0), tile1), (SpatialKey(0,0), tile2))), 33)
+      val actual = rdd.matchHistogram(sourceHistogram, targetHistogram).flatMap({ _._2.toArray.toList }).collect
+      val expected = List[Double](5, 1, 2, 3, 4, 5)
+
+      actual should be (expected)
+    }
+
+    it("should work with multiband tiles") {
+      val band1 = ShortArrayTile(Array[Short](16, 1, 2), 1, 3).asInstanceOf[Tile]
+      val band2 = ShortArrayTile(Array[Short](4, 8, 16), 1, 3).asInstanceOf[Tile]
+      val tile1 = ArrayMultibandTile(band1, band2)
+      val tile2 = ArrayMultibandTile(band2, band1)
+      val rdd = ContextRDD(sc.parallelize(List((SpatialKey(0,0), tile1), (SpatialKey(0,0), tile2))), 33)
+      val actual = rdd
+        .matchHistogram(sourceHistograms, targetHistograms)
+        .flatMap({ case (_, v) =>
+          v.bands.flatMap({ _.toArray.toList })
+        }).collect
+      val expected = List[Double](5, 1, 2, 3, 4, 5, 3, 4, 5, 5, 1, 2)
+
+      actual should be (expected)
+    }
+
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/sigmoidal/RDDSigmoidalContrastSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/sigmoidal/RDDSigmoidalContrastSpec.scala
@@ -26,7 +26,7 @@ class RDDSigmoidalContrastSpec extends FunSpec
     with Matchers
     with TestEnvironment {
 
-  describe("RDD Histogram Equalization") {
+  describe("RDD Sigmoidal Contrast") {
 
     it("should work with floating-point rasters") {
       val x = Double.MaxValue / 2.0


### PR DESCRIPTION
Still Needs:
   - [x] Unit Tests for the (Multiband|)Tile Methods
   - [x] RDD Methods
   - [x] Unit Tests for the RDD Methods
   - [x] ScalaDocs

The original image.
![screenshot from 2016-11-02 15 34 38](https://cloud.githubusercontent.com/assets/11281373/19944464/6c034b9a-a112-11e6-970a-3959365fecc3.png)

The image after sigmoidal contrast.  Notice that the histogram shown in the screenshot includes the boundary around the image.
![screenshot from 2016-11-02 15 41 57](https://cloud.githubusercontent.com/assets/11281373/19944640/1b6251c6-a113-11e6-84b4-edc3384e5f92.png)

The raw image after its histogram has been matched to that of the sigmoidal contrast image.  Notice that it is darker than the original and the histogram looks different.
![screenshot from 2016-11-02 15 35 17](https://cloud.githubusercontent.com/assets/11281373/19944503/941cd02e-a112-11e6-9449-75989120f5f5.png)

Here is the histogram of just inner part of the "histogram matching" image (without the boundary); that image inherited its histogram from the entire "sigmoidal contrast" image (including the boundary, not just the inner part).  The histogram of the inner part of the "histogram matching" image agrees nicely with the histogram of the entire "sigmoidal contrast" image (which is the histogram that we were trying to match).
![screenshot from 2016-11-02 15 35 38](https://cloud.githubusercontent.com/assets/11281373/19944719/5abb1a88-a113-11e6-8a19-413d8e6ee732.png)
