### PR TITLE
Fix math error in CDF interpolation

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/equalization/HistogramEqualization.scala
+++ b/raster/src/main/scala/geotrellis/raster/equalization/HistogramEqualization.scala
@@ -37,7 +37,6 @@ object HistogramEqualization {
     */
   @inline def intensityToCdf(cellType: CellType, cdf: Array[(Double, Double)])(x: Double): Double = {
     val i = java.util.Arrays.binarySearch(cdf, (x, 0.0), cmp)
-    val bits = cellType.bits
     val smallestCdf = cdf(0)._2
     val rawCdf =
       if (x < cdf(0)._1) { // x is smaller than any label in the array
@@ -50,10 +49,12 @@ object HistogramEqualization {
         cdf(i)._2
       }
       else { // x is between two labels in the array
-        val j = (-1 * i - 2)
+        val j = -1 * i - 2
+        val label0 = cdf(j+0)._1
+        val label1 = cdf(j+1)._1
+        val t = (x - label0) / (label1 - label0)
         val cdf0 = cdf(j+0)._2
         val cdf1 = cdf(j+1)._2
-        val t = (x - cdf0) / (cdf1 - cdf0)
         (1.0-t)*cdf0 + t*cdf1
       }
 

--- a/raster/src/main/scala/geotrellis/raster/matching/HistogramMatching.scala
+++ b/raster/src/main/scala/geotrellis/raster/matching/HistogramMatching.scala
@@ -28,11 +28,12 @@ object HistogramMatching {
   private val cmp = new BucketComparator
 
   /**
-    * An implementation of the compound transformation referred to in
-    * the citation given above.  The idea is to transform from the
-    * source histogram to an equalized one, then transform from the
-    * equalized one to the target one via the inverse of the
-    * transformation that would equalize the target one.
+    * An implementation of the second part of the compound
+    * transformation referred to in the citation given above.  The
+    * idea is to transform from the source histogram to an equalized
+    * one, then transform from the equalized one to the target one via
+    * the inverse of the transformation that would equalize the target
+    * one.
     */
   @inline private def transform(
     targetCdf: Array[(Double, Double)], fn: (Double => Double)


### PR DESCRIPTION
Verified using by equalizing Landsat imagery using histogram of the layer recorded at ingest.

![image](https://cloud.githubusercontent.com/assets/1158084/20230697/39255d06-a82b-11e6-9f14-89ab02dd6935.png)

Supersedes #1799 