### PR TITLE
Added missing options to hadoop and s3 input

### DIFF
--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/Input.scala
@@ -29,7 +29,8 @@ case class Input(
   noData: Option[Double] = None,
   clip: Option[Extent] = None,
   crs: Option[String] = None,
-  maxTileSize: Option[Int] = None
+  maxTileSize: Option[Int] = None,
+  numPartitions: Option[Int] = None
 ) extends Serializable {
   def getCrs = crs.map(CRS.fromName)
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/json/ConfigFormats.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/json/ConfigFormats.scala
@@ -218,7 +218,8 @@ trait ConfigFormats {
       "noData"  -> i.noData.toJson,
       "clip"    -> i.clip.toJson,
       "crs"   -> i.crs.toJson,
-      "maxTileSize"   -> i.crs.toJson
+      "maxTileSize"   -> i.crs.toJson,
+      "numPartitions" -> i.numPartitions.toJson
     )
     def read(value: JsValue): Input =
       value match {
@@ -231,7 +232,8 @@ trait ConfigFormats {
             noData  = fields.get("noData").map(_.convertTo[Double]),
             clip    = fields.get("clip").map(_.convertTo[Extent]),
             crs     = fields.get("crs").map(_.convertTo[String]),
-            maxTileSize = fields.get("maxTileSize").map(_.convertTo[Int])
+            maxTileSize = fields.get("maxTileSize").map(_.convertTo[Int]),
+            numPartitions = fields.get("numPartitions").map(_.convertTo[Int])
           )
         case _ =>
           throw new DeserializationException("Input must be a valid json object.")

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/GeoTiffHadoopInput.scala
@@ -30,6 +30,14 @@ import org.apache.spark.rdd.RDD
 
 class GeoTiffHadoopInput extends HadoopInput[ProjectedExtent, Tile]() {
   val format = "geotiff"
+
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] =
-    HadoopGeoTiffRDD.spatial(getPath(conf.input.backend).path, HadoopGeoTiffRDD.Options(crs = conf.input.getCrs))
+    HadoopGeoTiffRDD.spatial(
+      getPath(conf.input.backend).path,
+      HadoopGeoTiffRDD.Options(
+        crs = conf.input.getCrs,
+        maxTileSize = conf.input.maxTileSize,
+        numPartitions = conf.input.numPartitions
+      )
+    )
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/MultibandGeoTiffHadoopInput.scala
@@ -26,6 +26,14 @@ import org.apache.spark.rdd.RDD
 
 class MultibandGeoTiffHadoopInput extends HadoopInput[ProjectedExtent, MultibandTile] {
   val format = "multiband-geotiff"
+
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] =
-    HadoopGeoTiffRDD.spatialMultiband(getPath(conf.input.backend).path, HadoopGeoTiffRDD.Options(crs = conf.input.getCrs))
+    HadoopGeoTiffRDD.spatialMultiband(
+      getPath(conf.input.backend).path,
+      HadoopGeoTiffRDD.Options(
+        crs = conf.input.getCrs,
+        maxTileSize = conf.input.maxTileSize,
+        numPartitions = conf.input.numPartitions
+      )
+    )
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalGeoTiffHadoopInput.scala
@@ -25,13 +25,20 @@ import org.apache.spark.rdd.RDD
 
 class TemporalGeoTiffHadoopInput extends HadoopInput[TemporalProjectedExtent, Tile] {
   val format = "temporal-geotiff"
+
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, Tile)] =
     HadoopGeoTiffRDD.temporal(
       getPath(conf.input.backend).path,
       HadoopGeoTiffRDD.Options(
-        timeTag    = conf.output.keyIndexMethod.timeTag.getOrElse(HadoopGeoTiffRDD.GEOTIFF_TIME_TAG_DEFAULT),
-        timeFormat = conf.output.keyIndexMethod.timeFormat.getOrElse(HadoopGeoTiffRDD.GEOTIFF_TIME_FORMAT_DEFAULT),
-        crs = conf.input.getCrs
+        timeTag =
+          conf.output.keyIndexMethod.timeTag
+            .getOrElse(HadoopGeoTiffRDD.GEOTIFF_TIME_TAG_DEFAULT),
+        timeFormat =
+          conf.output.keyIndexMethod.timeFormat
+            .getOrElse(HadoopGeoTiffRDD.GEOTIFF_TIME_FORMAT_DEFAULT),
+        crs = conf.input.getCrs,
+        maxTileSize = conf.input.maxTileSize,
+        numPartitions = conf.input.numPartitions
       )
     )
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalMultibandGeoTiffHadoopInput.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/hadoop/TemporalMultibandGeoTiffHadoopInput.scala
@@ -26,13 +26,20 @@ import org.apache.spark.rdd.RDD
 
 class TemporalMultibandGeoTiffHadoopInput extends HadoopInput[TemporalProjectedExtent, MultibandTile] {
   val format = "temporal-geotiff"
+
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, MultibandTile)] =
     HadoopGeoTiffRDD.temporalMultiband(
       getPath(conf.input.backend).path,
       HadoopGeoTiffRDD.Options(
-        timeTag    = conf.output.keyIndexMethod.timeTag.getOrElse(HadoopGeoTiffRDD.GEOTIFF_TIME_TAG_DEFAULT),
-        timeFormat = conf.output.keyIndexMethod.timeFormat.getOrElse(HadoopGeoTiffRDD.GEOTIFF_TIME_FORMAT_DEFAULT),
-        crs = conf.input.getCrs
+        timeTag =
+          conf.output.keyIndexMethod.timeTag
+            .getOrElse(HadoopGeoTiffRDD.GEOTIFF_TIME_TAG_DEFAULT),
+        timeFormat =
+          conf.output.keyIndexMethod.timeFormat
+            .getOrElse(HadoopGeoTiffRDD.GEOTIFF_TIME_FORMAT_DEFAULT),
+        crs = conf.input.getCrs,
+        maxTileSize = conf.input.maxTileSize,
+        numPartitions = conf.input.numPartitions
       )
     )
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/s3/GeoTiffS3Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/s3/GeoTiffS3Input.scala
@@ -26,11 +26,18 @@ import org.apache.spark.rdd.RDD
 
 class GeoTiffS3Input extends S3Input[ProjectedExtent, Tile] {
   val format = "geotiff"
+
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] = {
     val path = getPath(conf.input.backend)
-    S3GeoTiffRDD.spatial(path.bucket, path.prefix, S3GeoTiffRDD.Options(
-      crs = conf.input.getCrs
-    ))
+
+    S3GeoTiffRDD.spatial(
+      path.bucket,
+      path.prefix,
+      S3GeoTiffRDD.Options(
+        crs = conf.input.getCrs,
+        maxTileSize = conf.input.maxTileSize,
+        numPartitions = conf.input.numPartitions
+      )
+    )
   }
 }
