### PR TITLE
Fix Non-Point Pixel + Partial Cell Rasterizer Bug

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizerSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizerSpec.scala
@@ -540,4 +540,24 @@ class PolygonRasterizerSpec extends FunSuite
     count should be (0)
     // println(GeoTiff(tile, e, LatLng).tile.asciiDraw)
   }
+  test("More triangle w/ non-point pixels") {
+    /*
+      ND ND  1
+      ND  1  1
+      ND ND  1
+      */
+    val tiny3 = Polygon(Point(50, 48), Point(99, 32), Point(99, 68), Point(50,48))
+    val e = Extent(0,0,100,100)
+    val re = RasterExtent(e, 3, 3)
+    val ro = Options(includePartial = true, sampleType=PixelIsArea)
+    val tile = IntArrayTile.empty(3,3)
+    var count = 0
+
+    PolygonRasterizer.foreachCellByPolygon(tiny3, re, ro)({ (col, row) =>
+      tile.set(col, row, 1)
+      count += 1
+    })
+
+    count should be (4)
+  }
 }

--- a/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizerSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizerSpec.scala
@@ -227,7 +227,7 @@ class PolygonRasterizerSpec extends FunSuite
     s.size should be (25)
   }
 
-  test("Polygon w/ non-point pixels, w/o partial cells, not contianing border center cells") {
+  test("Polygon w/ non-point pixels, w/o partial cells, not containing border center cells") {
     val extent = Extent(0, 0, 10, 10)
     val rasterExtent = RasterExtent(extent, 10, 10)
     val extent2 = Extent(0.7, 0.7, 9.3, 9.3)
@@ -240,7 +240,7 @@ class PolygonRasterizerSpec extends FunSuite
     assert(s.size < 100)
   }
 
-  test("Polygon w/ non-point pixels and partial cells, not contianing border center cells") {
+  test("Polygon w/ non-point pixels and partial cells, not containing border center cells") {
     val extent = Extent(0, 0, 10, 10)
     val rasterExtent = RasterExtent(extent, 10, 10)
     val extent2 = Extent(0.7, 0.7, 9.3, 9.3)
@@ -540,13 +540,77 @@ class PolygonRasterizerSpec extends FunSuite
     count should be (0)
     // println(GeoTiff(tile, e, LatLng).tile.asciiDraw)
   }
-  test("More triangle w/ non-point pixels") {
+
+  test("Small triangle w/ non-point pixels (1/4)") {
     /*
       ND ND  1
       ND  1  1
       ND ND  1
-      */
+     */
     val tiny3 = Polygon(Point(50, 48), Point(99, 32), Point(99, 68), Point(50,48))
+    val e = Extent(0,0,100,100)
+    val re = RasterExtent(e, 3, 3)
+    val ro = Options(includePartial = true, sampleType=PixelIsArea)
+    val tile = IntArrayTile.empty(3,3)
+    var count = 0
+
+    PolygonRasterizer.foreachCellByPolygon(tiny3, re, ro)({ (col, row) =>
+      tile.set(col, row, 1)
+      count += 1
+    })
+
+    count should be (4)
+  }
+
+  test("Small triangle w/ non-point pixels (2/4)") {
+    /*
+      1  ND  ND
+      1   1  ND
+      1  ND  ND
+     */
+    val tiny3 = Polygon(Point(50, 48), Point(1, 32), Point(1, 68), Point(50, 48))
+    val e = Extent(0,0,100,100)
+    val re = RasterExtent(e, 3, 3)
+    val ro = Options(includePartial = true, sampleType=PixelIsArea)
+    val tile = IntArrayTile.empty(3,3)
+    var count = 0
+
+    PolygonRasterizer.foreachCellByPolygon(tiny3, re, ro)({ (col, row) =>
+      tile.set(col, row, 1)
+      count += 1
+    })
+
+    count should be (4)
+  }
+
+  test("Small triangle w/ non-point pixels (3/4)") {
+    /*
+       1  1  1
+      ND  1 ND
+      ND ND ND
+     */
+    val tiny3 = Polygon(Point(48, 50), Point(32, 99), Point(68, 99), Point(48, 50))
+    val e = Extent(0,0,100,100)
+    val re = RasterExtent(e, 3, 3)
+    val ro = Options(includePartial = true, sampleType=PixelIsArea)
+    val tile = IntArrayTile.empty(3,3)
+    var count = 0
+
+    PolygonRasterizer.foreachCellByPolygon(tiny3, re, ro)({ (col, row) =>
+      tile.set(col, row, 1)
+      count += 1
+    })
+
+    count should be (4)
+  }
+
+  test("Small triangle w/ non-point pixels (4/4)") {
+    /*
+      ND  ND  ND
+      ND  1   ND
+      1   1   1
+     */
+    val tiny3 = Polygon(Point(48, 50), Point(32, 1), Point(68, 1), Point(48, 50))
     val e = Extent(0,0,100,100)
     val re = RasterExtent(e, 3, 3)
     val ro = Options(includePartial = true, sampleType=PixelIsArea)

--- a/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
@@ -141,7 +141,7 @@ object PolygonRasterizer {
       rtree.insert(new Envelope(min(col1, col2), max(col1, col2), segment._2, segment._4), segment)
     }
 
-    /* Find the segments for the holes */
+    /** Find the segments for the holes */
     cfor(0)(_ < poly.numberOfHoles, _ + 1) { i =>
       val coords = poly.jtsGeom.getInteriorRingN(i).getCoordinates
       cfor(1)(_ < coords.length, _ + 1) { ci =>
@@ -164,20 +164,20 @@ object PolygonRasterizer {
   }
 
   /**
-   * Given a list of edges, a y-value (the scanline), and a maximum
-   * x-coordinate, this function generates a list of left- and
-   * right-endpoints for runs of pixels.  When this function is run
-   * over all of the rows, the collective output is a rasterized
-   * polygon.  This implements part of the traditional scanline
-   * algorithm.
-   *
-   * This routine ASSUMES that the polygon is closed, is of finite
-   * area, and that its boundary does not self-intersect.
-   *
-   * @param edges  A list of active edges
-   * @param y      The y-value of the vertical scanline
-   * @param maxX   The maximum-possible x-coordinate
-   */
+    * Given a list of edges, a y-value (the scanline), and a maximum
+    * x-coordinate, this function generates a list of left- and
+    * right-endpoints for runs of pixels.  When this function is run
+    * over all of the rows, the collective output is a rasterized
+    * polygon.  This implements part of the traditional scanline
+    * algorithm.
+    *
+    * This routine ASSUMES that the polygon is closed, is of finite
+    * area, and that its boundary does not self-intersect.
+    *
+    * @param edges  A list of active edges
+    * @param y      The y-value of the vertical scanline
+    * @param maxX   The maximum-possible x-coordinate
+    */
   private def runsPoint(rtree: STRtree, y: Int, maxX: Int) = {
     val row = y + 0.5
     val xcoordsMap = mutable.Map[Double, Int]()
@@ -193,10 +193,12 @@ object PolygonRasterizer {
     })
 
     xcoordsMap.foreach({ case (xcoord, valence) =>
-      /* This is where the  ASSUMPTION is used.  Given the assumption,
-       * this intersection  should be used as  the open or close  of a
-       * run of  turned-on pixels  if and only  if the  sum associated
-       * with that intersection is -1, 0, or 1. */
+      /**
+        * This is where the  ASSUMPTION is used.  Given the assumption,
+        * this intersection  should be used as  the open or close  of a
+        * run of  turned-on pixels  if and only  if the  sum associated
+        * with that intersection is -1, 0, or 1.
+        */
       if (valence == -1 || valence == 0 || valence == 1) xcoordsList += (xcoord + 0.5)
     })
 
@@ -206,21 +208,21 @@ object PolygonRasterizer {
   }
 
   /**
-   * This does much the same things as runsPoint, except that instead
-   * of using a scanline, a "scan-rectangle" is used.  When this is
-   * run over all of the rows, the collective output is collection of
-   * pixels which completely covers the input polygon (when partial is
-   * true) or the collection of pixels which are completely inside of
-   * the polygon (when partial = false).
-   *
-   * This routine ASSUMES that the polygon is closed, is of finite
-   * area, and that its boundary does not self-intersect.
-   *
-   * @param edges    A list of active edges
-   * @param y        The y-value of the bottom of the vertical scan-rectangle
-   * @param maxX     The maximum-possible x-coordinate
-   * @param partial  True if all intersected cells are to be reported, otherwise only those on the interior of the polygon
-   */
+    * This does much the same things as runsPoint, except that instead
+    * of using a scanline, a "scan-rectangle" is used.  When this is
+    * run over all of the rows, the collective output is collection of
+    * pixels which completely covers the input polygon (when partial
+    * is true) or the collection of pixels which are completely inside
+    * of the polygon (when partial = false).
+    *
+    * This routine ASSUMES that the polygon is closed, is of finite
+    * area, and that its boundary does not self-intersect.
+    *
+    * @param edges    A list of active edges
+    * @param y        The y-value of the bottom of the vertical scan-rectangle
+    * @param maxX     The maximum-possible x-coordinate
+    * @param partial  True if all intersected cells are to be reported, otherwise only those on the interior of the polygon
+    */
   private def runsArea(rtree: STRtree, y: Int, maxX: Int, partial: Boolean) = {
     val (top, bot) = (y + 1, y + 0)
     val interactions = mutable.ListBuffer[Segment]()
@@ -234,9 +236,11 @@ object PolygonRasterizer {
     var botIntervalStart = 0.0
     var topIntervalStart = 0.0
 
-    /* Process each edge  which intersects the scan-rectangle.  Report
-     * all edges  except those which only  touch the top or  bottom of
-     * the scan-rectangle. */
+    /**
+      * Process each edge  which intersects the scan-rectangle.  Report
+      * all edges  except those which only  touch the top or  bottom of
+      * the scan-rectangle.
+      */
     rtree.query(new Envelope(Double.MinValue, Double.MaxValue, bot, top))
       .asScala
       .foreach({ edgeObj =>
@@ -255,67 +259,94 @@ object PolygonRasterizer {
     interactions
       .sortWith(_._1 < _._1)
       .foreach({ edge =>
-        val topIntervalStop = lineAxisIntersection(edge, top)._1
-        val botIntervalStop = lineAxisIntersection(edge, bot)._1
-        val touchesTop = (topIntervalStop != Double.NegativeInfinity)
-        val touchesBot = (botIntervalStop != Double.NegativeInfinity)
+        val topIntervalX = lineAxisIntersection(edge, top)._1
+        val botIntervalX = lineAxisIntersection(edge, bot)._1
+        val touchesTop = (topIntervalX != Double.NegativeInfinity)
+        val touchesBot = (botIntervalX != Double.NegativeInfinity)
 
-        /* Create top intervals: Generate  the list of intervals which
-         * are due to  intersections of the polygon  boundary with the
-         * top  of  the  scan-rectangle.    The  correctness  of  this
-         * approach comes from the ASSUMPTION stated above. */
+        /**
+          * If partial pixels are being reported, then all pixels which
+          * intersect with an edge must be reported.
+          */
+        if (partial) {
+          val firstX =
+            if (edge._2 <= bot) botIntervalX
+            else if (edge._2 >= top) topIntervalX
+            else edge._1
+          val secondX =
+            if (edge._4 <= bot) botIntervalX
+            else if (edge._4 >= top) topIntervalX
+            else edge._3
+
+          val smallerX = min(firstX, secondX)
+          val largerX = max(firstX, secondX)
+
+          intervals += ((floor(smallerX), ceil(largerX)))
+        }
+
+        /**
+          * Create top intervals: Generate the list of intervals which
+          * are due to intersections of the polygon boundary with the
+          * top of the scan-rectangle.  The correctness of this
+          * approach comes from the ASSUMPTION stated above.
+          */
         if (touchesTop) {
           if (topInterval == false) { // Start new top interval
             topInterval = true
-            topIntervalStart = topIntervalStop
+            topIntervalStart = topIntervalX
           }
           else if (topInterval == true) { // Finish current top interval
             topInterval = false
-            val smaller = min(topIntervalStart, topIntervalStop)
-            val larger = max(topIntervalStart, topIntervalStop)
-            if (partial)
-              intervals += ((floor(smaller), ceil(larger)))
-            else
-              topIntervals += ((ceil(smaller), floor(larger)))
+            val smaller = min(topIntervalStart, topIntervalX)
+            val larger = max(topIntervalStart, topIntervalX)
+
+            if (partial) intervals += ((floor(smaller), ceil(larger)))
+            else topIntervals += ((ceil(smaller), floor(larger)))
           }
         }
 
-        /* Create bottom intervals. */
+        /** Create bottom intervals. */
         if (touchesBot) {
           if (botInterval == false) { // Start new bot interval
             botInterval = true
-            botIntervalStart = botIntervalStop
+            botIntervalStart = botIntervalX
           }
           else if (botInterval == true) { // Finish current bot interval
             botInterval = false
-            val smaller = min(botIntervalStart, botIntervalStop)
-            val larger = max(botIntervalStart, botIntervalStop)
+            val smaller = min(botIntervalStart, botIntervalX)
+            val larger = max(botIntervalStart, botIntervalX)
+
             if (partial) intervals += ((floor(smaller), ceil(larger)))
             else botIntervals += ((ceil(smaller), floor(larger)))
           }
         }
 
-        /* Create middle intervals.  These result form boundary segments
-         * entirely contained in the scan-rectangle. */
-        if (partial && !touchesTop && !touchesBot)
-          intervals += ((math.floor(edge._1), math.ceil(edge._3)))
-        else if (!partial && (!touchesTop || !touchesBot))
+        /**
+          * Create middle intervals.  These result form boundary
+          * segments in the interior of the scan-rectangle.
+          */
+        if (!partial && (!touchesTop || !touchesBot))
           midIntervals += ((math.floor(edge._1), math.ceil(edge._3)))
       })
 
-    if (partial) mergeIntervals(intervals.sortWith(_._1 < _._1))
+    if (partial)
+      mergeIntervals(intervals.sortWith(_._1 < _._1))
     else {
-      /* When  partial pixels are  not being reported,  intervals from
-       * intersections with  the top and bottom  of the scan-rectangle
-       * must ratify one-another. */
+      /**
+        * When partial pixels are not being reported, intervals from
+        * intersections with the top and bottom of the scan-rectangle
+        * must ratify one-another.
+        */
       val sortedTopIntervals = topIntervals.sortWith(_._1 < _._1)
       val sortedBotIntervals = botIntervals.sortWith(_._1 < _._1)
       val intervals = mutable.ListBuffer.empty[Interval]
 
       sortedTopIntervals.zip(sortedBotIntervals).map({ case(a,b) =>
         val intersection = intervalIntersection(a,b)
-        /* Thanks to the ASSUMPTION stated above, middle intervals imply
-         * partial pixels in their x-extents. */
+        /**
+          * Thanks to the ASSUMPTION stated above, middle intervals imply
+          * partial pixels in their x-extents.
+          */
         val differences = midIntervals.foldLeft(intersection)(intervalDifference)
         intervals ++= differences
       })


### PR DESCRIPTION
The issue was that when there were edges which crossed a pixel but whose intersection with the scan rectangle was outside of that pixel, the pixel was not being reported.

Supersedes #1800
Connects #1801
