### PR TITLE
Fixed bug in merge logic.

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/merge/TileMergeMethodsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/merge/TileMergeMethodsSpec.scala
@@ -12,7 +12,7 @@ class TileMergeMethodsSpec extends FunSpec
     with RasterMatchers {
   describe("SinglebandTileMergeMethods") {
 
-    it("should merge prototype for each cell type") {
+    it("should merge smaller prototype tile for each cell type") {
       val cellTypes: Seq[CellType] =
         Seq(
           BitCellType,
@@ -102,6 +102,59 @@ class TileMergeMethodsSpec extends FunSpec
         val merged = proto.merge(smallerExtent, largerExtent, tile)
         withClue(s"Failing on cell type $ct: ") {
           assertEqual(merged, expected)
+        }
+      }
+    }
+
+    it("should merge 2 tiles into a larger tile for NoNoData cell types") {
+
+      val cellTypes: Seq[CellType] =
+        Seq(
+          BitCellType,
+          ByteCellType,
+          UByteCellType,
+          ShortCellType,
+          UShortCellType,
+          IntCellType,
+          FloatCellType,
+          DoubleCellType
+        )
+
+      for(ct <- cellTypes) {
+        val tile1 =
+          createTile(
+            Array(0.0, 2.0,
+                  3.0, 4.0), 2, 2).convert(ct)
+
+        val tile2 =
+          createTile(
+            Array(5.0, 6.0,
+                  7.0, 0.0), 2, 2).convert(ct)
+
+        val largerTile =
+          createTile(
+            Array.ofDim[Double](16), 4, 4
+          ).convert(ct)
+
+        val e1 = Extent(0, 2, 2, 4)
+        val e2 = Extent(2, 2, 4, 4)
+        val largeE = Extent(0, 0, 4, 4)
+
+        val expected =
+          createTile(
+            Array(0.0, 2.0, 5.0, 6.0,
+                  3.0, 4.0, 7.0, 0.0,
+                  0.0, 0.0, 0.0, 0.0,
+                  0.0, 0.0, 0.0, 0.0), 4, 4).convert(ct)
+
+        val actual =
+          largerTile
+            .mapDouble { x => x }
+            .merge(largeE, e1, tile1)
+            .merge(largeE, e2, tile2)
+
+        withClue(s"Failing on cell type $ct: ") {
+          assertEqual(actual, expected)
         }
       }
     }

--- a/raster/src/main/scala/geotrellis/raster/merge/SinglebandTileMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/SinglebandTileMergeMethods.scala
@@ -107,7 +107,10 @@ trait SinglebandTileMergeMethods extends TileMergeMethods[Tile] {
               cfor(0)(_ < self.cols, _ + 1) { col =>
                 if (self.get(col, row) == 0) {
                   val (x, y) = re.gridToMap(col, row)
-                  mutableTile.set(col, row, interpolate(x, y))
+                  val v = interpolate(x, y)
+                  if(isData(v)) {
+                    mutableTile.set(col, row, v)
+                  }
                 }
               }
             }
@@ -118,7 +121,10 @@ trait SinglebandTileMergeMethods extends TileMergeMethods[Tile] {
               cfor(0)(_ < self.cols, _ + 1) { col =>
                 if (self.getDouble(col, row) == 0.0) {
                   val (x, y) = re.gridToMap(col, row)
-                  mutableTile.setDouble(col, row, interpolate(x, y))
+                  val v = interpolate(x, y)
+                  if(isData(v)) {
+                    mutableTile.setDouble(col, row, v)
+                  }
                 }
               }
             }


### PR DESCRIPTION
There was a bug which took effect when we used the extent-based merge methods on cell types that had no NoData handling. This is caused by the interpolation returning NoData values when we interpolate outside the bounds of the original tile, so was happening when we were interpolating values of a larger raster with the values of a smaller one (e.g. during tileToLayout and Pyramiding)