### PR TITLE
Multiband histogram methods

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -72,7 +72,7 @@ package object raster
       with sigmoidal.SinglebandSigmoidalMethods
       with split.SinglebandTileSplitMethods
       with summary.polygonal.PolygonalSummaryMethods
-      with summary.SummaryMethods
+      with summary.SinglebandTileSummaryMethods
       with vectorize.VectorizeMethods
       with viewshed.ViewshedMethods
 
@@ -90,6 +90,7 @@ package object raster
       with resample.MultibandTileResampleMethods
       with sigmoidal.MultibandSigmoidalMethods
       with split.MultibandTileSplitMethods
+      with summary.MultibandTileSummaryMethods
 
   implicit class withSinglebandRasterMethods(val self: SinglebandRaster) extends MethodExtensions[SinglebandRaster]
       with reproject.SinglebandRasterReprojectMethods

--- a/raster/src/main/scala/geotrellis/raster/summary/MultibandTileSummaryMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/MultibandTileSummaryMethods.scala
@@ -1,0 +1,73 @@
+package geotrellis.raster.summary
+
+import geotrellis.raster._
+import geotrellis.raster.histogram.{Histogram, StreamingHistogram}
+import geotrellis.util.MethodExtensions
+
+
+/**
+  * Trait containing [[MultibandTile]] extension methods for summaries.
+  */
+trait MultibandTileSummaryMethods extends MethodExtensions[MultibandTile] {
+
+  /**
+    * Contains several different operations for building a histograms
+    * of a raster.
+    *
+    * @note     Tiles with a double type (FloatConstantNoDataCellType, DoubleConstantNoDataCellType) will have their values
+    *           rounded to integers when making the Histogram.
+    */
+  def histogram: Array[Histogram[Int]] =
+    self.bands.map(_.histogram).toArray
+
+  /**
+    * Create a histogram from double values in a raster.
+    */
+  def histogramDouble(): Array[Histogram[Double]] =
+    self.bands.map(_.histogramDouble(StreamingHistogram.DEFAULT_NUM_BUCKETS)).toArray
+
+  /**
+    * Create a histogram from double values in a raster.
+    */
+  def histogramDouble(numBuckets: Int): Array[Histogram[Double]] =
+    self.bands.map(StreamingHistogram.fromTile(_, numBuckets)).toArray
+
+  /**
+    * Generate quantile class breaks for a given raster.
+    */
+  def classBreaks(numBreaks: Int): Array[Array[Int]] =
+    self.bands.map(_.classBreaks(numBreaks)).toArray
+
+  /**
+    * Generate quantile class breaks for a given raster.
+    */
+  def classBreaksDouble(numBreaks: Int): Array[Array[Double]] =
+    self.bands.map(_.classBreaksDouble(numBreaks)).toArray
+
+  /**
+    * Determine statistical data for the given histogram.
+    *
+    * This includes mean, median, mode, stddev, and min and max values.
+    */
+  def statistics: Array[Option[Statistics[Int]]] =
+    self.bands.map(_.histogram.statistics()).toArray
+
+  /**
+    * Determine statistical data for the given histogram.
+    *
+    * This includes mean, median, mode, stddev, and min and max values.
+    */
+  def statisticsDouble: Array[Option[Statistics[Double]]] =
+    self.bands.map(_.histogramDouble().statistics()).toArray
+
+  /**
+    * Calculate a raster in which each value is set to the standard deviation of that cell's value.
+    *
+    * @return        MultibandTile of IntConstantNoDataCellType data
+    * @note          Currently only supports working with integer types. If you pass in a MultibandTile
+    *                with double type data (FloatConstantNoDataCellType, DoubleConstantNoDataCellType) the values will be rounded to
+    *                Ints.
+    */
+  def standardDeviations(factor: Double = 1.0): MultibandTile =
+    self.mapBands { (band, tile) => tile.standardDeviations(factor) }
+}