-

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/s3/MultibandGeoTiffS3Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/s3/MultibandGeoTiffS3Input.scala
@@ -26,10 +26,18 @@ import org.apache.spark.rdd.RDD
 
 class MultibandGeoTiffS3Input extends S3Input[ProjectedExtent, MultibandTile] {
   val format = "multiband-geotiff"
+
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] = {
     val path = getPath(conf.input.backend)
-    S3GeoTiffRDD.spatialMultiband(path.bucket, path.prefix, S3GeoTiffRDD.Options(
-      crs = conf.input.getCrs
-    ))
+
+    S3GeoTiffRDD.spatialMultiband(
+      path.bucket,
+      path.prefix,
+      S3GeoTiffRDD.Options(
+        crs = conf.input.getCrs,
+        maxTileSize = conf.input.maxTileSize,
+        numPartitions = conf.input.numPartitions
+      )
+    )
   }
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/s3/TemporalGeoTiffS3Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/s3/TemporalGeoTiffS3Input.scala
@@ -26,12 +26,24 @@ import org.apache.spark.rdd.RDD
 
 class TemporalGeoTiffS3Input extends S3Input[TemporalProjectedExtent, Tile] {
   val format = "temporal-geotiff"
+
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, Tile)] = {
     val path = getPath(conf.input.backend)
-    S3GeoTiffRDD.temporal(path.bucket, path.prefix, S3GeoTiffRDD.Options(
-      timeTag = conf.output.keyIndexMethod.timeTag.getOrElse(S3GeoTiffRDD.GEOTIFF_TIME_TAG_DEFAULT),
-      timeFormat = conf.output.keyIndexMethod.timeTag.getOrElse(S3GeoTiffRDD.GEOTIFF_TIME_FORMAT_DEFAULT),
-      crs = conf.input.getCrs
-    ))
+
+    S3GeoTiffRDD.temporal(
+      path.bucket,
+      path.prefix,
+      S3GeoTiffRDD.Options(
+        timeTag =
+          conf.output.keyIndexMethod.timeTag
+            .getOrElse(S3GeoTiffRDD.GEOTIFF_TIME_TAG_DEFAULT),
+        timeFormat =
+          conf.output.keyIndexMethod.timeTag
+            .getOrElse(S3GeoTiffRDD.GEOTIFF_TIME_FORMAT_DEFAULT),
+        crs = conf.input.getCrs,
+        maxTileSize = conf.input.maxTileSize,
+        numPartitions = conf.input.numPartitions
+      )
+    )
   }
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/s3/TemporalMultibandGeoTiffS3Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/s3/TemporalMultibandGeoTiffS3Input.scala
@@ -26,12 +26,24 @@ import org.apache.spark.rdd.RDD
 
 class TemporalMultibandGeoTiffS3Input extends S3Input[TemporalProjectedExtent, MultibandTile] {
   val format = "temporal-geotiff"
+
   def apply(conf: EtlConf)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, MultibandTile)] = {
     val path = getPath(conf.input.backend)
-    S3GeoTiffRDD.temporalMultiband(path.bucket, path.prefix, S3GeoTiffRDD.Options(
-      timeTag = conf.output.keyIndexMethod.timeTag.getOrElse(S3GeoTiffRDD.GEOTIFF_TIME_TAG_DEFAULT),
-      timeFormat = conf.output.keyIndexMethod.timeTag.getOrElse(S3GeoTiffRDD.GEOTIFF_TIME_FORMAT_DEFAULT),
-      crs = conf.input.getCrs
-    ))
+
+    S3GeoTiffRDD.temporalMultiband(
+      path.bucket,
+      path.prefix,
+      S3GeoTiffRDD.Options(
+        timeTag =
+          conf.output.keyIndexMethod.timeTag
+            .getOrElse(S3GeoTiffRDD.GEOTIFF_TIME_TAG_DEFAULT),
+        timeFormat =
+          conf.output.keyIndexMethod.timeTag
+            .getOrElse(S3GeoTiffRDD.GEOTIFF_TIME_FORMAT_DEFAULT),
+        crs = conf.input.getCrs,
+        maxTileSize = conf.input.maxTileSize,
+        numPartitions = conf.input.numPartitions
+      )
+    )
   }
 }


### PR DESCRIPTION
`maxTileSize` and `numPartitions` needed to be passed from ETL configuration through to hadoop and s3 GeoTiff inputs.