--- a/raster/src/main/scala/geotrellis/raster/summary/MultibandTileSummaryMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/MultibandTileSummaryMethods.scala
@@ -24,7 +24,7 @@ trait MultibandTileSummaryMethods extends MethodExtensions[MultibandTile] {
     * Create a histogram from double values in a raster.
     */
   def histogramDouble(): Array[Histogram[Double]] =
-    self.bands.map(_.histogramDouble(StreamingHistogram.DEFAULT_NUM_BUCKETS)).toArray
+    histogramDouble(StreamingHistogram.DEFAULT_NUM_BUCKETS)
 
   /**
     * Create a histogram from double values in a raster.

--- a/raster/src/main/scala/geotrellis/raster/summary/SinglebandTileSummaryMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/SinglebandTileSummaryMethods.scala
@@ -8,7 +8,7 @@ import geotrellis.util.MethodExtensions
 /**
   * Trait containing [[Tile]] extension methods for summaries.
   */
-trait SummaryMethods extends MethodExtensions[Tile] {
+trait SinglebandTileSummaryMethods extends MethodExtensions[Tile] {
 
   /**
     * Contains several different operations for building a histograms

--- a/spark/src/main/scala/geotrellis/spark/summary/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/summary/Implicits.scala
@@ -11,5 +11,8 @@ trait Implicits {
   implicit class withStatsTileRDDMethods[K](val self: RDD[(K, Tile)])
     (implicit val keyClassTag: ClassTag[K]) extends StatsTileRDDMethods[K]
 
+  implicit class withStatsMultibandTileRDDMethods[K](val self: RDD[(K, MultibandTile)])
+    (implicit val keyClassTag: ClassTag[K]) extends StatsMultibandTileRDDMethods[K]
+
   implicit class withStatsTileCollectionMethods[K](val self: Seq[(K, Tile)]) extends StatsTileCollectionMethods[K]
 }

--- a/spark/src/main/scala/geotrellis/spark/summary/StatsMultibandTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/summary/StatsMultibandTileRDDMethods.scala
@@ -1,0 +1,66 @@
+package geotrellis.spark.summary
+
+import geotrellis.raster._
+import geotrellis.raster.histogram._
+import geotrellis.raster.mapalgebra.local._
+import geotrellis.raster.summary._
+import geotrellis.spark._
+import geotrellis.util.MethodExtensions
+
+import org.apache.spark.Partitioner
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext._
+
+import scala.reflect.ClassTag
+
+abstract class StatsMultibandTileRDDMethods[K: ClassTag] extends MethodExtensions[RDD[(K, MultibandTile)]] {
+
+  /**
+    * Compute the histogram of an RDD of [[MultibandTile]] objects.
+    *
+    * @return  A [[Histogram[Double]]]
+    */
+  def histogram(): Array[Histogram[Double]] =
+    histogram(StreamingHistogram.DEFAULT_NUM_BUCKETS)
+
+  /**
+    * Compute the histogram of an RDD of [[MultibandTile]] objects.
+    *
+    * @param  numBuckets  The number of buckets that the histogram should have
+    * @param  fraction    The fraction of [[MultibandTile]] objects to sample (the default is 100%)
+    * @param  seed        The seed of the RNG which determines which tiles to take the histograms of
+    * @return             A [[Histogram[Double]]]
+    */
+  def histogram(numBuckets: Int, fraction: Double = 1.0, seed: Long = 33): Array[Histogram[Double]] =
+    (if (fraction >= 1.0) self; else self.sample(withReplacement = false, fraction, seed))
+      .map { case (key, tile) => tile.histogramDouble(numBuckets) }
+      .reduce { _ zip _  map { case (a, b) => a merge b } }
+
+
+  /** Gives a histogram that uses exact counts of integer values.
+    *
+    * @note This cannot handle counts that are larger than Int.MaxValue, and
+    *       should not be used with very large datasets whose counts will overflow.
+    *       These histograms can get very large with a wide range of values.
+    */
+  def histogramExactInt: Array[Histogram[Int]] = {
+    self
+      .map { case (key, tile) => tile.histogram }
+      .reduce { _ zip _  map { case (a, b) => a merge b } }
+  }
+
+  def classBreaks(numBreaks: Int): Array[Array[Int]] =
+    classBreaksDouble(numBreaks).map(_.map(_.toInt))
+
+  def classBreaksDouble(numBreaks: Int): Array[Array[Double]] =
+    histogram(numBreaks).map(_.quantileBreaks(numBreaks))
+
+  /** Gives class breaks using a histogram that uses exact counts of integer values.
+    *
+    * @note This cannot handle counts that are larger than Int.MaxValue, and
+    *       should not be used with very large datasets whose counts will overflow.
+    *       These histograms can get very large with a wide range of values.
+    */
+  def classBreaksExactInt(numBreaks: Int): Array[Array[Int]] =
+    histogramExactInt.map(_.quantileBreaks(numBreaks))
+}


### PR DESCRIPTION
Adds method extensions for `histogram` and related stats functions to `MultibandTile` and `RDD[(K, MultibandTile)]`.

Because `MultibandTile` is essentially a `Vector[Tile]` the extension methods have little choice than return an `Array` of their `Tile` counterpart.

Fixes: https://github.com/geotrellis/geotrellis/issues/1773